### PR TITLE
Blizzlike NPC crit adjustments

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -6089,6 +6089,14 @@ bool Unit::IsSpellCrit(Unit* pVictim, SpellEntry const* spellProto, SpellSchoolM
     if (spellProto->HasAttribute(SPELL_ATTR_EX2_CANT_CRIT))
         return false;
 
+    // Creatures do not crit with their spells or abilities, unless it is owned by a player (pet, totem, etc)
+    if (GetTypeId() != TYPEID_PLAYER)
+    {
+        Unit* owner = GetOwner();
+        if (!owner || owner->GetTypeId() != TYPEID_PLAYER)
+            return false;
+    }
+
     float crit_chance = 0.0f;
     switch (spellProto->DmgClass)
     {


### PR DESCRIPTION
NPCs can no longer crit with spells and abilities.
This part is often overlooked in many forks, resulting in NPCs being able to crit with abilities (and spells), which were modeled after ones available to players (and have similar damage parameters).

Source:
[WoWWiki] (https://web.archive.org/web/20160728101909/http://wowwiki.wikia.com/wiki/Spell_critical_strike?oldid=2104859)
>  Mobs are unable to get critical strikes with spells. 

[WoWHead] (https://web.archive.org/web/20160728090939/http://www.wowhead.com/forums&topic=17116/do-npcs-crit)

> NPC specials do NOT crit/crush now. The only thing that can crit/crush is their auto-attack.

This applies to all game versions.


