### PR TITLE
Fix Demonic Sacrifice

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -286,7 +286,7 @@ void Spell::EffectInstaKill(SpellEffectIndex /*eff_idx*/)
     data << uint32(m_spellInfo->Id);
     m_caster->SendMessageToSet(&data, true);
 
-    m_caster->DealDamage(unitTarget, unitTarget->GetHealth(), nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, nullptr, false);
+    m_caster->DealDamage(unitTarget, unitTarget->GetHealth(), nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, m_spellInfo, false);
 }
 
 void Spell::EffectEnvironmentalDMG(SpellEffectIndex eff_idx)

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -637,7 +637,7 @@ uint32 Unit::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDa
     }
 
     // Get in CombatState
-    if (pVictim != this && damagetype != DOT)
+    if (pVictim != this && damagetype != DOT && (!spellProto || !spellProto->HasAttribute(SPELL_ATTR_EX3_NO_INITIAL_AGGRO)))
     {
         SetInCombatWith(pVictim);
         pVictim->SetInCombatWith(this);


### PR DESCRIPTION
Demonic Sacrifice should not put caster in short combat with his own (dead) pet.
This may slow down buffing in groups significantly, because buffers also receive that pointless short combat state in a chain reaction.

I admit, this is a rather hackish one, but the context is funny: we make pet suicide here instead of killing it ourselves. :)
Also, from performance standpoint we don't introduce additional code or branching anywhere and reusing existing one.