### PR TITLE
Fix special case of restarting fly path too soon on load

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -14824,6 +14824,7 @@ void Player::_LoadAuras(QueryResult* result, uint32 timediff)
                 if (caster_guid != GetObjectGuid() && holder->GetTrackedAuraType() == TRACK_AURA_TYPE_SINGLE_TARGET)
                     holder->SetTrackedAuraType(TRACK_AURA_TYPE_NOT_TRACKED);
 
+                holder->SetState(SPELLAURAHOLDER_STATE_DB_LOAD); // Safeguard mechanism against some actions
                 AddSpellAuraHolder(holder);
                 DETAIL_LOG("Added auras from spellid %u", spellproto->Id);
             }

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -6715,8 +6715,8 @@ void Aura::HandleAuraSafeFall(bool Apply, bool Real)
     // implemented in WorldSession::HandleMovementOpcodes
 
     // only special case
-    if (Apply && Real && GetId() == 32474 && GetTarget()->GetTypeId() == TYPEID_PLAYER)
-        ((Player*)GetTarget())->ActivateTaxiPathTo(506, GetId());
+    if (Apply && Real && GetId() == 32474 && GetTarget()->GetTypeId() == TYPEID_PLAYER && GetHolder()->GetState() != SPELLAURAHOLDER_STATE_DB_LOAD)
+        ((Player*)GetTarget())->ActivateTaxiPathTo(506, GetId()); // on DB load flight path is initiated on its own after its safe to do so
 }
 
 void Aura::HandleFactionOverride(bool apply, bool Real)

--- a/src/game/SpellAuras.h
+++ b/src/game/SpellAuras.h
@@ -77,7 +77,8 @@ enum SpellAuraHolderState
 {
     SPELLAURAHOLDER_STATE_CREATED       = 0,                // just created, initialization steps
     SPELLAURAHOLDER_STATE_READY         = 1,                // all initialization steps are done
-    SPELLAURAHOLDER_STATE_REMOVING      = 2                 // removing steps
+    SPELLAURAHOLDER_STATE_REMOVING      = 2,                // removing steps
+    SPELLAURAHOLDER_STATE_DB_LOAD       = 3                 // during db load some events must not be executed
 };
 
 class MANGOS_DLL_SPEC SpellAuraHolder


### PR DESCRIPTION
If player is using fly path related to draenei Call of Water, in the rare occasion of a crash happening during the fly path, restart of fly path is done after db load of player, but aura will try to do it before that and can lead to chain crashing on player login.
