### PR TITLE
Partial spell crit revamp

### DIFF
--- a/src/game/SpellMgr.h
+++ b/src/game/SpellMgr.h
@@ -181,6 +181,39 @@ inline bool IsElementalShield(SpellEntry const* spellInfo)
     return (spellInfo->SpellFamilyFlags & uint64(0x42000000400)) || spellInfo->Id == 23552;
 }
 
+inline bool IsSpellEffectAbleToCrit(const SpellEntry* entry, SpellEffectIndex index)
+{
+    if (!entry || entry->HasAttribute(SPELL_ATTR_EX2_CANT_CRIT))
+        return false;
+
+    switch (entry->Effect[index])
+    {
+        case SPELL_EFFECT_SCHOOL_DAMAGE:
+        case SPELL_EFFECT_HEAL:
+        case SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL:
+        case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
+        case SPELL_EFFECT_WEAPON_DAMAGE:
+        case SPELL_EFFECT_NORMALIZED_WEAPON_DMG:
+            return true;
+        case SPELL_EFFECT_ENERGIZE: // Mana Potion and similar spells, Lay on hands
+            return (entry->SpellFamilyName && entry->DmgClass);
+    }
+    return false;
+}
+
+inline bool IsSpellAbleToCrit(const SpellEntry* entry)
+{
+    if (!entry || entry->HasAttribute(SPELL_ATTR_EX2_CANT_CRIT))
+        return false;
+
+    for (uint32 i = EFFECT_INDEX_0; i < MAX_EFFECT_INDEX; ++i)
+    {
+        if (entry->Effect[i] && IsSpellEffectAbleToCrit(entry, SpellEffectIndex(i)))
+            return true;
+    }
+    return false;
+}
+
 int32 CompareAuraRanks(uint32 spellId_1, uint32 spellId_2);
 
 // order from less to more strict

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -6113,7 +6113,7 @@ int32 Unit::SpellBaseDamageBonusTaken(SpellSchoolMask schoolMask)
 bool Unit::IsSpellCrit(Unit* pVictim, SpellEntry const* spellProto, SpellSchoolMask schoolMask, WeaponAttackType attackType)
 {
     // not critting spell
-    if (spellProto->HasAttribute(SPELL_ATTR_EX2_CANT_CRIT))
+    if (!IsSpellAbleToCrit(spellProto))
         return false;
 
     // Creatures do not crit with their spells or abilities, unless it is owned by a player (pet, totem, etc)
@@ -6127,12 +6127,12 @@ bool Unit::IsSpellCrit(Unit* pVictim, SpellEntry const* spellProto, SpellSchoolM
     float crit_chance = 0.0f;
     switch (spellProto->DmgClass)
     {
-        case SPELL_DAMAGE_CLASS_NONE:
-            return false;
+        case SPELL_DAMAGE_CLASS_NONE: // By default uses spell attack table: Many heals and damage spells
         case SPELL_DAMAGE_CLASS_MAGIC:
         {
+            // Physical school with spell attack table equals base crit chance: healthstone, potion, etc
             if (schoolMask & SPELL_SCHOOL_MASK_NORMAL)
-                crit_chance = 0.0f;
+                crit_chance = float(m_baseSpellCritChance);
             // For other schools
             else if (GetTypeId() == TYPEID_PLAYER)
                 crit_chance = GetFloatValue(PLAYER_SPELL_CRIT_PERCENTAGE1 + GetFirstSchoolInMask(schoolMask));


### PR DESCRIPTION
This effectively and properly replaces:
https://github.com/cmangos/mangos-tbc/pull/105
https://github.com/cmangos/mangos-tbc/pull/104

The data is researched and correct as of Vanilla and TBC. Additional research and adaptation is required for WotLK (now that periodic effects may crit in this expansion under certain conditions for example).

List of individual resolved issues with new mechanics:
* Lifebloom, Earth Shield, Bloodthirst heal effect and Lay on Hands are now able to crit
* Dark Rune, Healthstones and potions are now able to crit
* Item spells and procs that were previously unable to crit (Such as Vial of the Sunwell, Sulthraze the- Lasher, Linken's Boomerang and others) are now all able to crit correctly.
* Health leech effects (Such as Death Coil and Lifestealing enchant) are no longer able to crit.