### PR TITLE
Fixes water walking not being castable on players in various 'forms'

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -5308,7 +5308,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                     Player const* player = static_cast<Player const*>(expectedTarget);
                     
                     // Player is not allowed to cast water walk on shapeshifted/mounted player 
-                    if (player->GetShapeshiftForm() != FORM_NONE || player->IsMounted())
+                    if (player->IsInDisallowedMountForm() || player->IsMounted())
                         return SPELL_FAILED_BAD_TARGETS;
                 }
 


### PR DESCRIPTION
This applies to warriors (due to stances), priests in shadow form and stealthed rogues.