### PR TITLE
Update client control state when on taxi

### DIFF
--- a/src/game/WaypointMovementGenerator.cpp
+++ b/src/game/WaypointMovementGenerator.cpp
@@ -383,6 +383,7 @@ void FlightPathMovementGenerator::Finalize(Player& player)
 
     player.Unmount();
     player.RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_DISABLE_MOVE | UNIT_FLAG_TAXI_FLIGHT);
+    player.SetClientControl(&player, 1);
 
     if (player.m_taxi.empty())
     {
@@ -409,6 +410,7 @@ void FlightPathMovementGenerator::Reset(Player& player)
     player.getHostileRefManager().setOnlineOfflineState(false);
     player.addUnitState(UNIT_STAT_TAXI_FLIGHT);
     player.SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_DISABLE_MOVE | UNIT_FLAG_TAXI_FLIGHT);
+    player.SetClientControl(&player, 0);
 
     Movement::MoveSplineInit init(player);
     uint32 end = GetPathAtMapEnd();


### PR DESCRIPTION
A server-client communication enhancement.

As evident from the source of [QuestHelper 0.50] (http://legacy.curseforge.com/media/files/88/684/QuestHelper-0.50.zip) for TBC, client expects a control update when taking/leaving a taxi flight path.

```lua
  if event == "PLAYER_CONTROL_GAINED" then
    self:flightEnded()
  end

  if event == "PLAYER_CONTROL_LOST" then
    self:flightBegan()
  end
```
This patch fixes flight path timer display for QuestHelper and possibly other addons.