### PR TITLE
Fix showing proper quest giver marks

### DIFF
--- a/src/game/QuestDef.h
+++ b/src/game/QuestDef.h
@@ -101,12 +101,12 @@ enum QuestStatus
 enum __QuestGiverStatus
 {
     DIALOG_STATUS_NONE                     = 0,
-    DIALOG_STATUS_UNAVAILABLE              = 1,
-    DIALOG_STATUS_CHAT                     = 2,
-    DIALOG_STATUS_INCOMPLETE               = 3,
-    DIALOG_STATUS_REWARD_REP               = 4,
-    DIALOG_STATUS_AVAILABLE_REP            = 5,
-    DIALOG_STATUS_AVAILABLE                = 6,
+    DIALOG_STATUS_UNAVAILABLE              = 1,             // Grey Exclamation Mark
+    DIALOG_STATUS_CHAT                     = 2,             // No marker
+    DIALOG_STATUS_INCOMPLETE               = 3,             // Grey Question Mark - quest taken
+    DIALOG_STATUS_REWARD_REP               = 4,             // Blue Question Mark - non-daily repeatable available
+    DIALOG_STATUS_AVAILABLE_REP            = 5,             // Blue Exclamation Mark - daily available
+    DIALOG_STATUS_AVAILABLE                = 6,             // Yellow Exclamation Mark - quest available
     DIALOG_STATUS_REWARD2                  = 7,             // no yellow dot on minimap
     DIALOG_STATUS_REWARD                   = 8,             // yellow dot on minimap
     DIALOG_STATUS_UNDEFINED                = 100            // Used as result for unassigned ScriptCall

--- a/src/game/QuestHandler.cpp
+++ b/src/game/QuestHandler.cpp
@@ -537,9 +537,9 @@ uint32 WorldSession::getDialogStatus(const Player* pPlayer, const Object* questg
         QuestStatus status = pPlayer->GetQuestStatus(quest_id);
 
         if (status == QUEST_STATUS_COMPLETE && !pPlayer->GetQuestRewardStatus(quest_id))
-            dialogStatusNew = pQuest->IsRepeatable() ? DIALOG_STATUS_REWARD_REP : DIALOG_STATUS_REWARD;
+            dialogStatusNew = pQuest->IsRepeatable() && pQuest->IsDailyOrWeekly() ? DIALOG_STATUS_REWARD_REP : DIALOG_STATUS_REWARD;
         else if (pQuest->IsAutoComplete() && pPlayer->CanTakeQuest(pQuest, false))
-            dialogStatusNew = pQuest->IsRepeatable() ? DIALOG_STATUS_AVAILABLE_REP : DIALOG_STATUS_AVAILABLE;
+            dialogStatusNew = pQuest->IsRepeatable() ? pQuest->IsDailyOrWeekly() ? DIALOG_STATUS_AVAILABLE_REP : DIALOG_STATUS_REWARD_REP : DIALOG_STATUS_AVAILABLE;
         else if (status == QUEST_STATUS_INCOMPLETE)
             dialogStatusNew = DIALOG_STATUS_INCOMPLETE;
 
@@ -567,10 +567,7 @@ uint32 WorldSession::getDialogStatus(const Player* pPlayer, const Object* questg
                 {
                     int32 lowLevelDiff = sWorld.getConfig(CONFIG_INT32_QUEST_LOW_LEVEL_HIDE_DIFF);
 
-                    auto questStatusItr = pPlayer->getQuestStatusMap().find(quest_id);
-                    bool rewarded = (questStatusItr != pPlayer->getQuestStatusMap().end()) ? questStatusItr->second.m_rewarded : false;
-
-                    if (pQuest->IsAutoComplete() || (pQuest->IsRepeatable() && rewarded))
+                    if (pQuest->IsAutoComplete())
                     {
                         dialogStatusNew = DIALOG_STATUS_REWARD_REP;
                     }


### PR DESCRIPTION
Previously if a quest giver had non-daily/weekly repeatable quests, a daily exclamation mark was shown above his head. Correct behaviour is to show blue question mark in case of such quests. Example is commendations questgiver in ironforge near middle.

Might need testing/changing(or not apply at all) for classic branch, as there are no daily quests there.
