### PR TITLE
Fix periodic leech effects threat generation

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -6101,6 +6101,9 @@ void Aura::PeriodicTick()
             uint32 heal = pCaster->SpellHealingBonusTaken(pCaster, spellProto, int32(new_damage * multiplier), DOT, GetStackAmount());
 
             int32 gain = pCaster->DealHeal(pCaster, heal, spellProto);
+            // Health Leech effects do not generate healing aggro
+            if (m_modifier.m_auraname == SPELL_AURA_PERIODIC_LEECH)
+                break;
             pCaster->getHostileRefManager().threatAssist(pCaster, gain * 0.5f * sSpellMgr.GetSpellThreatMultiplier(spellProto), spellProto);
             break;
         }


### PR DESCRIPTION
Periodic Health leech should not generate healing aggro (only damage).
Sources: [DTM](http://legacy.curseforge.com/media/files/201/513/DiamondThreatMeter_1.7.0_hybrid.zip), [KTM](http://legacy.curseforge.com/media/files/87/88/KLHThreatMeter.22.1.zip).
