### PR TITLE
Blizzlike SPELL_AURA_MOD_CRIT_DAMAGE_BONUS calculation

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -1515,14 +1515,17 @@ void Unit::CalculateMeleeDamage(Unit* pVictim, CalcDamageInfo* damageInfo, Weapo
             damageInfo->procEx |= PROC_EX_CRITICAL_HIT;
             // Crit bonus calc
             damageInfo->damage += damageInfo->damage;
+
+            // Apply SPELL_AURA_MOD_CRIT_DAMAGE_BONUS modifier first
+            const int32 bonus = GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_CRIT_DAMAGE_BONUS, SPELL_SCHOOL_MASK_NORMAL);
+            damageInfo->damage += int32((damageInfo->damage) * float(bonus / 100.0f));
+
             int32 mod = 0;
             // Apply SPELL_AURA_MOD_ATTACKER_RANGED_CRIT_DAMAGE or SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_DAMAGE
             if (damageInfo->attackType == RANGED_ATTACK)
                 mod += damageInfo->target->GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_RANGED_CRIT_DAMAGE);
             else
                 mod += damageInfo->target->GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_DAMAGE);
-
-            mod += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_CRIT_DAMAGE_BONUS, SPELL_SCHOOL_MASK_NORMAL);
 
             uint32 crTypeMask = damageInfo->target->GetCreatureTypeMask();
 
@@ -6179,6 +6182,10 @@ uint32 Unit::SpellCriticalDamageBonus(SpellEntry const* spellProto, uint32 damag
             break;
     }
 
+    // Apply SPELL_AURA_MOD_CRIT_DAMAGE_BONUS modifier first
+    const int32 pctBonus = GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_CRIT_DAMAGE_BONUS, GetSpellSchoolMask(spellProto));
+    crit_bonus += int32((damage + crit_bonus) * float(pctBonus / 100.0f));
+
     // adds additional damage to crit_bonus (from talents)
     if (Player* modOwner = GetSpellModOwner())
         modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_CRIT_DAMAGE_BONUS, crit_bonus);
@@ -6196,8 +6203,6 @@ uint32 Unit::SpellCriticalDamageBonus(SpellEntry const* spellProto, uint32 damag
     }
     else
         critPctDamageMod += pVictim->GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_ATTACKER_SPELL_CRIT_DAMAGE, GetSpellSchoolMask(spellProto));
-
-    critPctDamageMod += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_CRIT_DAMAGE_BONUS, GetSpellSchoolMask(spellProto));
 
     uint32 creatureTypeMask = pVictim->GetCreatureTypeMask();
     critPctDamageMod += GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_CRIT_PERCENT_VERSUS, creatureTypeMask);


### PR DESCRIPTION
Also known as Chaotic Skyfire Diamond and Relentless Earthstorm Diamond fix.
SPELL_AURA_MOD_CRIT_DAMAGE_BONUS is a separate modifier and should be applied before any other crit mods.

Sources:
[WoWHead Chaotic Skyfire Diamond math] (https://web.archive.org/web/20160725024548/http://www.wowhead.com/item=34220/chaotic-skyfire-diamond#comments:id=231157)
[WoWHead Relentless Earthstorm Diamond math] (https://web.archive.org/web/20160725024919/http://www.wowhead.com/item=32409/relentless-earthstorm-diamond#comments:id=222694)
[EJ Warlock DPS Math] (https://web.archive.org/web/20080913120502/http://elitistjerks.com/f31/t17008-warlock_pve_raiding_compendium/)

Test results for Warlock casting Shadow Bolt with Ruin talent:

Step | Dmg | Bonus | Note
------------ | ------------- | ------------- | -------------
1 | 669 | 334 | Before mods
2 | 669 | 364 | Bonus percentage applied
3 | 669 | 735 | Talents and other mods applied
4 | 1404 |  | Final damage

Check: 1404 / 669 = 2.09

More recent comments on WoWhead reflect that SPELL_AURA_MOD_CRIT_DAMAGE_BONUS math is still present as of WotLK, so i can prepare a pull request for another version too.