### PR TITLE
Fix swiftmend ignoring owner of hots

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -3050,7 +3050,7 @@ void Spell::EffectHeal(SpellEffectIndex /*eff_idx*/)
             int32 tickheal = targetAura->GetModifier()->m_amount;
             int32 tickcount = GetSpellDuration(targetAura->GetSpellProto()) / targetAura->GetSpellProto()->EffectAmplitude[idx] - 1;
 
-            unitTarget->RemoveAurasDueToSpell(targetAura->GetId());
+            unitTarget->RemoveAurasByCasterSpell(targetAura->GetId(), targetAura->GetCasterGuid());
 
             addhealth += tickheal * tickcount;
         }


### PR DESCRIPTION
Forces Swiftmend ability to interact only with caster's HoTs instead of wiping all druid HoTs on the target.