### PR TITLE
Fixed warning for string to char* conversion

### DIFF
--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -6507,7 +6507,7 @@ void ObjectMgr::LoadPointsOfInterest()
     sLog.outString();
 }
 
-static char* SERVER_SIDE_SPELL      = "MaNGOS server-side spell";
+static char* SERVER_SIDE_SPELL      = (char*)"MaNGOS server-side spell";
 
 struct SQLSpellLoader : public SQLStorageLoaderBase<SQLSpellLoader, SQLHashStorage>
 {


### PR DESCRIPTION
ObjectMgr.cpp:6929:39: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]