### PR TITLE
Sd2improvements

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -231,6 +231,7 @@ UPDATE creature_template SET ScriptName='npc_twiggy_flathead' WHERE entry=6248;
 DELETE FROM scripted_areatrigger WHERE entry=522;
 INSERT INTO scripted_areatrigger VALUES (522,'at_twiggy_flathead');
 UPDATE creature_template SET ScriptName='npc_wizzlecranks_shredder' WHERE entry=3439;
+UPDATE creature_template SET ScriptName='npc_gallywix' WHERE entry=7288;
 
 /* BLACK TEMPLE */
 UPDATE instance_template SET ScriptName='instance_black_temple' WHERE map=564;

--- a/src/game/AI/CreatureAI.h
+++ b/src/game/AI/CreatureAI.h
@@ -153,6 +153,7 @@ class MANGOS_DLL_SPEC CreatureAI
          * @param pDoneTo Unit* to whom Damage of amount uiDamage will be dealt
          * @param uiDamage Amount of Damage that will be dealt, can be changed here
          */
+        virtual void DamageDeal(Unit* pDoneTo, uint32& uiDamage, DamageEffectType damagetype, SpellEntry const* spellInfo) { DamageDeal(pDoneTo, uiDamage, damagetype); }
         virtual void DamageDeal(Unit* /*pDoneTo*/, uint32& /*uiDamage*/, DamageEffectType damagetype) {}
 
         /**
@@ -162,6 +163,7 @@ class MANGOS_DLL_SPEC CreatureAI
          * @param pDealer Unit* who will deal Damage to the creature
          * @param uiDamage Amount of Damage that will be dealt, can be changed here
          */
+        virtual void DamageTaken(Unit* pDealer, uint32& uiDamage, DamageEffectType damagetype, SpellEntry const* spellInfo) { DamageTaken(pDealer, uiDamage, damagetype); }
         virtual void DamageTaken(Unit* /*pDealer*/, uint32& /*uiDamage*/, DamageEffectType damagetype) {}
 
         /**

--- a/src/game/AI/CreatureAI.h
+++ b/src/game/AI/CreatureAI.h
@@ -153,7 +153,7 @@ class MANGOS_DLL_SPEC CreatureAI
          * @param pDoneTo Unit* to whom Damage of amount uiDamage will be dealt
          * @param uiDamage Amount of Damage that will be dealt, can be changed here
          */
-        virtual void DamageDeal(Unit* /*pDoneTo*/, uint32& /*uiDamage*/) {}
+        virtual void DamageDeal(Unit* /*pDoneTo*/, uint32& /*uiDamage*/, DamageEffectType damagetype) {}
 
         /**
          * Called at any Damage from any attacker (before damage apply)
@@ -162,7 +162,7 @@ class MANGOS_DLL_SPEC CreatureAI
          * @param pDealer Unit* who will deal Damage to the creature
          * @param uiDamage Amount of Damage that will be dealt, can be changed here
          */
