### PR TITLE
Fix take ammo for most ranged spells

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -2918,6 +2918,7 @@ void Spell::cast(bool skipCheck)
 
     TakePower();
     TakeReagents();                                         // we must remove reagents before HandleEffects to allow place crafted item in same slot
+    TakeAmmo();
 
     SendCastResult(castResult);
     SendSpellGo();                                          // we must send smsg_spell_go packet before m_castItem delete in TakeCastItem()...
@@ -3876,6 +3877,36 @@ void Spell::TakePower()
     if (powerType == POWER_MANA && m_powerCost > 0)
         m_caster->SetLastManaUse();
 }
+
+void Spell::TakeAmmo()
+{
+    if (m_attackType == RANGED_ATTACK && m_caster->GetTypeId() == TYPEID_PLAYER)
+    {
+        Item* pItem = ((Player*)m_caster)->GetWeaponForAttack(RANGED_ATTACK, true, false);
+
+        // wands don't have ammo
+        if (!pItem || pItem->GetProto()->SubClass == ITEM_SUBCLASS_WEAPON_WAND)
+            return;
+
+        if (pItem->GetProto()->InventoryType == INVTYPE_THROWN)
+        {
+            if (pItem->GetMaxStackCount() == 1)
+            {
+                // decrease durability for non-stackable throw weapon
+                ((Player*)m_caster)->DurabilityPointLossForEquipSlot(EQUIPMENT_SLOT_RANGED);
+            }
+            else
+            {
+                // decrease items amount for stackable throw weapon
+                uint32 count = 1;
+                ((Player*)m_caster)->DestroyItemCount(pItem, count, true);
+            }
+        }
+        else if (uint32 ammo = ((Player*)m_caster)->GetUInt32Value(PLAYER_AMMO_ID))
+            ((Player*)m_caster)->DestroyItemCount(ammo, 1, true);
+    }
+}
+
 
 void Spell::TakeReagents()
 {

--- a/src/game/Spell.h
+++ b/src/game/Spell.h
@@ -326,6 +326,7 @@ class Spell
         void cast(bool skipCheck = false);
         void finish(bool ok = true);
         void TakePower();
+        void TakeAmmo();
         void TakeReagents();
         void TakeCastItem();
 

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -4662,32 +4662,6 @@ void Spell::EffectWeaponDmg(SpellEffectIndex eff_idx)
             ((Player*)m_caster)->AddComboPoints(unitTarget, 1);
     }
 
-    // take ammo
-    if (m_attackType == RANGED_ATTACK && m_caster->GetTypeId() == TYPEID_PLAYER)
-    {
-        Item* pItem = ((Player*)m_caster)->GetWeaponForAttack(RANGED_ATTACK, true, false);
-
-        // wands don't have ammo
-        if (!pItem || pItem->GetProto()->SubClass == ITEM_SUBCLASS_WEAPON_WAND)
-            return;
-
-        if (pItem->GetProto()->InventoryType == INVTYPE_THROWN)
-        {
-            if (pItem->GetMaxStackCount() == 1)
-            {
-                // decrease durability for non-stackable throw weapon
-                ((Player*)m_caster)->DurabilityPointLossForEquipSlot(EQUIPMENT_SLOT_RANGED);
-            }
-            else
-            {
-                // decrease items amount for stackable throw weapon
-                uint32 count = 1;
-                ((Player*)m_caster)->DestroyItemCount(pItem, count, true);
-            }
-        }
-        else if (uint32 ammo = ((Player*)m_caster)->GetUInt32Value(PLAYER_AMMO_ID))
-            ((Player*)m_caster)->DestroyItemCount(ammo, 1, true);
-    }
 }
 
 void Spell::EffectThreat(SpellEffectIndex /*eff_idx*/)


### PR DESCRIPTION
Fix spells like Arcane Shot not taking ammo while they should

This commit [c653a66](http://github.com/mangos-zero/server-old/commit/c653a66) is one of those pending backports from old mangos-zero concatenated in: https://github.com/cmangos/issues/wiki/classic_backporting-todo-zero-commits

stfx adviced to first apply to TBC, then backport to classic

I tested it and this is my report:

> cala: tested take ammo and found issue on current revision: ammo are not taken for all spells (ex: ‘arcane shot’ does not take ammo but ‘serpent sting’ does). However, if no ammo in inventory no ranged spell can be casted, even those like ‘arcane shot’ that do not take ammo (though probably should take). I’ll try to test this commit.
> stfx: was this behavior ever changed? it should be tested/fixed on tbc also if needed
> cala (march 13-13): this fix does allow all spells to take ammo. It should be applied to TBC firsthand, then backported to classic.
