### PR TITLE
Add visual to script

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -2013,6 +2013,14 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
                     case 43873:                             // Headless Horseman Laugh
                         target->PlayDistanceSound(11965);
                         return;
+                    case 45787:
+                        if (Creature* talbuk = (Creature*)target)
+                        {
+                            talbuk->CastSpell(talbuk, 42386, TRIGGERED_OLD_TRIGGERED);
+                            talbuk->CombatStop();
+                            talbuk->ForcedDespawn(10000);
+                        }
+                        return;
                     case 46637:                             // Break Ice
                         target->CastSpell(target, 46638, TRIGGERED_OLD_TRIGGERED, nullptr, this);
                         return;


### PR DESCRIPTION
('45787','0','101','21','6','1','0','4','0','0','0','1','Talbuk Tag
Sleep'); is already in wotlk DBC

Rest is handled in ACID, fixes an ACID error as well