### PR TITLE
Fix Judgement on multiple targets

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -938,15 +938,6 @@ bool IsSingleTargetSpell(SpellEntry const* spellInfo)
     if (spellInfo->HasAttribute(SPELL_ATTR_EX5_SINGLE_TARGET_SPELL))
         return true;
 
-    // TODO - need found Judgements rule
-    switch (GetSpellSpecific(spellInfo->Id))
-    {
-        case SPELL_JUDGEMENT:
-            return true;
-        default:
-            break;
-    }
-
     // single target triggered spell.
     // Not real client side single target spell, but it' not triggered until prev. aura expired.
     // This is allow store it in single target spells list for caster for spell proc checking
@@ -964,12 +955,10 @@ bool IsSingleTargetSpells(SpellEntry const* spellInfo1, SpellEntry const* spellI
             spellInfo1->SpellIconID == spellInfo2->SpellIconID)
         return true;
 
-    // TODO - need found Judgements rule
     SpellSpecific spec1 = GetSpellSpecific(spellInfo1->Id);
     // spell with single target specific types
     switch (spec1)
     {
-        case SPELL_JUDGEMENT:
         case SPELL_MAGE_POLYMORPH:
             if (GetSpellSpecific(spellInfo2->Id) == spec1)
                 return true;


### PR DESCRIPTION
This one is an old and well-known bug in the emulator due to developers not caring enough to research.

The main reason why it was left as is, is the lack of sources for research I was suprised this fact was mentioned very rarely. WoWhead cleared old comments on Judgement spell with WotLK prepatch (which one revamped the spell in turn), but [comments were indexed by search engines](http://i.imgur.com/xKhSkeb.png) and still display partial data.

As for full-blown source, here is [a vanilla raiding guide](https://web.archive.org/web/20160727194837/https://paladin-guide.blogspot.ru/2005/12/judgements.html).

Exact quote from the link above:
> Re: Judgements on several mobs.
> I do this sometimes if there are 2-3 mobs.
> Judge them after each other, and then just use TAB to switch between them.
> I then have a main target that I want to kill first, and the other(s) I jsut switch on to keep the judgement on.

"TODO - need found Judgements rule" is done 10 years later. There is no rule. :smile: 