### PR TITLE
Fix PROC_FLAG_KILL for TYPEID_UNIT

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -725,6 +725,8 @@ uint32 Unit::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDa
 
             player_tap->SendDirectMessage(&data);
         }
+        else if (GetTypeId() == TYPEID_UNIT && this != pVictim)
+            ProcDamageAndSpell(pVictim, PROC_FLAG_KILL, PROC_FLAG_KILLED, PROC_EX_NONE, 0);
 
         // Reward player, his pets, and group/raid members
         if (player_tap != pVictim)


### PR DESCRIPTION
Example: Doomwalker has a spell that procs if he kills a player (he should instaheal for a LOT)
This doesnt work because we dont proc spells for TYPEID_UNIT