### PR TITLE
Eaicommands

### DIFF
--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -156,6 +156,8 @@ For all ACTION_T_RANDOM Actions, When a Particular Param is selected for the Eve
 48   ACTION_T_CHANGE_MOVEMENT               MovementType, WanderDistance    Change the unit movement type (Param1). If the movement type is Random Movement (1), the WanderDistance (Param2) must be provided. If the movement type is Waypoint Movement (2), Param2 is PathId.
 49   ACTION_T_DYNAMIC_MOVEMENT              EnableDynamicMovement           Enable dynamic movement behavior (1 = on; 0 = off)
 50   ACTION_T_SET_REACT_STATE               ReactState                      Change react state of the creature
+51   ACTION_T_PAUSE_WAYPOINTS               DoPause                         Pause waypoints of creature
+52   ACTION_T_INTERRUPT_SPELL               SpellType - CurrentSpellTypes   Interrupt spell in given slot for creature
 
 * = Use -1 where the param is expected to do nothing. Random constant is generated for each event, so if you have a random yell and a random sound, they will be linked up with each other (ie. param2 with param2).
 
@@ -930,6 +932,22 @@ Parameter 1: EnableDynamicMovement - Enable dynamic movement behavior. 1 = on / 
 50 = ACTION_T_SET_REACT_STATE:
 ------------------------------
 Parameter 1: ReactState - Define the react state of the creature. 0 = Passive, 1 = Defensive, 2 = Aggresive. Default behavior is Aggresive.
+
+------------------------------
+51 = ACTION_T_PAUSE_WAYPOINTS:
+------------------------------
+Parameter 1: DoPause - Pause or unpause waypoints for creature. 0 - Unpause, 1 - Pause. Identical in behaviour to DBScript command.
+
+------------------------------
+52 = ACTION_T_INTERRUPT_SPELL:
+------------------------------
+Parameter 1: SpellType - Interrupt spell in SpellType slot. SpellType is based on CurrentSpellTypes in code.
+CURRENT_MELEE_SPELL             = 0
+CURRENT_GENERIC_SPELL           = 1
+CURRENT_AUTOREPEAT_SPELL        = 2
+CURRENT_CHANNELED_SPELL         = 3
+Melee spells, generic spells and autorepeat spells have their interruptability based on interrupt flags, albeit this flag is wrongly missing for some spells.
+Main purpose of this command is to research and find channeled spells, which do not interrupt as a result of not having found an interrupt flag.
 
 =========================================
 Target Types

--- a/src/game/AI/CreatureEventAI.cpp
+++ b/src/game/AI/CreatureEventAI.cpp
@@ -1080,6 +1080,11 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                 m_creature->clearUnitState(UNIT_STAT_WAYPOINT_PAUSED);
             break;
         }
+        case ACTION_T_INTERRUPT_SPELL:
+        {
+            m_creature->InterruptSpell((CurrentSpellTypes)action.interruptSpell.currentSpellType);
+            break;
+        }
         default:
             sLog.outError("CreatureEventAi::ProcessAction(): action(%u) not implemented", static_cast<uint32>(action.type));
             break;

--- a/src/game/AI/CreatureEventAI.cpp
+++ b/src/game/AI/CreatureEventAI.cpp
@@ -1072,6 +1072,14 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             m_reactState = ReactStates(action.setReactState.reactState);
             break;
         }
+        case ACTION_T_PAUSE_WAYPOINTS:
+        {
+            if (action.pauseWaypoint.doPause)
+                m_creature->addUnitState(UNIT_STAT_WAYPOINT_PAUSED);
+            else
+                m_creature->clearUnitState(UNIT_STAT_WAYPOINT_PAUSED);
+            break;
+        }
         default:
             sLog.outError("CreatureEventAi::ProcessAction(): action(%u) not implemented", static_cast<uint32>(action.type));
             break;

