### PR TITLE
Added support for Stormspire to Shattrath teleporter during quest 10280

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -74,6 +74,8 @@ INSERT INTO scripted_areatrigger VALUES
 (4052,'at_temple_ahnqiraj');
 DELETE FROM scripted_areatrigger WHERE entry=3587;
 INSERT INTO scripted_areatrigger VALUES (3587,'at_ancient_leaf');
+DELETE FROM scripted_areatrigger WHERE entry=4479;
+INSERT INTO scripted_areatrigger VALUES (4479,'at_haramad_teleport');
 
 
 /* BATTLEGROUNDS */

--- a/src/scriptdev2/scripts/world/areatrigger_scripts.cpp
+++ b/src/scriptdev2/scripts/world/areatrigger_scripts.cpp
@@ -237,6 +237,25 @@ bool AreaTrigger_at_ancient_leaf(Player* pPlayer, AreaTriggerEntry const* pAt)
     return false;
 }
 
+/*######
+## at_haramad_teleport
+######*/
+
+enum
+{
+    QUEST_SPECIAL_DELIVERY_TO_SHATTRATH = 10280
+};
+
+static const WorldLocation haramadTeleportDest(530, -1810.465, 5323.083, -12.428, 2.040);
+
+bool AreaTrigger_at_haramad_teleport(Player* pPlayer, AreaTriggerEntry const* /*pAt*/)
+{
+    if (pPlayer->IsCurrentQuest(QUEST_SPECIAL_DELIVERY_TO_SHATTRATH))
+        pPlayer->TeleportTo(haramadTeleportDest);
+
+    return false;
+}
+
 void AddSC_areatrigger_scripts()
 {
     Script* pNewScript;
@@ -274,5 +293,10 @@ void AddSC_areatrigger_scripts()
     pNewScript = new Script;
     pNewScript->Name = "at_ancient_leaf";
     pNewScript->pAreaTrigger = &AreaTrigger_at_ancient_leaf;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "at_haramad_teleport";
+    pNewScript->pAreaTrigger = &AreaTrigger_at_haramad_teleport;
     pNewScript->RegisterSelf();
 }


### PR DESCRIPTION
During quest [10280](http://www.wowhead.com/quest=10280/special-delivery-to-shattrath-city) a [teleporter](http://i.imgur.com/3FottU0.png) next to the quest giver is supposed to transport the player directly to Shattrath City (Source: [wowhead comments](http://www.wowhead.com/quest=10280/special-delivery-to-shattrath-city), quest description, [video](https://www.youtube.com/watch?v=zrsDrEnJUik)). This is now working.