### PR TITLE
EventAI reset fix

### DIFF
--- a/src/game/CreatureEventAI.cpp
+++ b/src/game/CreatureEventAI.cpp
@@ -1068,11 +1068,11 @@ void CreatureEventAI::JustRespawned()                       // NOTE that this is
 
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        // Reset generic timer
+        // Reset generic timer because rest is reset properly in Reset()
         if (i->Event.event_type == EVENT_T_TIMER_GENERIC)
         {
-            if (i->UpdateRepeatTimer(m_creature, i->Event.timer.initialMin, i->Event.timer.initialMax))
-                i->Enabled = true;
+            i->Enabled = true;
+            i->Time = 0;
         }
         // Handle Spawned Events
         else if (SpawnedEventConditionsCheck(i->Event))
@@ -1093,16 +1093,11 @@ void CreatureEventAI::Reset()
         switch (event.event_type)
         {
             // Reset all out of combat timers
-            case EVENT_T_TIMER_OOC:
-            {
-                if (i->UpdateRepeatTimer(m_creature, event.timer.initialMin, event.timer.initialMax))
-                    i->Enabled = true;
+            case EVENT_T_TIMER_GENERIC:
                 break;
-            }
-            default:
-                // TODO: enable below code line / verify this is correct to enable events previously disabled (ex. aggro yell), instead of enable this in void Aggro()
-                //i->Enabled = true;
-                //i->Time = 0;
+            default: // reset all events here, was previously done on enter combat
+                i->Enabled = true;
+                i->Time = 0;
                 break;
         }
     }
@@ -1230,11 +1225,6 @@ void CreatureEventAI::EnterCombat(Unit* enemy)
             case EVENT_T_TIMER_IN_COMBAT:
                 if (i->UpdateRepeatTimer(m_creature, event.timer.initialMin, event.timer.initialMax))
                     i->Enabled = true;
-                break;
-            // All normal events need to be re-enabled and their time set to 0
-            default:
-                i->Enabled = true;
-                i->Time = 0;
                 break;
         }
     }

--- a/src/game/CreatureEventAI.cpp
+++ b/src/game/CreatureEventAI.cpp
@@ -1071,8 +1071,8 @@ void CreatureEventAI::JustRespawned()                       // NOTE that this is
         // Reset generic timer because rest is reset properly in Reset()
         if (i->Event.event_type == EVENT_T_TIMER_GENERIC)
         {
-            i->Enabled = true;
-            i->Time = 0;
+            if (i->UpdateRepeatTimer(m_creature, i->Event.timer.initialMin, i->Event.timer.initialMax))
+                i->Enabled = true;
         }
         // Handle Spawned Events
         else if (SpawnedEventConditionsCheck(i->Event))
@@ -1093,11 +1093,12 @@ void CreatureEventAI::Reset()
         switch (event.event_type)
         {
             // Reset all out of combat timers
+            case EVENT_T_TIMER_IN_COMBAT:
             case EVENT_T_TIMER_GENERIC:
                 break;
             default: // reset all events here, was previously done on enter combat
-                i->Enabled = true;
-                i->Time = 0;
+                if (i->UpdateRepeatTimer(m_creature, event.timer.initialMin, event.timer.initialMax))
+                    i->Enabled = true;
                 break;
         }
     }
@@ -1327,14 +1328,16 @@ void CreatureEventAI::UpdateAI(const uint32 diff)
             // Decrement Timers
             if (i->Time)
             {
-                if (i->Time > m_EventDiff)
+                // Do not decrement timers if event cannot trigger in this phase
+                if (!(i->Event.event_inverse_phase_mask & (1 << m_Phase)))
                 {
-                    // Do not decrement timers if event cannot trigger in this phase
-                    if (!(i->Event.event_inverse_phase_mask & (1 << m_Phase)))
+                    if (i->Time > m_EventDiff)
+                    {                        
                         i->Time -= m_EventDiff;
+                    }
+                    else
+                        i->Time = 0;
                 }
-                else
-                    i->Time = 0;
             }
 
             // Skip processing of events that have time remaining or are disabled


### PR DESCRIPTION
Changed from reset on enter combat, on reset during Reset function,
except for GENERIC, which is properly reset only on respawn

@cyberium this is what I was talking about, pls merge this :)