### PR TITLE
Core/Player: Skip item SPELLTRIGGER_ON_USE at form change

### DIFF
--- a/src/game/Group.cpp
+++ b/src/game/Group.cpp
@@ -418,6 +418,7 @@ void Group::Disband(bool hideDestroy)
         }
 
         _homebindIfInstance(player);
+        SendObjectUpdateToMembers(player);
     }
     RollId.clear();
     m_memberSlots.clear();
@@ -968,6 +969,8 @@ void Group::SendUpdate()
             data << uint8(m_difficulty);                    // Heroic Mod Group
         }
         player->GetSession()->SendPacket(&data);
+
+        SendObjectUpdateToMembers(player);
     }
 }
 
@@ -1766,6 +1769,29 @@ void Group::RewardGroupAtKill(Unit* pVictim, Player* player_tap)
             // member (alive or dead) or his corpse at req. distance
             if (player_tap->IsAtGroupRewardDistance(pVictim))
                 RewardGroupAtKill_helper(player_tap, pVictim, count, PvP, group_rate, sum_level, is_dungeon, not_gray_member_with_max_level, member_with_max_level, xp);
+        }
+    }
+}
+
+void Group::SendObjectUpdateToMembers(Player* player)
+{
+    for (member_citerator citr = m_memberSlots.begin(); citr != m_memberSlots.end(); ++citr)
+    {
+        if (player = sObjectMgr.GetPlayer(citr->guid))
+        {
+            // call update for all party members
+            for (member_citerator citr2 = m_memberSlots.begin(); citr2 != m_memberSlots.end(); ++citr2)
+            {
+                if (citr->guid == citr2->guid)
+                    continue;
+
+                if (Player* member = sObjectMgr.GetPlayer(citr2->guid))
+                {
+                    player->SendCreateUpdateToPlayer(member);
+                    if (Pet* pet = player->GetPet())
+                        pet->SendCreateUpdateToPlayer(member);
+                }
+            }
         }
     }
 }

--- a/src/game/Group.h
+++ b/src/game/Group.h
@@ -189,6 +189,8 @@ class MANGOS_DLL_SPEC Group
         void   SetLootThreshold(ItemQualities threshold) { m_lootThreshold = threshold; }
         void   Disband(bool hideDestroy = false);
 
+        void   SendObjectUpdateToMembers(Player* player);
+
         // properties accessories
         uint32 GetId() const { return m_Id; }
         ObjectGuid GetObjectGuid() const { return ObjectGuid(HIGHGUID_GROUP, GetId()); }

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -7063,8 +7063,11 @@ void Player::ApplyItemEquipSpell(Item* item, bool apply, bool form_change)
             // at un-apply remove all spells (not only at-apply, so any at-use active affects from item and etc)
             // except with at-use with negative charges, so allow consuming item spells (including with extra flag that prevent consume really)
             // applied to player after item remove from equip slot
-            if (spellData.SpellTrigger == ITEM_SPELLTRIGGER_ON_USE && spellData.SpellCharges < 0)
-                continue;
+            if (spellData.SpellTrigger == ITEM_SPELLTRIGGER_ON_USE)
+            {
+                if (form_change || (!form_change && spellData.SpellCharges < 0))
+                    continue;
+            }
         }
 
         // check if it is valid spell


### PR DESCRIPTION
This will fix auras casted from items with spell charges (e.g.: http://www.wowhead.com/spell=25211/heavy-golden-necklace-of-battle) disappearing on form change