### PR TITLE
Fix multi-instance flight paths after client control patch

### DIFF
--- a/src/game/TaxiHandler.cpp
+++ b/src/game/TaxiHandler.cpp
@@ -199,35 +199,10 @@ void WorldSession::HandleMoveSplineDoneOpcode(WorldPacket& recv_data)
     recv_data >> movementInfo;
     recv_data >> Unused<uint32>();                          // unk
 
-
-    // in taxi flight packet received in 2 case:
-    // 1) end taxi path in far (multi-node) flight
-    // 2) switch from one map to other in case multi-map taxi path
-    // we need process only (1)
+    // in taxi flight packet received at the end of current path in far (multi-node) flight
     uint32 curDest = GetPlayer()->m_taxi.GetTaxiDestination();
     if (!curDest)
         return;
-
-    TaxiNodesEntry const* curDestNode = sTaxiNodesStore.LookupEntry(curDest);
-
-    // far teleport case
-    if (curDestNode && curDestNode->map_id != GetPlayer()->GetMapId())
-    {
-        if (GetPlayer()->GetMotionMaster()->GetCurrentMovementGeneratorType() == FLIGHT_MOTION_TYPE)
-        {
-            // short preparations to continue flight
-            FlightPathMovementGenerator* flight = (FlightPathMovementGenerator*)(GetPlayer()->GetMotionMaster()->top());
-
-            flight->Interrupt(*GetPlayer());                // will reset at map landing
-
-            flight->SetCurrentNodeAfterTeleport();
-            TaxiPathNodeEntry const& node = flight->GetPath()[flight->GetCurrentNode()];
-            flight->SkipCurrentNode();
-
-            GetPlayer()->TeleportTo(curDestNode->map_id, node.x, node.y, node.z, GetPlayer()->GetOrientation());
-        }
-        return;
-    }
 
     uint32 destinationnode = GetPlayer()->m_taxi.NextTaxiDestination();
     if (destinationnode > 0)                                // if more destinations to go

--- a/src/game/WaypointMovementGenerator.cpp
+++ b/src/game/WaypointMovementGenerator.cpp
@@ -442,7 +442,20 @@ bool FlightPathMovementGenerator::Update(Player& player, const uint32& /*diff*/)
         while (true);
     }
 
-    return i_currentNode < (i_path->size() - 1);
+    const bool flying = (i_currentNode < (i_path->size() - 1));
+
+    // Multi-map flight paths
+    if (flying && (*i_path)[i_currentNode + 1].mapid != player.GetMapId())
+    {
+        // short preparations to continue flight
+        Interrupt(player);                // will reset at map landing
+        SetCurrentNodeAfterTeleport();
+        TaxiPathNodeEntry const& node = (*i_path)[i_currentNode];
+        SkipCurrentNode();
+        player.TeleportTo(node.mapid, node.x, node.y, node.z, player.GetOrientation());
+    }
+
+    return flying;
 }
 
 void FlightPathMovementGenerator::SetCurrentNodeAfterTeleport()


### PR DESCRIPTION
Self-explanatory. Fixes Ghostlands<>EPL flight path. Serverside processing, because client no longer spams us with useless packets.

Also, control patch potentially fixed an old bug with players who are flying-by on taxi randomly visually falling to the ground level before disappearing (because we are not broadcasting movement garbage from client anymore).

Can be applied to vanilla for the sake of unification, though there arent any multi-map flight paths.

[Read the full story here] (https://github.com/cmangos/mangos-wotlk/commit/61fc35b3c83f15aa548bd68a111f8d21a921b18a)

