### PR TITLE
Fix Feral Swiftness talent

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -5967,6 +5967,8 @@ void Player::CheckAreaExploreAndOutdoor()
             SpellEntry const* spellInfo = sSpellStore.LookupEntry(itr->first);
             if (!spellInfo || !IsNeedCastSpellAtOutdoor(spellInfo) || HasAura(itr->first))
                 continue;
+            if ((spellInfo->Stances || spellInfo->StancesNot) && !IsNeedCastSpellAtFormApply(spellInfo, GetShapeshiftForm()))
+                continue;
             CastSpell(this, itr->first, true, nullptr);
         }
     }


### PR DESCRIPTION
Check for stances when re-applying passive outdoor-only spells.

Without this patch this talent would be active in any form or without forms.