### PR TITLE
Tempest Keep Update

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -1418,21 +1418,21 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                     uint32 count = 0;
                     for (TargetList::const_iterator ihit = m_UniqueTargetInfo.begin(); ihit != m_UniqueTargetInfo.end(); ++ ihit)
                     {
-                        if (ihit->effectMask & (1 << effect_idx))
+                        if (ihit->effectMask & (1 << eff_idx))
                             ++count;
                     }
                     
                     damage = 11500;
                     damage /= count;
                     
-                    SpellEntry const* spellInfo = sSpellStore.LookupEntry(42784);
+                    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(42784);
                 
                     for (TargetList::const_iterator ihit = m_UniqueTargetInfo.begin(); ihit != m_UniqueTargetInfo.end(); ++ihit)
                     {
-                        if (ihit->effectMask & (1 << effect_idx))
+                        if (ihit->effectMask & (1 << eff_idx))
                         {
-                            if (Unit* pCastTarget = (*unitTarget)->GetMap()->GetUnit((*ihit)->GetUnitGuid()))
-                                m_caster->DealDamage(pCastTarget, damage, SPELL_DIRECT_DAMAGE, SPELL_SCHOOL_MASK_ARCANE, spellInfo, false);
+                            if (Unit* pCastTarget = (*unitTarget)->GetMap()->GetUnit((*ihit).getUnitGuid()))
+                                m_caster->DealDamage(pCastTarget, damage, nullptr, SPELL_DIRECT_DAMAGE, SPELL_SCHOOL_MASK_ARCANE, spellInfo, false);
                         }
                     }
                 }

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -1431,7 +1431,7 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                     {
                         if (ihit->effectMask & (1 << eff_idx))
                         {
-                            if (Unit* pCastTarget = (*unitTarget)->GetMap()->GetUnit((*ihit).getUnitGuid()))
+                            if (Unit* pCastTarget = unitTarget->GetMap()->GetUnit((*ihit).getUnitGuid()))
                                 m_caster->DealDamage(pCastTarget, damage, nullptr, SPELL_DIRECT_DAMAGE, SPELL_SCHOOL_MASK_ARCANE, spellInfo, false);
                         }
                     }

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -1410,6 +1410,32 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                     ((Creature*)unitTarget)->ForcedDespawn(3000);
                     return;
                 }