-        virtual void DamageTaken(Unit* /*pDealer*/, uint32& /*uiDamage*/) {}
+        virtual void DamageTaken(Unit* /*pDealer*/, uint32& /*uiDamage*/, DamageEffectType damagetype) {}
 
         /**
          * Called when the creature is killed

--- a/src/game/AI/CreatureEventAI.cpp
+++ b/src/game/AI/CreatureEventAI.cpp
@@ -1549,7 +1549,7 @@ void CreatureEventAI::ReceiveEmote(Player* pPlayer, uint32 text_emote)
 
 #define HEALTH_STEPS            3
 
-void CreatureEventAI::DamageTaken(Unit* dealer, uint32& damage)
+void CreatureEventAI::DamageTaken(Unit* dealer, uint32& damage, DamageEffectType damagetype)
 {
     if (m_InvinceabilityHpLevel > 0 && m_creature->GetHealth() < m_InvinceabilityHpLevel + damage)
     {

--- a/src/game/AI/CreatureEventAI.h
+++ b/src/game/AI/CreatureEventAI.h
@@ -656,7 +656,7 @@ class MANGOS_DLL_SPEC CreatureEventAI : public CreatureAI
         void AttackStart(Unit* who) override;
         void MoveInLineOfSight(Unit* who) override;
         void SpellHit(Unit* pUnit, const SpellEntry* pSpell) override;
-        void DamageTaken(Unit* done_by, uint32& damage) override;
+        void DamageTaken(Unit* done_by, uint32& damage, DamageEffectType damagetype) override;
         void HealedBy(Unit* healer, uint32& healedAmount) override;
         void UpdateAI(const uint32 diff) override;
         bool IsVisible(Unit*) const override;

--- a/src/game/Level3.cpp
+++ b/src/game/Level3.cpp
@@ -3519,7 +3519,7 @@ bool ChatHandler::HandleDamageCommand(char* args)
 
         damage -= absorb + resist;
 
-        player->DealDamageMods(target, damage, &absorb);
+        player->DealDamageMods(target, damage, &absorb, DIRECT_DAMAGE);
         player->DealDamage(target, damage, nullptr, DIRECT_DAMAGE, schoolmask, nullptr, false);
         player->SendAttackStateUpdate(HITINFO_NORMALSWING2, target, schoolmask, damage, absorb, resist, VICTIMSTATE_NORMAL, 0);
         return true;

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -914,7 +914,11 @@ uint32 Player::EnvironmentalDamage(EnviromentalDamage type, uint32 damage)
 
     damage -= absorb + resist;
 
-    DealDamageMods(this, damage, &absorb);
+    DamageEffectType damageType = SELF_DAMAGE;
+    if (type == DAMAGE_FALL && getClass() == CLASS_ROGUE)
+        damageType = SELF_DAMAGE_ROGUE_FALL;
+
+    DealDamageMods(this, damage, &absorb, damageType);
 
     WorldPacket data(SMSG_ENVIRONMENTALDAMAGELOG, (21));
     data << GetObjectGuid();
@@ -923,10 +927,6 @@ uint32 Player::EnvironmentalDamage(EnviromentalDamage type, uint32 damage)
     data << uint32(absorb);
     data << uint32(resist);
     SendMessageToSet(&data, true);
-
-    DamageEffectType damageType = SELF_DAMAGE;
-    if (type == DAMAGE_FALL && getClass() == CLASS_ROGUE)
-        damageType = SELF_DAMAGE_ROGUE_FALL;
 
     uint32 final_damage = DealDamage(this, damage, nullptr, damageType, SPELL_SCHOOL_MASK_NORMAL, nullptr, false);
 

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -1022,7 +1022,7 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
 
         unitTarget->CalculateAbsorbResistBlock(caster, &damageInfo, m_spellInfo);
 
-        caster->DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE);
+        caster->DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE, m_spellInfo);
 
         // Send log damage message to client
         caster->SendSpellNonMeleeDamageLog(&damageInfo);

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -1022,7 +1022,7 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
 
         unitTarget->CalculateAbsorbResistBlock(caster, &damageInfo, m_spellInfo);
 
-        caster->DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb);
+        caster->DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE);
 
         // Send log damage message to client
         caster->SendSpellNonMeleeDamageLog(&damageInfo);

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -5875,7 +5875,7 @@ void Aura::PeriodicTick()
             DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s attacked %s for %u dmg inflicted by %u",
                               GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, GetId());
 
-            pCaster->DealDamageMods(target, pdamage, &absorb);
+            pCaster->DealDamageMods(target, pdamage, &absorb, DOT);
 
             // Set trigger flag
             uint32 procAttacker = PROC_FLAG_ON_DO_PERIODIC; //  | PROC_FLAG_SUCCESSFUL_HARMFUL_SPELL_HIT;
@@ -5944,7 +5944,7 @@ void Aura::PeriodicTick()
             DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s health leech of %s for %u dmg inflicted by %u abs is %u",
                               GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, GetId(), absorb);
 
-            pCaster->DealDamageMods(target, pdamage, &absorb);
+            pCaster->DealDamageMods(target, pdamage, &absorb, DOT);
 
             pCaster->SendSpellNonMeleeDamageLog(target, GetId(), pdamage, GetSpellSchoolMask(spellProto), absorb, resist, false, 0);
 
@@ -6039,7 +6039,7 @@ void Aura::PeriodicTick()
                     uint32 damage = spellProto->manaPerSecond;
                     uint32 absorb = 0;
 
-                    pCaster->DealDamageMods(pCaster, damage, &absorb);
+                    pCaster->DealDamageMods(pCaster, damage, &absorb, NODAMAGE);
                     if (pCaster->GetHealth() > damage)
                     {
                         pCaster->SendSpellNonMeleeDamageLog(pCaster, GetId(), damage, GetSpellSchoolMask(spellProto), absorb, 0, false, 0, false);
@@ -6255,7 +6255,7 @@ void Aura::PeriodicTick()
 
             damageInfo.target->CalculateAbsorbResistBlock(pCaster, &damageInfo, spellProto);
 
-            pCaster->DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb);
+            pCaster->DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE);
 
             pCaster->SendSpellNonMeleeDamageLog(&damageInfo);
 

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -5875,7 +5875,7 @@ void Aura::PeriodicTick()
             DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s attacked %s for %u dmg inflicted by %u",
                               GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, GetId());
 
-            pCaster->DealDamageMods(target, pdamage, &absorb, DOT);
+            pCaster->DealDamageMods(target, pdamage, &absorb, DOT, spellProto);
 
             // Set trigger flag
             uint32 procAttacker = PROC_FLAG_ON_DO_PERIODIC; //  | PROC_FLAG_SUCCESSFUL_HARMFUL_SPELL_HIT;
@@ -5944,7 +5944,7 @@ void Aura::PeriodicTick()
             DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s health leech of %s for %u dmg inflicted by %u abs is %u",
                               GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, GetId(), absorb);
 
-            pCaster->DealDamageMods(target, pdamage, &absorb, DOT);
+            pCaster->DealDamageMods(target, pdamage, &absorb, DOT, spellProto);
 
             pCaster->SendSpellNonMeleeDamageLog(target, GetId(), pdamage, GetSpellSchoolMask(spellProto), absorb, resist, false, 0);
 
@@ -6039,7 +6039,7 @@ void Aura::PeriodicTick()
                     uint32 damage = spellProto->manaPerSecond;
                     uint32 absorb = 0;
 
-                    pCaster->DealDamageMods(pCaster, damage, &absorb, NODAMAGE);
+                    pCaster->DealDamageMods(pCaster, damage, &absorb, NODAMAGE, spellProto);
                     if (pCaster->GetHealth() > damage)
                     {
                         pCaster->SendSpellNonMeleeDamageLog(pCaster, GetId(), damage, GetSpellSchoolMask(spellProto), absorb, 0, false, 0, false);
@@ -6255,7 +6255,7 @@ void Aura::PeriodicTick()
 
             damageInfo.target->CalculateAbsorbResistBlock(pCaster, &damageInfo, spellProto);
 
-            pCaster->DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE);
+            pCaster->DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE, spellProto);
 
             pCaster->SendSpellNonMeleeDamageLog(&damageInfo);
 

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -515,7 +515,7 @@ void Unit::RemoveSpellsCausingAura(AuraType auraType, ObjectGuid casterGuid)
     }
 }
 
-void Unit::DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb, DamageEffectType damagetype)
+void Unit::DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb, DamageEffectType damagetype, SpellEntry const* spellProto)
 {
     if (!pVictim->isAlive() || pVictim->IsTaxiFlying() || (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode()))
     {
@@ -538,10 +538,10 @@ void Unit::DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb, DamageE
 
     // Script Event damage Deal
     if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->AI())
-        ((Creature*)this)->AI()->DamageDeal(pVictim, damage, damagetype);
+        ((Creature*)this)->AI()->DamageDeal(pVictim, damage, damagetype, spellProto);
     // Script Event damage taken
     if (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->AI())
-        ((Creature*)pVictim)->AI()->DamageTaken(this, damage, damagetype);
+        ((Creature*)pVictim)->AI()->DamageTaken(this, damage, damagetype, spellProto);
 
     if (absorb && originalDamage > damage)
         *absorb += (originalDamage - damage);
@@ -1297,7 +1297,7 @@ uint32 Unit::SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage
     SpellNonMeleeDamage damageInfo(this, pVictim, spellInfo->Id, SpellSchoolMask(spellInfo->SchoolMask));
     CalculateSpellDamage(&damageInfo, damage, spellInfo);
     damageInfo.target->CalculateAbsorbResistBlock(this, &damageInfo, spellInfo);
-    DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE);
+    DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE, spellInfo);
     SendSpellNonMeleeDamageLog(&damageInfo);
     DealSpellDamage(&damageInfo, true);
     return damageInfo.damage;
@@ -1803,7 +1803,7 @@ void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
                     // CalcAbsorbResist(pVictim, SpellSchools(spellProto->School), SPELL_DIRECT_DAMAGE, damage, &absorb, &resist);
                     // damage-=absorb + resist;
 
-                    pVictim->DealDamageMods(this, damage, nullptr, SPELL_DIRECT_DAMAGE);
+                    pVictim->DealDamageMods(this, damage, nullptr, SPELL_DIRECT_DAMAGE, i_spellProto);
 
                     WorldPacket data(SMSG_SPELLDAMAGESHIELD, (8 + 8 + 4 + 4 + 4));
                     data << pVictim->GetObjectGuid();
@@ -2162,7 +2162,7 @@ void Unit::CalculateDamageAbsorbAndResist(Unit* pCaster, SpellSchoolMask schoolM
 
             uint32 splitted = currentAbsorb;
             uint32 splitted_absorb = 0;
-            pCaster->DealDamageMods(caster, splitted, &splitted_absorb, DIRECT_DAMAGE);
+            pCaster->DealDamageMods(caster, splitted, &splitted_absorb, DIRECT_DAMAGE, (*i)->GetSpellProto());
 
             pCaster->SendSpellNonMeleeDamageLog(caster, (*i)->GetSpellProto()->Id, splitted, schoolMask, splitted_absorb, 0, false, 0, false);
 
@@ -2195,7 +2195,7 @@ void Unit::CalculateDamageAbsorbAndResist(Unit* pCaster, SpellSchoolMask schoolM
             }
 
             uint32 split_absorb = 0;
-            pCaster->DealDamageMods(caster, splitted, &split_absorb, DIRECT_DAMAGE);
+            pCaster->DealDamageMods(caster, splitted, &split_absorb, DIRECT_DAMAGE, (*i)->GetSpellProto());
 
             pCaster->SendSpellNonMeleeDamageLog(caster, (*i)->GetSpellProto()->Id, splitted, schoolMask, split_absorb, 0, false, 0, false);
 

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -515,7 +515,7 @@ void Unit::RemoveSpellsCausingAura(AuraType auraType, ObjectGuid casterGuid)
     }
 }
 
-void Unit::DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb)
+void Unit::DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb, DamageEffectType damagetype)
 {
     if (!pVictim->isAlive() || pVictim->IsTaxiFlying() || (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode()))
     {
@@ -538,10 +538,10 @@ void Unit::DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb)
 
     // Script Event damage Deal
     if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->AI())
-        ((Creature*)this)->AI()->DamageDeal(pVictim, damage);
+        ((Creature*)this)->AI()->DamageDeal(pVictim, damage, damagetype);
     // Script Event damage taken
     if (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->AI())
-        ((Creature*)pVictim)->AI()->DamageTaken(this, damage);
+        ((Creature*)pVictim)->AI()->DamageTaken(this, damage, damagetype);
 
     if (absorb && originalDamage > damage)
         *absorb += (originalDamage - damage);
@@ -1297,7 +1297,7 @@ uint32 Unit::SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage
     SpellNonMeleeDamage damageInfo(this, pVictim, spellInfo->Id, SpellSchoolMask(spellInfo->SchoolMask));
     CalculateSpellDamage(&damageInfo, damage, spellInfo);
     damageInfo.target->CalculateAbsorbResistBlock(this, &damageInfo, spellInfo);
-    DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb);
+    DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE);
     SendSpellNonMeleeDamageLog(&damageInfo);
     DealSpellDamage(&damageInfo, true);
     return damageInfo.damage;
@@ -1803,7 +1803,7 @@ void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
                     // CalcAbsorbResist(pVictim, SpellSchools(spellProto->School), SPELL_DIRECT_DAMAGE, damage, &absorb, &resist);
                     // damage-=absorb + resist;
 
-                    pVictim->DealDamageMods(this, damage, nullptr);
+                    pVictim->DealDamageMods(this, damage, nullptr, SPELL_DIRECT_DAMAGE);
 
                     WorldPacket data(SMSG_SPELLDAMAGESHIELD, (8 + 8 + 4 + 4 + 4));
                     data << pVictim->GetObjectGuid();
@@ -2162,7 +2162,7 @@ void Unit::CalculateDamageAbsorbAndResist(Unit* pCaster, SpellSchoolMask schoolM
 
             uint32 splitted = currentAbsorb;
             uint32 splitted_absorb = 0;
-            pCaster->DealDamageMods(caster, splitted, &splitted_absorb);
+            pCaster->DealDamageMods(caster, splitted, &splitted_absorb, DIRECT_DAMAGE);
 
             pCaster->SendSpellNonMeleeDamageLog(caster, (*i)->GetSpellProto()->Id, splitted, schoolMask, splitted_absorb, 0, false, 0, false);
 
@@ -2195,7 +2195,7 @@ void Unit::CalculateDamageAbsorbAndResist(Unit* pCaster, SpellSchoolMask schoolM
             }
 
             uint32 split_absorb = 0;
-            pCaster->DealDamageMods(caster, splitted, &split_absorb);
+            pCaster->DealDamageMods(caster, splitted, &split_absorb, DIRECT_DAMAGE);
 
             pCaster->SendSpellNonMeleeDamageLog(caster, (*i)->GetSpellProto()->Id, splitted, schoolMask, split_absorb, 0, false, 0, false);
 
@@ -2299,7 +2299,7 @@ void Unit::AttackerStateUpdate(Unit* pVictim, WeaponAttackType attType, bool ext
     CalcDamageInfo damageInfo;
     CalculateMeleeDamage(pVictim, &damageInfo, attType);
     // Send log damage message to client
-    DealDamageMods(pVictim, damageInfo.damage, &damageInfo.absorb);
+    DealDamageMods(pVictim, damageInfo.damage, &damageInfo.absorb, DIRECT_DAMAGE);
     SendAttackStateUpdate(&damageInfo);
     ProcDamageAndSpell(damageInfo.target, damageInfo.procAttacker, damageInfo.procVictim, damageInfo.procEx, damageInfo.damage, damageInfo.attackType);
     DealMeleeDamage(&damageInfo, true);

--- a/src/game/Unit.h
+++ b/src/game/Unit.h
@@ -1387,7 +1387,7 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         void Unmount(bool from_aura = false);
 
         uint16 GetMaxSkillValueForLevel(Unit const* target = nullptr) const { return (target ? GetLevelForTarget(target) : getLevel()) * 5; }
-        void DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb, DamageEffectType damagetype);
+        void DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb, DamageEffectType damagetype, SpellEntry const* spellProto = nullptr);
         uint32 DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDamage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask, SpellEntry const* spellProto, bool durabilityLoss);
         int32 DealHeal(Unit* pVictim, uint32 addhealth, SpellEntry const* spellProto, bool critical = false);
 

--- a/src/game/Unit.h
+++ b/src/game/Unit.h
@@ -1387,7 +1387,7 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         void Unmount(bool from_aura = false);
 
         uint16 GetMaxSkillValueForLevel(Unit const* target = nullptr) const { return (target ? GetLevelForTarget(target) : getLevel()) * 5; }
-        void DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb);
+        void DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb, DamageEffectType damagetype);
         uint32 DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDamage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask, SpellEntry const* spellProto, bool durabilityLoss);
         int32 DealHeal(Unit* pVictim, uint32 addhealth, SpellEntry const* spellProto, bool critical = false);
 

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -2219,7 +2219,7 @@ SpellAuraProcResult Unit::HandleProcTriggerDamageAuraProc(Unit* pVictim, uint32 
     SpellNonMeleeDamage damageInfo(this, pVictim, spellInfo->Id, SpellSchoolMask(spellInfo->SchoolMask));
     CalculateSpellDamage(&damageInfo, triggeredByAura->GetModifier()->m_amount, spellInfo);
     damageInfo.target->CalculateAbsorbResistBlock(this, &damageInfo, spellInfo);
-    DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE);
+    DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE, spellInfo);
     SendSpellNonMeleeDamageLog(&damageInfo);
     DealSpellDamage(&damageInfo, true);
     return SPELL_AURA_PROC_OK;

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -2219,7 +2219,7 @@ SpellAuraProcResult Unit::HandleProcTriggerDamageAuraProc(Unit* pVictim, uint32 
     SpellNonMeleeDamage damageInfo(this, pVictim, spellInfo->Id, SpellSchoolMask(spellInfo->SchoolMask));
     CalculateSpellDamage(&damageInfo, triggeredByAura->GetModifier()->m_amount, spellInfo);
     damageInfo.target->CalculateAbsorbResistBlock(this, &damageInfo, spellInfo);
-    DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb);
+    DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE);
     SendSpellNonMeleeDamageLog(&damageInfo);
     DealSpellDamage(&damageInfo, true);
     return SPELL_AURA_PROC_OK;

--- a/src/scriptdev2/include/sc_creature.h
+++ b/src/scriptdev2/include/sc_creature.h
@@ -73,10 +73,10 @@ struct ScriptedAI : public CreatureAI
         void HealedBy(Unit* /*pHealer*/, uint32& /*uiHealedAmount*/) override {}
 
         // Called at any Damage to any victim (before damage apply)
