### PR TITLE
Fix for triggered spells costing mana/rage/energy

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -2697,7 +2697,9 @@ void Spell::prepare(SpellCastTargets const* targets, Aura* triggeredByAura)
     }
 
     // Fill cost data
-    m_powerCost = CalculatePowerCost(m_spellInfo, m_caster, this, m_CastItem);
+    if (!m_IsTriggeredSpell){
+        m_powerCost = CalculatePowerCost(m_spellInfo, m_caster, this, m_CastItem);
+    }
 
     SpellCastResult result = CheckCast(true);
     if (result != SPELL_CAST_OK && !IsAutoRepeat())         // always cast autorepeat dummy for triggering


### PR DESCRIPTION
Check whether spell is triggered before cost computation