### PR TITLE
Event AI command.

### DIFF
--- a/src/game/CreatureEventAI.h
+++ b/src/game/CreatureEventAI.h
@@ -23,6 +23,10 @@
 #include "Creature.h"
 #include "CreatureAI.h"
 #include "Unit.h"
+#include "ObjectGuid.h"
+#include "WaypointManager.h"
+#include "WaypointMovementGenerator.h"
+#include "MotionMaster.h"
 
 class Player;
 class WorldObject;
@@ -121,6 +125,8 @@ enum EventAI_ActionType
     ACTION_T_SET_STAND_STATE            = 47,               // StandState, unused, unused
     ACTION_T_CHANGE_MOVEMENT            = 48,               // MovementType, WanderDistance, unused
     ACTION_T_DYNAMIC_MOVEMENT           = 49,               // EnableDynamicMovement (1 = on; 0 = off)
+    ACTION_T_SET_CONTROL_ATTACK         = 50,               // Allow Attack Start (0 = true, anything else passive react on aggro.)
+    ACTION_T_SET_CURRENT_WAYPOINT       = 51,               // Creature can set alternative waypoint.
 
     ACTION_T_END,
 };
@@ -423,6 +429,19 @@ struct CreatureEventAI_Action
             uint32 unused1;
             uint32 unused2;
         } dynamicMovement;
+        // ACTION_T_SET_CONTROL_ATTACK                      = 50
+        struct
+        {
+            uint32 state;                                   // Allow Attack Start (0 = true, anything else passive react on aggro.)
+            uint32 unused1;
+            uint32 unused2;
+        } setControlAttack;
+        struct
+        {
+           uint32 uiPointId;                               // Creature can set alternative waypoint.
+           uint32 unused1;
+           uint32 unused2;
+        } setCurrentWaypoint;
         // RAW
         struct
         {
@@ -652,6 +671,8 @@ class MANGOS_DLL_SPEC CreatureEventAI : public CreatureAI
         void SummonedCreatureJustDied(Creature* unit) override;
         void SummonedCreatureDespawn(Creature* unit) override;
         void ReceiveAIEvent(AIEventType eventType, Creature* pSender, Unit* pInvoker, uint32 miscValue) override;
+        
+        void SetCurrentWaypoint(uint32 uiPointId);
 
         static int Permissible(const Creature*);
 
@@ -680,6 +701,7 @@ class MANGOS_DLL_SPEC CreatureEventAI : public CreatureAI
         bool   m_MeleeEnabled;                              // If we allow melee auto attack
         bool   m_DynamicMovement;                           // Core will control creatures movement if this is enabled
         bool   m_HasOOCLoSEvent;                            // Cache if a OOC-LoS Event exists
+        bool   m_IsControlAttackEnabled;                    // Check if we allow attack start or not.
         uint32 m_InvinceabilityHpLevel;                     // Minimal health level allowed at damage apply
 
         uint32 m_throwAIEventMask;                          // Automatically throw AIEvents that are encoded into this mask

--- a/src/game/CreatureEventAIMgr.cpp
+++ b/src/game/CreatureEventAIMgr.cpp
@@ -835,6 +835,8 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                     case ACTION_T_RANGED_MOVEMENT:          // Distance, Angle
                     case ACTION_T_CALL_FOR_HELP:            // Distance
                     case ACTION_T_DYNAMIC_MOVEMENT:         // EnableDynamicMovement (1 = on; 0 = off)
+                    case ACTION_T_SET_CONTROL_ATTACK:       // Allow Attack Start (0 = true, anything else passive react on aggro.)
+                    case ACTION_T_SET_CURRENT_WAYPOINT:     // Creature can set alternative waypoint.
                         break;
 
                     case ACTION_T_RANDOM_SAY:


### PR DESCRIPTION
ACTION_T_SET_CONTROL_ATTACK -  control npc, allow run AttackStart function or not. Likely ReactPassive.
ACTION_T_SET_CURRENT_WAYPOINT - you can current waypoint for creature. Using creature_movement_template and creature_movement tables. You can link with db_script_on_creature_movement.

Example: Brutallus in Isle of Quel'Danas. Not in Sunwell. Cannot attack Madrigosa. Have events. Which can be performed using db_script_on_creature_movement.
Madrigosa in Sunwell Plateau not handled, but don't should attack start Brutallus after SpellHit Charge.
For Better Behaviour i can add DeleteThreatList, CombatStop and other needed for this case actions
Mu'ru summoned add (Void Sentinel and Void Spawn, Humanoids not have delay, you can attack start humanoids and get aggressive behaviour) have delay before attack. Control Attack can help this. Add on Spawn "Passive" reaction, after 3 second - remove and SetInCombatWithZone. 
For @xfurry 
Not ALL summoned npc have delay before attack. Bridge Event npc before Pathaleon in Mechanar not have delay, no need suggestion applied in core delay.
Kargath adds in Shattered Halls not have delay.
ACTION_T_SET_CURRENT_WAYPOINT can help.

Also Control Attack can used for invisible trigger, which should not be aggressive and have the AI.
Or any trigger without AI, but without aggressive behaviour. Broggok in Blood Furnace have invisible trigger for Poison spells. You can delete from SD2 and replace on EAI.