-        void DamageDeal(Unit* /*pDoneTo*/, uint32& /*uiDamage*/) override {}
+        void DamageDeal(Unit* /*pDoneTo*/, uint32& /*uiDamage*/, DamageEffectType damagetype) override {}
 
         // Called at any Damage from any attacker (before damage apply)
-        void DamageTaken(Unit* /*pDealer*/, uint32& /*uiDamage*/) override {}
+        void DamageTaken(Unit* /*pDealer*/, uint32& /*uiDamage*/, DamageEffectType damagetype) override {}
 
         // Called at creature death
         void JustDied(Unit* /*pKiller*/) override {}

--- a/src/scriptdev2/scripts/eastern_kingdoms/blackwing_lair/boss_razorgore.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/blackwing_lair/boss_razorgore.cpp
@@ -84,7 +84,7 @@ struct boss_razorgoreAI : public ScriptedAI
         DoScriptText(SAY_DEATH, m_creature);
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;

--- a/src/scriptdev2/scripts/eastern_kingdoms/karazhan/boss_shade_of_aran.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/karazhan/boss_shade_of_aran.cpp
@@ -171,7 +171,7 @@ struct boss_aranAI : public ScriptedAI
         m_creature->RemoveGuardians();
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType damagetype) override
     {
         if (!m_bDrinkInturrupted && m_bIsDrinking && uiDamage > 0)
         {
@@ -202,9 +202,6 @@ struct boss_aranAI : public ScriptedAI
 
     void UpdateAI(const uint32 uiDiff) override
     {
-        if (!m_creature->SelectHostileTarget() || !m_creature->getVictim())
-            return;
-
         // Start drinking when below 20% mana
         if (!m_bIsDrinking && m_creature->GetPowerType() == POWER_MANA && (m_creature->GetPower(POWER_MANA) * 100 / m_creature->GetMaxPower(POWER_MANA)) < 20)
         {
@@ -260,6 +257,9 @@ struct boss_aranAI : public ScriptedAI
             // no other spells during mana recovery
             return;
         }
+
+        if (!m_creature->SelectHostileTarget() || !m_creature->getVictim())
+            return;
 
         // Normal spell casts
         if (m_uiNormalCastTimer < uiDiff)

--- a/src/scriptdev2/scripts/eastern_kingdoms/karazhan/boss_shade_of_aran.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/karazhan/boss_shade_of_aran.cpp
@@ -173,7 +173,8 @@ struct boss_aranAI : public ScriptedAI
 
     void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType damagetype) override
     {
-        if (!m_bDrinkInturrupted && m_bIsDrinking && uiDamage > 0)
+        // Must only break drinking on direct damage
+        if (!m_bDrinkInturrupted && m_bIsDrinking && uiDamage > 0 && (damagetype == SPELL_DIRECT_DAMAGE || damagetype == DIRECT_DAMAGE))
         {
             if (!m_creature->HasAura(SPELL_DRINK))
                 return;

--- a/src/scriptdev2/scripts/eastern_kingdoms/karazhan/bosses_opera.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/karazhan/bosses_opera.cpp
@@ -844,7 +844,7 @@ struct boss_julianneAI : public ScriptedAI
         m_creature->ForcedDespawn();
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;
@@ -1091,7 +1091,7 @@ struct boss_romuloAI : public ScriptedAI
         m_creature->ForcedDespawn();
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;

--- a/src/scriptdev2/scripts/eastern_kingdoms/karazhan/chess_event.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/karazhan/chess_event.cpp
@@ -660,7 +660,7 @@ struct npc_king_llaneAI : public npc_chess_piece_genericAI
 
     bool m_bIsAttacked;
 
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+    void DamageTaken(Unit* pDoneBy, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (!uiDamage || !m_bIsAttacked || !m_pInstance || pDoneBy->GetTypeId() != TYPEID_UNIT)
             return;
@@ -771,7 +771,7 @@ struct npc_warchief_blackhandAI : public npc_chess_piece_genericAI
 
     bool m_bIsAttacked;
 
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+    void DamageTaken(Unit* pDoneBy, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (!uiDamage || !m_bIsAttacked || !m_pInstance || pDoneBy->GetTypeId() != TYPEID_UNIT)
             return;

--- a/src/scriptdev2/scripts/eastern_kingdoms/magisters_terrace/boss_felblood_kaelthas.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/magisters_terrace/boss_felblood_kaelthas.cpp
@@ -158,7 +158,7 @@ struct boss_felblood_kaelthasAI : public ScriptedAI, private DialogueHelper
     }
 
     // Boss has an interesting speech before killed, so we need to fake death (without stand state) and allow him to finish his theatre
-    void DamageTaken(Unit* /*pKiller*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pKiller*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;
@@ -465,7 +465,7 @@ struct mob_felkael_phoenixAI : public ScriptedAI
         ScriptedAI::EnterEvadeMode();
     }
 
-    void DamageTaken(Unit* /*pKiller*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pKiller*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;

--- a/src/scriptdev2/scripts/eastern_kingdoms/molten_core/boss_golemagg.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/molten_core/boss_golemagg.cpp
@@ -153,7 +153,7 @@ struct mob_core_ragerAI : public ScriptedAI
         m_uiMangleTimer = 7 * IN_MILLISECONDS;              // These times are probably wrong
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (m_creature->GetHealthPercent() < 50.0f)
         {

--- a/src/scriptdev2/scripts/eastern_kingdoms/molten_core/boss_majordomo_executus.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/molten_core/boss_majordomo_executus.cpp
@@ -242,7 +242,7 @@ struct boss_majordomoAI : public ScriptedAI
         m_luiMajordomoAddsGUIDs.clear();
     }
 
-    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage > m_creature->GetHealth())
         {

--- a/src/scriptdev2/scripts/eastern_kingdoms/naxxramas/boss_thaddius.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/naxxramas/boss_thaddius.cpp
@@ -588,7 +588,7 @@ struct boss_thaddiusAddsAI : public ScriptedAI
         DoMeleeAttackIfReady();
     }
 
-    void DamageTaken(Unit* pKiller, uint32& uiDamage) override
+    void DamageTaken(Unit* pKiller, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;

--- a/src/scriptdev2/scripts/eastern_kingdoms/scarlet_monastery/boss_headless_horseman.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/scarlet_monastery/boss_headless_horseman.cpp
@@ -172,7 +172,7 @@ struct boss_headless_horsemanAI : public ScriptedAI
         }
     }
 
-    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (m_fightPhase != PHASE_HEAD_TOSS && uiDamage >= m_creature->GetHealth())
         {
@@ -392,7 +392,7 @@ struct boss_head_of_horsemanAI : public ScriptedAI
         }
     }
 
-    void DamageTaken(Unit* /*pDealer*/, uint32& /*uiDamage*/) override
+    void DamageTaken(Unit* /*pDealer*/, uint32& /*uiDamage*/, DamageEffectType /*damagetype*/) override
     {
         // allow him to die the last phase
         if (m_uiHeadPhase >= 3)

--- a/src/scriptdev2/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -106,7 +106,7 @@ struct boss_scarlet_commander_mograineAI : public ScriptedAI
             pWhitemane->Respawn();
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth() || m_bHasDied)
             return;
@@ -258,7 +258,7 @@ struct boss_high_inquisitor_whitemaneAI : public ScriptedAI
         // This needs to be empty because Whitemane should NOT aggro while fighting Mograine. Mograine will give us a target.
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;

--- a/src/scriptdev2/scripts/eastern_kingdoms/shadowfang_keep/shadowfang_keep.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/shadowfang_keep/shadowfang_keep.cpp
@@ -855,7 +855,7 @@ struct npc_deathstalker_vincentAI : public ScriptedAI
             m_creature->SetStandState(UNIT_STAND_STATE_DEAD);
     }
 
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+    void DamageTaken(Unit* pDoneBy, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (pDoneBy)
         {

--- a/src/scriptdev2/scripts/eastern_kingdoms/stormwind_city.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/stormwind_city.cpp
@@ -63,7 +63,7 @@ struct npc_bartlebyAI : public ScriptedAI
         AttackStart(pAttacker);
     }
 
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+    void DamageTaken(Unit* pDoneBy, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage > m_creature->GetHealth() || ((m_creature->GetHealth() - uiDamage) * 100 / m_creature->GetMaxHealth() < 15))
         {
@@ -122,7 +122,7 @@ struct npc_dashel_stonefistAI : public ScriptedAI
         AttackStart(pAttacker);
     }
 
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+    void DamageTaken(Unit* pDoneBy, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage > m_creature->GetHealth() || ((m_creature->GetHealth() - uiDamage) * 100 / m_creature->GetMaxHealth() < 15))
         {

--- a/src/scriptdev2/scripts/eastern_kingdoms/sunwell_plateau/boss_kalecgos.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/sunwell_plateau/boss_kalecgos.cpp
@@ -148,7 +148,7 @@ struct boss_kalecgosAI : public ScriptedAI
             m_pInstance->SetData(TYPE_KALECGOS, IN_PROGRESS);
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage > m_creature->GetHealth())
         {
@@ -359,7 +359,7 @@ struct boss_sathrovarrAI : public ScriptedAI
         m_creature->SummonCreature(NPC_KALECGOS_HUMAN, aKalecHumanLoc[0], aKalecHumanLoc[1], aKalecHumanLoc[2], aKalecHumanLoc[3], TEMPSUMMON_DEAD_DESPAWN, 0, true);
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage > m_creature->GetHealth())
         {

--- a/src/scriptdev2/scripts/eastern_kingdoms/sunwell_plateau/boss_muru.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/sunwell_plateau/boss_muru.cpp
@@ -119,7 +119,7 @@ struct boss_muruAI : public Scripted_NoMovementAI
             m_pInstance->SetData(TYPE_MURU, FAIL);
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage > m_creature->GetHealth())
         {

--- a/src/scriptdev2/scripts/eastern_kingdoms/tirisfal_glades.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/tirisfal_glades.cpp
@@ -110,7 +110,7 @@ struct npc_calvin_montagueAI : public ScriptedAI
         AttackStart(pAttacker);
     }
 
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+    void DamageTaken(Unit* pDoneBy, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage > m_creature->GetHealth() || ((m_creature->GetHealth() - uiDamage) * 100 / m_creature->GetMaxHealth() < 15))
         {

--- a/src/scriptdev2/scripts/eastern_kingdoms/wetlands.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/wetlands.cpp
@@ -126,7 +126,7 @@ struct npc_tapoke_slim_jahnAI : public npc_escortAI, private DialogueHelper
             pSummoned->AI()->AttackStart(pPlayer);
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (!HasEscortState(STATE_ESCORT_ESCORTING))
             return;

--- a/src/scriptdev2/scripts/eastern_kingdoms/zulgurub/boss_thekal.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/zulgurub/boss_thekal.cpp
@@ -71,7 +71,7 @@ struct boss_thekalBaseAI : public ScriptedAI
     virtual void OnFakeingDeath() {}
     virtual void OnRevive() {}
 
-    void DamageTaken(Unit* /*pKiller*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pKiller*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;

--- a/src/scriptdev2/scripts/kalimdor/dustwallow_marsh.cpp
+++ b/src/scriptdev2/scripts/kalimdor/dustwallow_marsh.cpp
@@ -237,7 +237,7 @@ struct npc_morokkAI : public npc_escortAI
         AttackStart(pAttacker);
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (HasEscortState(STATE_ESCORT_ESCORTING))
         {

--- a/src/scriptdev2/scripts/kalimdor/dustwallow_marsh.cpp
+++ b/src/scriptdev2/scripts/kalimdor/dustwallow_marsh.cpp
@@ -73,7 +73,7 @@ struct mobs_risen_husk_spiritAI : public ScriptedAI
             m_pCreditPlayer->RewardPlayerAndGroupAtEvent(pSummoned->GetEntry(), pSummoned);
     }
 
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+    void DamageTaken(Unit* pDoneBy, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;
@@ -640,7 +640,7 @@ struct npc_private_hendelAI : public ScriptedAI
         AttackStart(pAttacker);
     }
 
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+    void DamageTaken(Unit* pDoneBy, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage > m_creature->GetHealth() || m_creature->GetHealthPercent() < 20.0f)
         {

--- a/src/scriptdev2/scripts/kalimdor/ruins_of_ahnqiraj/ruins_of_ahnqiraj.cpp
+++ b/src/scriptdev2/scripts/kalimdor/ruins_of_ahnqiraj/ruins_of_ahnqiraj.cpp
@@ -100,7 +100,7 @@ struct mob_anubisath_guardianAI : public ScriptedAI
         --m_uiSummonCount;
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& /*uiDamage*/) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& /*uiDamage*/, DamageEffectType /*damagetype*/) override
     {
         // when we reach 10% of HP explode or enrage
         if (!m_bIsEnraged && m_creature->GetHealthPercent() < 10.0f)

--- a/src/scriptdev2/scripts/kalimdor/temple_of_ahnqiraj/boss_cthun.cpp
+++ b/src/scriptdev2/scripts/kalimdor/temple_of_ahnqiraj/boss_cthun.cpp
@@ -383,7 +383,7 @@ struct boss_cthunAI : public Scripted_NoMovementAI
         m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
     }
 
-    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         // Ignore damage reduction when vulnerable
         if (m_Phase == PHASE_CTHUN_WEAKENED)

--- a/src/scriptdev2/scripts/kalimdor/temple_of_ahnqiraj/boss_twinemperors.cpp
+++ b/src/scriptdev2/scripts/kalimdor/temple_of_ahnqiraj/boss_twinemperors.cpp
@@ -85,7 +85,7 @@ struct boss_twin_emperorsAI : public ScriptedAI
     }
 
     // Workaround for the shared health pool
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (!m_pInstance)
             return;

--- a/src/scriptdev2/scripts/kalimdor/temple_of_ahnqiraj/boss_viscidus.cpp
+++ b/src/scriptdev2/scripts/kalimdor/temple_of_ahnqiraj/boss_viscidus.cpp
@@ -201,7 +201,7 @@ struct boss_viscidusAI : public ScriptedAI
         }
     }
 
-    void DamageTaken(Unit* pDealer, uint32& uiDamage) override
+    void DamageTaken(Unit* pDealer, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         // apply missing aura: 50% damage reduction;
         uiDamage = uiDamage * 0.5f;

--- a/src/scriptdev2/scripts/kalimdor/the_barrens.cpp
+++ b/src/scriptdev2/scripts/kalimdor/the_barrens.cpp
@@ -591,6 +591,27 @@ CreatureAI* GetAI_npc_wizzlecranks_shredder(Creature* pCreature)
     return new npc_wizzlecranks_shredderAI(pCreature);
 }
 
+struct npc_gallywixAI : public ScriptedAI
+{
+    npc_gallywixAI(Creature* pCreature) : ScriptedAI(pCreature)
+    {
+        Reset();
+    }
+
+    void Reset() override {}
+
+    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage, DamageEffectType /*damagetype*/, SpellEntry const* spellInfo)
+    {
+        if (spellInfo && spellInfo->IsFitToFamilyMask(0x0000000000800200)) // on Ambush
+            uiDamage = (m_creature->GetHealth()*0.5); // Ambush should do 50% health in damage to this creature
+    }
+};
+
+CreatureAI* GetAI_npc_gallywix(Creature* pCreature)
+{
+    return new npc_gallywixAI(pCreature);
+}
+
 void AddSC_the_barrens()
 {
     Script* pNewScript;
@@ -620,5 +641,10 @@ void AddSC_the_barrens()
     pNewScript->Name = "npc_wizzlecranks_shredder";
     pNewScript->GetAI = &GetAI_npc_wizzlecranks_shredder;
     pNewScript->pQuestAcceptNPC = &QuestAccept_npc_wizzlecranks_shredder;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "npc_gallywix";
+    pNewScript->GetAI = &GetAI_npc_gallywix;
     pNewScript->RegisterSelf();
 }

--- a/src/scriptdev2/scripts/outland/black_temple/boss_illidan.cpp
+++ b/src/scriptdev2/scripts/outland/black_temple/boss_illidan.cpp
@@ -427,7 +427,7 @@ struct boss_illidan_stormrageAI : public ScriptedAI, private DialogueHelper
         DoScriptText(urand(0, 1) ? SAY_KILL1 : SAY_KILL2, m_creature);
     }
 
