### PR TITLE
Remove powerCost from triggered spells

### DIFF
--- a/src/game/CreatureAI.cpp
+++ b/src/game/CreatureAI.cpp
@@ -52,7 +52,7 @@ CanCastResult CreatureAI::CanCastSpell(Unit* pTarget, const SpellEntry* pSpell, 
             return CAST_FAIL_STATE;
 
         // Check for power (also done by Spell::CheckCast())
-        if (m_creature->GetPower((Powers)pSpell->powerType) < Spell::CalculatePowerCost(pSpell, m_creature))
+        if (m_creature->GetPower((Powers)pSpell->powerType) < Spell::CalculatePowerCost(pSpell, m_creature, isTriggered))
             return CAST_FAIL_POWER;
 
         if (!m_creature->IsWithinLOSInMap(pTarget) && m_creature != pTarget)

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -2697,7 +2697,7 @@ void Spell::prepare(SpellCastTargets const* targets, Aura* triggeredByAura)
     }
 
     // Fill cost data
-    m_powerCost = CalculatePowerCost(m_spellInfo, m_caster, this, m_CastItem);
+    m_powerCost = CalculatePowerCost(m_spellInfo, m_caster, m_IsTriggeredSpell, this, m_CastItem);
 
     SpellCastResult result = CheckCast(true);
     if (result != SPELL_CAST_OK && !IsAutoRepeat())         // always cast autorepeat dummy for triggering
@@ -5604,10 +5604,10 @@ SpellCastResult Spell::CheckRange(bool strict)
     return SPELL_CAST_OK;
 }
 
-uint32 Spell::CalculatePowerCost(SpellEntry const* spellInfo, Unit* caster, Spell const* spell, Item* castItem)
+uint32 Spell::CalculatePowerCost(SpellEntry const* spellInfo, Unit* caster, bool isTriggered, Spell const* spell, Item* castItem)
 {
-    // item cast not used power
-    if (castItem)
+    // item cast or triggered do not use power
+    if (castItem || isTriggered)
         return 0;
 
     // Spell drain all exist power on cast (Only paladin lay of Hands)

--- a/src/game/Spell.h
+++ b/src/game/Spell.h
@@ -345,7 +345,7 @@ class Spell
         SpellCastResult CheckCasterAuras() const;
 
         int32 CalculateDamage(SpellEffectIndex i, Unit* target) { return m_caster->CalculateSpellDamage(target, m_spellInfo, i, &m_currentBasePoints[i]); }
-        static uint32 CalculatePowerCost(SpellEntry const* spellInfo, Unit* caster, Spell const* spell = nullptr, Item* castItem = nullptr);
+        static uint32 CalculatePowerCost(SpellEntry const* spellInfo, Unit* caster, bool isTriggered, Spell const* spell = nullptr, Item* castItem = nullptr);
 
         bool HaveTargetsForEffect(SpellEffectIndex effect) const;
         void Delayed();


### PR DESCRIPTION
@robinsch this should be more to your liking then.
@cala afaik we are missing it from all cores

Example: devastate triggers sunder armor for no cost. (possibly many more)