--- a/src/game/AI/CreatureEventAI.h
+++ b/src/game/AI/CreatureEventAI.h
@@ -127,6 +127,7 @@ enum EventAI_ActionType
     ACTION_T_DYNAMIC_MOVEMENT           = 49,               // EnableDynamicMovement (1 = on; 0 = off)
     ACTION_T_SET_REACT_STATE            = 50,               // React state, unused, unused
     ACTION_T_PAUSE_WAYPOINTS            = 51,               // DoPause 0: unpause waypoint 1: pause waypoint, unused, unused
+    ACTION_T_INTERRUPT_SPELL            = 52,               // SpellType enum CurrentSpellTypes, unused, unused
 
     ACTION_T_END,
 };
@@ -446,6 +447,13 @@ struct CreatureEventAI_Action
             uint32 unused1;
             uint32 unused2;
         } pauseWaypoint;
+        // ACTION_T_INTERRUPT_SPELL                         = 52
+        struct
+        {
+            uint32 currentSpellType;                        // enum CurrentSpellTypes
+            uint32 unused1;
+            uint32 unused2;
+        } interruptSpell;
         // RAW
         struct
         {

--- a/src/game/AI/CreatureEventAI.h
+++ b/src/game/AI/CreatureEventAI.h
@@ -126,6 +126,7 @@ enum EventAI_ActionType
     ACTION_T_CHANGE_MOVEMENT            = 48,               // MovementType, WanderDistance if Movement Type 1 and PathId if Movement Type 2, unused
     ACTION_T_DYNAMIC_MOVEMENT           = 49,               // EnableDynamicMovement (1 = on; 0 = off)
     ACTION_T_SET_REACT_STATE            = 50,               // React state, unused, unused
+    ACTION_T_PAUSE_WAYPOINTS            = 51,               // DoPause 0: unpause waypoint 1: pause waypoint, unused, unused
 
     ACTION_T_END,
 };
@@ -438,6 +439,13 @@ struct CreatureEventAI_Action
             uint32 unused1;
             uint32 unused2;
         } setReactState;
+        // ACTION_T_PAUSE_WAYPOINTS                         = 51
+        struct                                              
+        {
+            uint32 doPause;                                 // bool: 1 = on; 0 = off
+            uint32 unused1;
+            uint32 unused2;
+        } pauseWaypoint;
         // RAW
         struct
         {

--- a/src/game/AI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/CreatureEventAIMgr.cpp
@@ -897,6 +897,8 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                         }
                         break;
 
+                    case ACTION_T_PAUSE_WAYPOINTS:
+                        break;
                     default:
                         sLog.outErrorEventAI("Event %u Action %u have currently not checked at load action type (%u). Need check code update?", i, j + 1, temp.action[j].type);
                         break;

--- a/src/game/AI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/CreatureEventAIMgr.cpp
@@ -896,8 +896,14 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                             continue;
                         }
                         break;
-
                     case ACTION_T_PAUSE_WAYPOINTS:
+                        break;
+                    case ACTION_T_INTERRUPT_SPELL:
+                        if (action.interruptSpell.currentSpellType > 4)
+                        {
+                            sLog.outErrorEventAI("Event %u Action %u uses invalid current cast spell %u (must be smaller or equal to 4)", i, j + 1, action.setReactState.reactState, REACT_AGGRESSIVE);
+                            continue;
+                        }
                         break;
                     default:
                         sLog.outErrorEventAI("Event %u Action %u have currently not checked at load action type (%u). Need check code update?", i, j + 1, temp.action[j].type);


### PR DESCRIPTION
Implement two EAI commands required for this kind of behaviour:

https://gist.github.com/killerwife/569e3517c36634d116c620c7a1c93c91

The pause waypoints is a mirror to DBSCRIPT, so that we can make scripts work when creature leaves combat again.

The Interrupt Spell is to provide interrupt command when creature casts some kind of infinite spell that prevents it from making any actions in combat, like for example the green beam spell.

@cyberium @xfurry @grz3s
