### PR TITLE
Fix invisible spirit healers

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -4581,6 +4581,7 @@ void Player::RepopAtGraveyard()
             data << ClosestGrave->z;
             GetSession()->SendPacket(&data);
         }
+        UpdateVisibilityAndView();
     }
 }
 


### PR DESCRIPTION
This fixes an issue that occurs if you die close to a spirit healer/guide.
