### PR TITLE
Backport Arena Season broadcast and Instance Difficulty update

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -18312,6 +18312,11 @@ void Player::SendInitialPacketsBeforeAddToMap()
     // tutorial stuff
     GetSession()->SendTutorialsData();
 
+    data.Initialize(SMSG_INSTANCE_DIFFICULTY, 4 + 4);
+    data << uint32(GetMap()->GetDifficulty());
+    data << uint32(0);
+    GetSession()->SendPacket(&data);
+
     SendInitialSpells();
 
     data.Initialize(SMSG_SEND_UNLEARN_SPELLS, 4);

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -7620,6 +7620,9 @@ void Player::SendInitWorldStates(uint32 zoneid, uint32 areaid)
     size_t count_pos = data.wpos();
     data << uint16(0);                                      // count of uint64 blocks, placeholder
 
+    // Current arena season
+    FillInitialWorldState(data, count, 0xC77, sWorld.getConfig(CONFIG_UINT32_ARENA_SEASON_ID));
+
     switch (zoneid)
     {
         case 139:                                           // Eastern Plaguelands


### PR DESCRIPTION
All credits go to original authors, unfortunately i couldn't track down original commits in the wotlk repo.

Enables display of current Arena Season and current dungeon difficulty in the UI.
For testing in the client:
`/run message(GetCurrentArenaSeason())`
`/run message(GetInstanceDifficulty())`