+                case 42784:                                 // Wrath of the Astromancer AoE Debuff (2.4.3)
+                {
+                    if (!unitTarget || unitTarget->GetTypeId() != TYPEID_PLAYER)
+                        return;
+                
+                    uint32 count = 0;
+                    for (TargetList::const_iterator ihit = m_UniqueTargetInfo.begin(); ihit != m_UniqueTargetInfo.end(); ++ ihit)
+                    {
+                        if (ihit->effectMask & (1 << effect_idx))
+                            ++count;
+                    }
+                    
+                    damage = 11500;
+                    damage /= count;
+                    
+                    SpellEntry const* spellInfo = sSpellStore.LookupEntry(42784);
+                
+                    for (TargetList::const_iterator ihit = m_UniqueTargetInfo.begin(); ihit != m_UniqueTargetInfo.end(); ++ihit)
+                    {
+                        if (ihit->effectMask & (1 << effect_idx))
+                        {
+                            if (Unit* pCastTarget = (*unitTarget)->GetMap()->GetUnit((*ihit)->GetUnitGuid()))
+                                m_caster->DealDamage(pCastTarget, damage, SPELL_DIRECT_DAMAGE, SPELL_SCHOOL_MASK_ARCANE, spellInfo, false);
+                        }
+                    }
+                }
                 case 43096:                                 // Summon All Players
                 {
                     if (!unitTarget || unitTarget->GetTypeId() != TYPEID_PLAYER)

--- a/src/scriptdev2/scripts/outland/tempest_keep/the_eye/boss_astromancer.cpp
+++ b/src/scriptdev2/scripts/outland/tempest_keep/the_eye/boss_astromancer.cpp
@@ -38,12 +38,13 @@ enum
 
     SPELL_ARCANE_MISSILES               = 33031,
     SPELL_WRATH_OF_THE_ASTROMANCER      = 42783,
+    SPELL_WRATH_OF_THE_ASTROMANCER_DOT  = 42784,            // AoE damage on bomb application.
     SPELL_BLINDING_LIGHT                = 33009,
     SPELL_PSYHIC_SCREAM                 = 34322,
     SPELL_SOLARIAN_TRANSFORM            = 39117,
     SPELL_VOID_BOLT                     = 39329,
     SPELL_MARK_OF_SOLARIAN              = 33023,            // acts as an enrage spell
-    // SPELL_ROTATE_ASTROMANCER          = 33283,           // purpose unk
+    // SPELL_ROTATE_ASTROMANCER         = 33283,            // purpose unk
 
     // summoned creatures
     NPC_SOLARIUM_AGENT                  = 18925,
@@ -109,7 +110,7 @@ struct boss_high_astromancer_solarianAI : public ScriptedAI
     {
         m_uiArcaneMissilesTimer        = 0;
         m_uiWrathOfTheAstromancerTimer = urand(15000, 25000);
-        m_uiBlindingLightTimer         = 35000;
+        m_uiBlindingLightTimer         = 20000;
         m_uiFearTimer                  = 20000;
         m_uiVoidBoltTimer              = 10000;
         m_uiSplitTimer                 = 50000;
@@ -263,7 +264,7 @@ struct boss_high_astromancer_solarianAI : public ScriptedAI
                     if (Unit* pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 1, SPELL_WRATH_OF_THE_ASTROMANCER, SELECT_FLAG_PLAYER))
                     {
                         if (DoCastSpellIfCan(pTarget, SPELL_WRATH_OF_THE_ASTROMANCER) == CAST_OK)
-                            m_uiWrathOfTheAstromancerTimer = urand(15000, 25000);
+                            m_uiWrathOfTheAstromancerTimer = urand(20000, 25000);
                     }
                     else
                         m_uiWrathOfTheAstromancerTimer = 10000;
@@ -275,8 +276,8 @@ struct boss_high_astromancer_solarianAI : public ScriptedAI
                 if (m_uiBlindingLightTimer < uiDiff)
                 {
                     // She casts this spell every 45 seconds. It is a kind of Moonfire spell, which she strikes down on the whole raid simultaneously. It hits everyone in the raid for 2280 to 2520 arcane damage.
-                    if (DoCastSpellIfCan(m_creature, SPELL_BLINDING_LIGHT) == CAST_OK)
-                        m_uiBlindingLightTimer = 45000;
+                    if (DoCastSpellIfCan(m_creature, SPELL_BLINDING_LIGHT) == CAST_OK && DoCastSpellIfCan(m_creature, SPELL_MARK_OF_SOLARIAN) == CAST_OK)
+                        m_uiBlindingLightTimer = 20000;
                 }
                 else
                     m_uiBlindingLightTimer -= uiDiff;
@@ -302,8 +303,6 @@ struct boss_high_astromancer_solarianAI : public ScriptedAI
                 // Phase 1 Timer
                 if (m_uiSplitTimer < uiDiff)
                 {
-                    // ToDo: the timer of this ability is around 45-50 seconds. Please check if this is correct!
-                    DoCastSpellIfCan(m_creature, SPELL_MARK_OF_SOLARIAN, CAST_INTERRUPT_PREVIOUS);
                     m_Phase = PHASE_SPLIT;
 
                     // After these 50 seconds she portals to the middle of the room and disappears, leaving 3 light portals behind.
@@ -324,7 +323,6 @@ struct boss_high_astromancer_solarianAI : public ScriptedAI
                 break;
 
             case PHASE_SPLIT:
-
                 // Summon 4 Agents on each portal
                 if (m_uiSummonAgentsTimer)
                 {
@@ -370,8 +368,8 @@ struct boss_high_astromancer_solarianAI : public ScriptedAI
                         m_creature->SetVisibility(VISIBILITY_ON);
                         m_uiArcaneMissilesTimer        = 0;
                         m_uiSummonPriestsTimer         = 0;
-                        m_uiBlindingLightTimer         = 35000;
-                        m_uiWrathOfTheAstromancerTimer = urand(15000, 25000);
+                        m_uiBlindingLightTimer         = 20000;
+                        m_uiWrathOfTheAstromancerTimer = urand(20000, 25000);
                     }
                     else
                         m_uiSummonPriestsTimer -= uiDiff;

--- a/src/scriptdev2/scripts/outland/tempest_keep/the_eye/boss_void_reaver.cpp
+++ b/src/scriptdev2/scripts/outland/tempest_keep/the_eye/boss_void_reaver.cpp
@@ -16,8 +16,8 @@
 
 /* ScriptData
 SDName: Boss_Void_Reaver
-SD%Complete: 95
-SDComment: Small adjustments may be required
+SD%Complete: 100
+SDComment:
 SDCategory: Tempest Keep, The Eye
 EndScriptData */
 
@@ -59,7 +59,7 @@ struct boss_void_reaverAI : public ScriptedAI
 
     void Reset() override
     {
-        m_uiPoundingTimer   = 13000;
+        m_uiPoundingTimer   = 12000;
         m_uiArcaneOrbTimer  = 3000;
         m_uiKnockAwayTimer  = 30000;
         m_uiBerserkTimer    = 10 * MINUTE * IN_MILLISECONDS;
@@ -140,7 +140,12 @@ struct boss_void_reaverAI : public ScriptedAI
             }
 
             if (suitableTargets.empty())
-                m_uiArcaneOrbTimer = 3000;
+            {
+                if (Unit* pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0))
+                {
+                    m_creature->SummonCreature(NPC_ARCANE_ORB_TARGET, pTarget->GetPositionX(), pTarget->GetPositionY(), pTarget->GetPositionZ(), 0, TEMPSUMMON_CORPSE_DESPAWN, 0);
+                    m_uiArcaneOrbTimer = 3000;
+                }
             else
             {
                 Unit* pTarget = suitableTargets[urand(0, suitableTargets.size() - 1)];


### PR DESCRIPTION
## Updates for Al'ar, Solarian and Void Reaver.

## Al'ar:
### - Movement has been improved, has the chance to do one of 3 things:
1. Stay at the current platform and summon an ember.
2. Move to the next platform and summon an ember.
3. Move to the middle of the room and Flame Quill.

### - Updated the threat system to do the following:
1. Check first if there are any melee in range.
2. If no melee are in range, target the person at range with the highest threat.
3. Use Flame Buffet if they are out of range for auto attack.

## Void Reaver:
- Fixed a bug where he **wouldn't** use Arcane Orb if everyone is within 18 yards.

## High Astromancer Solarian:
- Implemented the AoE arcane damage for Wrath of the Astromancer.
- Made it so that she does Mark of Solarian on every Blinding Light.
- Fixed Timers.