### PR TITLE
Some bugs related to quest 10353 (Arconus the Insatiable)

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -6295,6 +6295,9 @@ bool Spell::CheckTarget(Unit* target, SpellEffectIndex eff)
 
     switch (m_spellInfo->Id)
     {
+        case 34877:                                         // Custodian of Time summon (quest 10277)
+        case 35381:                                         // Reflection of Ya-six summon (quest 10353)
+            return !target->HasAura(m_spellInfo->Id);
         case 37433:                                         // Spout (The Lurker Below), only players affected if its not in water
             if (target->GetTypeId() != TYPEID_PLAYER || target->IsInWater())
                 return false;

--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -720,6 +720,7 @@ bool IsPositiveEffect(SpellEntry const* spellproto, SpellEffectIndex effIndex)
                     {
                         case 13139:                         // net-o-matic special effect
                         case 23445:                         // evil twin
+                        case 35381:                         // Reflection of Ya-six
                         case 35679:                         // Protectorate Demolitionist
                         case 37695:                         // Stanky
                         case 38637:                         // Nether Exhaustion (red)


### PR DESCRIPTION
When you accept quest [10353 ](http://www.wowhead.com/quest=10353/arconus-the-insatiable)from npc [20552 ](http://www.wowhead.com/npc=20552/agent-ya-six) a [guardian ](http://www.wowhead.com/npc=20603/reflection-of-ya-six)is summoned and you are given a 10 minute debuff to prevent the guardian being summoned again within 10 minutes. This patch fixes some bugs related to this quest:

- The debuff is no longer a positive effect so players can no longer cancel it by rightclicking the icon.
- The guardian is no longer summoned if a player accepts the quest while the debuff is active on the player. 

Note: I do not know if the way I prevented the summon when the debuff is active is the best one, but I did not find another way to do it. Although I'm a bit new to this so it's very possible that I missed something.