### PR TITLE
Implement penalty for downranking with Blessing of Light

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -6340,7 +6340,7 @@ uint32 Unit::SpellHealingBonusTaken(Unit* pCaster, SpellEntry const* spellProto,
             {
                 if (((spellProto->SpellFamilyFlags & uint64(0x0000000040000000)) && (*i)->GetEffIndex() == EFFECT_INDEX_1) ||  // Flash of Light
                         ((spellProto->SpellFamilyFlags & uint64(0x0000000080000000)) && (*i)->GetEffIndex() == EFFECT_INDEX_0))    // Holy Light
-                    TakenTotal += (*i)->GetModifier()->m_amount;
+                    TakenTotal += ((*i)->GetModifier()->m_amount * CalculateLevelPenalty(spellProto));  // BoL is penalized since 2.3.0
             }
         }
     }


### PR DESCRIPTION
Penalty applies to bonus provided by Blessing of Light since Patch 2.3.0.

Source:
[EJ Holy Pala thread (01 Jul 2008)] (https://web.archive.org/web/20080701042503/http://elitistjerks.com/f31/t16934-healadin_thread/).