-    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;

--- a/src/scriptdev2/scripts/outland/black_temple/boss_reliquary_of_souls.cpp
+++ b/src/scriptdev2/scripts/outland/black_temple/boss_reliquary_of_souls.cpp
@@ -349,7 +349,7 @@ struct essence_base_AI : public ScriptedAI
         m_creature->ForcedDespawn();
     }
 
-    void DamageTaken(Unit* /*pKiller*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pKiller*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;

--- a/src/scriptdev2/scripts/outland/black_temple/illidari_council.cpp
+++ b/src/scriptdev2/scripts/outland/black_temple/illidari_council.cpp
@@ -334,7 +334,7 @@ struct boss_illidari_councilAI : public ScriptedAI
         }
     }
 
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+    void DamageTaken(Unit* pDoneBy, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         int32 uiDamageTaken = (int32)uiDamage;
         m_creature->CastCustomSpell(m_creature, SPELL_SHARED_RULE_DAM, &uiDamageTaken, nullptr, nullptr, true);

--- a/src/scriptdev2/scripts/outland/coilfang_reservoir/slave_pens/boss_ahune.cpp
+++ b/src/scriptdev2/scripts/outland/coilfang_reservoir/slave_pens/boss_ahune.cpp
@@ -128,7 +128,7 @@ struct boss_ahuneAI : public Scripted_NoMovementAI
         m_creature->ForcedDespawn();
     }
 
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+    void DamageTaken(Unit* pDoneBy, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         // it's not clear whether this should work like this or should be handled by the proc aura
         if (Creature* pCore = m_creature->GetMap()->GetCreature(m_frozenCoreGuid))
@@ -290,7 +290,7 @@ struct npc_frozen_coreAI : public Scripted_NoMovementAI
         DoCastSpellIfCan(m_creature, SPELL_ICE_SPEAR_AURA, CAST_TRIGGERED | CAST_AURA_NOT_PRESENT);
     }
 
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+    void DamageTaken(Unit* pDoneBy, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         // it's not clear whether this should work like this or should be handled by the proc aura
         if (Creature* pAhune = m_creature->GetMap()->GetCreature(m_ahuheGuid))

--- a/src/scriptdev2/scripts/outland/hellfire_citadel/hellfire_ramparts/boss_nazan_and_vazruden.cpp
+++ b/src/scriptdev2/scripts/outland/hellfire_citadel/hellfire_ramparts/boss_nazan_and_vazruden.cpp
@@ -390,7 +390,7 @@ struct boss_vazrudenAI : public ScriptedAI
         DoScriptText(urand(0, 1) ? SAY_KILL1 : SAY_KILL2, m_creature);
     }
 
-    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (!m_bHealthBelow && m_pInstance && (float(m_creature->GetHealth() - uiDamage) / m_creature->GetMaxHealth()) < 0.30f)
         {

--- a/src/scriptdev2/scripts/outland/nagrand.cpp
+++ b/src/scriptdev2/scripts/outland/nagrand.cpp
@@ -76,7 +76,7 @@ struct mob_lumpAI : public ScriptedAI
         AttackStart(pAttacker);
     }
 
-    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (m_creature->GetHealth() < uiDamage || (m_creature->GetHealth() - uiDamage) * 100 / m_creature->GetMaxHealth() < 30)
         {
@@ -445,7 +445,7 @@ struct npc_rethhedronAI : public ScriptedAI
         }
     }
 
-    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDealer*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         // go to epilog at 10% health
         if (!m_bEventFinished && m_creature->GetHealthPercent() < 10.0f)

--- a/src/scriptdev2/scripts/outland/shattrath_city.cpp
+++ b/src/scriptdev2/scripts/outland/shattrath_city.cpp
@@ -185,7 +185,7 @@ struct npc_dirty_larryAI : public ScriptedAI
         AttackStart(pAttacker);
     }
 
-    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;
@@ -568,7 +568,7 @@ struct npc_salsalabimAI : public ScriptedAI
         m_uiMagneticPullTimer = 15000;
     }
 
-    void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+    void DamageTaken(Unit* pDoneBy, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (pDoneBy->GetTypeId() == TYPEID_PLAYER)
         {

--- a/src/scriptdev2/scripts/outland/tempest_keep/the_eye/boss_alar.cpp
+++ b/src/scriptdev2/scripts/outland/tempest_keep/the_eye/boss_alar.cpp
@@ -229,7 +229,7 @@ struct boss_alarAI : public ScriptedAI
         }
     }
 
-    void DamageTaken(Unit* /*pKiller*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pKiller*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         // Only init fake in phase one
         if (m_uiPhase != PHASE_ONE)

--- a/src/scriptdev2/scripts/outland/tempest_keep/the_eye/boss_kaelthas.cpp
+++ b/src/scriptdev2/scripts/outland/tempest_keep/the_eye/boss_kaelthas.cpp
@@ -755,7 +755,7 @@ struct advisor_base_ai : public ScriptedAI
         }
     }
 
-    void DamageTaken(Unit* /*pDoneby*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pDoneby*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         // Allow fake death only in the first phase
         if (!m_bCanFakeDeath)
@@ -1122,7 +1122,7 @@ struct mob_phoenix_tkAI : public ScriptedAI
         ScriptedAI::EnterEvadeMode();
     }
 
-    void DamageTaken(Unit* /*pKiller*/, uint32& uiDamage) override
+    void DamageTaken(Unit* /*pKiller*/, uint32& uiDamage, DamageEffectType /*damagetype*/) override
     {
         if (uiDamage < m_creature->GetHealth())
             return;


### PR DESCRIPTION
Added two parameters to DamageTaken and DamageDealt to enable scripting of special events.

Event A) Shade of Aran must only break drinking on direct damage.
Event B) Gallywix during quest script, must always take 50% of health from Ambushes.

EAI part for testing of q.2478 https://gist.github.com/killerwife/4bf3a68a46796f904e65f659bf81ec7e will be added to tbc-db when PR goes through.

@xfurry @cyberium Please add this as soon as possible :)
