### PR TITLE
fixes for drop_db sql

### DIFF
--- a/sql/create/db_drop_mysql.sql
+++ b/sql/create/db_drop_mysql.sql
@@ -1,21 +1,7 @@
-REVOKE ALL PRIVILEGES ON * . * FROM 'mangos'@'localhost';
+DROP USER IF EXISTS 'mangos'@'localhost';
 
-REVOKE ALL PRIVILEGES ON `mangos` . * FROM 'mangos'@'localhost';
+DROP DATABASE IF EXISTS `mangos`;
 
-REVOKE GRANT OPTION ON `mangos` . * FROM 'mangos'@'localhost';
+DROP DATABASE IF EXISTS `characters`;
 
-REVOKE ALL PRIVILEGES ON `characters` . * FROM 'mangos'@'localhost';
-
-REVOKE GRANT OPTION ON `characters` . * FROM 'mangos'@'localhost';
-
-REVOKE ALL PRIVILEGES ON `realmd` . * FROM 'mangos'@'localhost';
-
-REVOKE GRANT OPTION ON `realmd` . * FROM 'mangos'@'localhost';
-
-DELETE FROM `user` WHERE CONVERT( User USING utf8 ) = CONVERT( 'mangos' USING utf8 ) AND CONVERT( Host USING utf8 ) = CONVERT( 'localhost' USING utf8 ) ;
-
-DROP DATABASE IF EXISTS `mangos` ;
-
-DROP DATABASE IF EXISTS `characters` ;
-
-DROP DATABASE IF EXISTS `realmd` ;
+DROP DATABASE IF EXISTS `realmd`;


### PR DESCRIPTION
i was having some issues with mysql errors when running the db_drop_mysql.sql file so i took a look.

revoke all on *.* and revoke grant after revoke all privs don't do anything; dropping the user drops all the grants anyway. drop user if exists only works on mysql 5.7.8 and above, but it was released over a year ago so i figured it was ok.