### PR TITLE
Fix Mana Tap racial instantly rewarding mana

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -2934,8 +2934,6 @@ void Spell::EffectPowerDrain(SpellEffectIndex eff_idx)
     if (drain_power == POWER_MANA && m_caster != unitTarget)
     {
         float manaMultiplier = m_spellInfo->EffectMultipleValue[eff_idx];
-        if (manaMultiplier == 0)
-            manaMultiplier = 1;
 
         if (Player* modOwner = m_caster->GetSpellModOwner())
             modOwner->ApplySpellMod(m_spellInfo->Id, SPELLMOD_MULTIPLE_VALUE, manaMultiplier);


### PR DESCRIPTION
Fixes incorrect Power Drain effect logic.
All effects that should reward Mana have their correct multipliers set. Spells that shouldn't reward mana have their multiplier zeroed out (like Mana Tap). The assumption about (0 == 1) evidently was made upon reading misleading descriptions for a couple NPC/testing spells without multiplier, which were likely copy-pasted from other spells that should reward mana.