### PR TITLE
Fix MSG_INSPECT_HONOR_STATS response

### DIFF
--- a/src/game/MiscHandler.cpp
+++ b/src/game/MiscHandler.cpp
@@ -1093,7 +1093,7 @@ void WorldSession::HandleInspectHonorStatsOpcode(WorldPacket& recv_data)
 
     WorldPacket data(MSG_INSPECT_HONOR_STATS, 8 + 1 + 4 * 4);
     data << player->GetObjectGuid();
-    data << uint8(player->GetUInt32Value(PLAYER_FIELD_HONOR_CURRENCY));
+    data << uint8(player->GetHighestPvPRankIndex());
     data << uint32(player->GetUInt32Value(PLAYER_FIELD_KILLS));
     data << uint32(player->GetUInt32Value(PLAYER_FIELD_TODAY_CONTRIBUTION));
     data << uint32(player->GetUInt32Value(PLAYER_FIELD_YESTERDAY_CONTRIBUTION));

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -17622,6 +17622,19 @@ uint32 Player::GetMaxPersonalArenaRatingRequirement()
     return max_personal_rating;
 }
 
+uint8 Player::GetHighestPvPRankIndex()
+{
+    uint8 index = 0;
+    for (uint8 rank = 1; rank <= 28; ++rank)
+    {
+        if (HasTitle(rank))
+             // Old rank index starts at 5, values below 5 are discontinued negative ranks
+            index = (rank <= 14) ? (rank + 4) : (rank - 10);
+    }
+
+    return index;
+}
+
 void Player::UpdateHomebindTime(uint32 time)
 {
     // GMs never get homebind timer online

--- a/src/game/Player.h
+++ b/src/game/Player.h
@@ -1808,6 +1808,7 @@ class MANGOS_DLL_SPEC Player : public Unit
         void ModifyHonorPoints(int32 value);
         void ModifyArenaPoints(int32 value);
 
+        uint8 GetHighestPvPRankIndex();
         uint32 GetMaxPersonalArenaRatingRequirement();
 
         // End of PvP System


### PR DESCRIPTION
The single byte parameter is actually the player's highest vanilla PvP rank index.
The range of valid values is 0-18.

I am not a mangos developer or a reverse engineer myself, so this discovery was made by debugging [Examiner] (http://legacy.curseforge.com/media/files/78/477/Examiner08.05.03.zip) addon, which is malfunctioning on all existing TBC servers.
It used to throw Lua errors on seemingly random inspects when calling UnitPVPRank function with the 6th returned value of GetInspectHonorData function.
A quick test confirmed that contents of the byte parameter are getting passed exactly as the 6th returned value.
The small size of the data (1 byte) confirms the claim by implication.