### PR TITLE
Implement variable length dbscript string logic

### DIFF
--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -153,7 +153,7 @@ For all ACTION_T_RANDOM Actions, When a Particular Param is selected for the Eve
 45   ACTION_T_THROW_AI_EVENT                EventType, Radius               Throws an AIEvent of type (Param1) to nearby friendly Npcs in range of (Param2)
 46   ACTION_T_SET_THROW_MASK                EventTypeMask                   Marks for which AIEvents the npc will throw AIEvents on its own.
 47   ACTION_T_SET_STAND_STATE               StandState                      Set the unit stand state (Param1) of the current creature.
-48   ACTION_T_CHANGE_MOVEMENT               MovementType, WanderDistance    Change the unit movement type (Param1). If the movement type is Random Movement (1), the WanderDistance (Param2) must be provided.
+48   ACTION_T_CHANGE_MOVEMENT               MovementType, WanderDistance    Change the unit movement type (Param1). If the movement type is Random Movement (1), the WanderDistance (Param2) must be provided. If the movement type is Waypoint Movement (2), Param2 is PathId.
 49   ACTION_T_DYNAMIC_MOVEMENT              EnableDynamicMovement           Enable dynamic movement behavior (1 = on; 0 = off)
 50   ACTION_T_SET_REACT_STATE               ReactState                      Change react state of the creature
 

--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -948,6 +948,7 @@ Target types are used by certain actions and may effect actions differently
 8    TARGET_T_HOSTILE_RANDOM_PLAYER          Random Player on The Threat List
 9    TARGET_T_HOSTILE_RANDOM_NOT_TOP_PLAYER  Any Random Player Except Top Threat
 10   TARGET_T_EVENT_SENDER              Creature who sent a received AIEvent - only triggered by EVENT_T_RECEIVE_AI_EVENT
+11   TARGET_T_SUMMONER                  Summoner of given Unit if it has one
 
 =========================================
 Cast Flags

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -236,7 +236,7 @@ Where "A  ->  B" means that the command is executed from A with B as target.
 
 20 SCRIPT_COMMAND_MOVEMENT                  resultingSource = Creature
                                             * datalong = MovementType (0:idle, 1:random or 2:waypoint)
-                                            * datalong2 = wanderDistance (for random movement)
+                                            * datalong2 = wanderDistance (for random movement), pathId (for waypoint movement)
                                             * data_flags & SCRIPT_FLAG_COMMAND_ADDITIONAL: RandomMovement around current position
 
 21 SCRIPT_COMMAND_SET_ACTIVEOBJECT          resultingSource = Creature

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -35,7 +35,7 @@ The action to execute.
 ## datalong
 -- --------------------------
 
-2 multipurpose fields, store raw data as unsigned values
+3 multipurpose fields, store raw data as unsigned values
 
 -- --------------------------
 ## buddy_entry
@@ -153,6 +153,7 @@ Where "A  ->  B" means that the command is executed from A with B as target.
 -- --------------------------
 
  0 SCRIPT_COMMAND_TALK                      resultingSource = WorldObject, resultingTarget = Unit/none
+                                            * datalong = dbscript_string_template ID - will randomize between all db_script_strings in given template
                                             * dataint = text entry from db_script_string -table. dataint2-dataint4 optionally, for random selection of text
 
  1 SCRIPT_COMMAND_EMOTE                     resultingSource = Unit, resultingTarget = Unit/none

--- a/sql/updates/mangos/03PathId.sql
+++ b/sql/updates/mangos/03PathId.sql
@@ -1,0 +1,3 @@
+ALTER TABLE creature_movement_template ADD pathId int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Path ID for entry' AFTER entry, DROP PRIMARY KEY, ADD PRIMARY KEY (entry, pathId, point);
+
+

--- a/sql/updates/mangos/variableLengthDbscriptString.sql
+++ b/sql/updates/mangos/variableLengthDbscriptString.sql
@@ -1,0 +1,30 @@
+DROP TABLE IF EXISTS `dbscript_string_template`;
+CREATE TABLE `dbscript_string_template` (
+  `id` int(11) unsigned NOT NULL COMMENT 'Id of template' AUTO_INCREMENT,
+  `string_id` int(11) NOT NULL DEFAULT '0' COMMENT 'db_script_string id',
+  PRIMARY KEY (`id`,`string_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPACT COMMENT='DBScript system';
+
+ALTER TABLE dbscripts_on_creature_death ADD COLUMN datalong3 INT(11) UNSIGNED NOT NULL DEFAULT '0' AFTER datalong2;
+ALTER TABLE dbscripts_on_creature_movement ADD COLUMN datalong3 INT(11) UNSIGNED NOT NULL DEFAULT '0' AFTER datalong2;
+ALTER TABLE dbscripts_on_event ADD COLUMN datalong3 INT(11) UNSIGNED NOT NULL DEFAULT '0' AFTER datalong2;
+ALTER TABLE dbscripts_on_go_template_use ADD COLUMN datalong3 INT(11) UNSIGNED NOT NULL DEFAULT '0' AFTER datalong2;
+ALTER TABLE dbscripts_on_go_use ADD COLUMN datalong3 INT(11) UNSIGNED NOT NULL DEFAULT '0' AFTER datalong2;
+ALTER TABLE dbscripts_on_gossip ADD COLUMN datalong3 INT(11) UNSIGNED NOT NULL DEFAULT '0' AFTER datalong2;
+ALTER TABLE dbscripts_on_promo_code_use ADD COLUMN datalong3 INT(11) UNSIGNED NOT NULL DEFAULT '0' AFTER datalong2;
+ALTER TABLE dbscripts_on_quest_end ADD COLUMN datalong3 INT(11) UNSIGNED NOT NULL DEFAULT '0' AFTER datalong2;
+ALTER TABLE dbscripts_on_quest_start ADD COLUMN datalong3 INT(11) UNSIGNED NOT NULL DEFAULT '0' AFTER datalong2;
+ALTER TABLE dbscripts_on_spell ADD COLUMN datalong3 INT(11) UNSIGNED NOT NULL DEFAULT '0' AFTER datalong2;
+
+UPDATE dbscripts_on_creature_death SET datalong=0 WHERE command=0;
+UPDATE dbscripts_on_creature_movement SET datalong=0 WHERE command=0;
+UPDATE dbscripts_on_event SET datalong=0 WHERE command=0;
+UPDATE dbscripts_on_go_template_use SET datalong=0 WHERE command=0;
+UPDATE dbscripts_on_go_use SET datalong=0 WHERE command=0;
+UPDATE dbscripts_on_gossip SET datalong=0 WHERE command=0;
+UPDATE dbscripts_on_promo_code_use SET datalong=0 WHERE command=0;
+UPDATE dbscripts_on_quest_end SET datalong=0 WHERE command=0;
+UPDATE dbscripts_on_quest_start SET datalong=0 WHERE command=0;
+UPDATE dbscripts_on_spell SET datalong=0 WHERE command=0;
+
+

--- a/src/game/AI/CreatureEventAI.cpp
+++ b/src/game/AI/CreatureEventAI.cpp
@@ -1044,10 +1044,10 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                     m_creature->GetMotionMaster()->MoveIdle();
                     break;
                 case RANDOM_MOTION_TYPE:
-                    m_creature->GetMotionMaster()->MoveRandomAroundPoint(m_creature->GetPositionX(), m_creature->GetPositionY(), m_creature->GetPositionZ(), float(action.changeMovement.wanderDistance));
+                    m_creature->GetMotionMaster()->MoveRandomAroundPoint(m_creature->GetPositionX(), m_creature->GetPositionY(), m_creature->GetPositionZ(), float(action.changeMovement.wanderORpathID));
                     break;
                 case WAYPOINT_MOTION_TYPE:
-                    m_creature->GetMotionMaster()->MoveWaypoint();
+                    m_creature->GetMotionMaster()->MoveWaypoint(action.changeMovement.wanderORpathID);
                     break;
             }
             break;

--- a/src/game/AI/CreatureEventAI.h
+++ b/src/game/AI/CreatureEventAI.h
@@ -123,7 +123,7 @@ enum EventAI_ActionType
     ACTION_T_THROW_AI_EVENT             = 45,               // EventType, Radius, unused
     ACTION_T_SET_THROW_MASK             = 46,               // EventTypeMask, unused, unused
     ACTION_T_SET_STAND_STATE            = 47,               // StandState, unused, unused
-    ACTION_T_CHANGE_MOVEMENT            = 48,               // MovementType, WanderDistance, unused
+    ACTION_T_CHANGE_MOVEMENT            = 48,               // MovementType, WanderDistance if Movement Type 1 and PathId if Movement Type 2, unused
     ACTION_T_DYNAMIC_MOVEMENT           = 49,               // EnableDynamicMovement (1 = on; 0 = off)
     ACTION_T_SET_REACT_STATE            = 50,               // React state, unused, unused
 
@@ -421,7 +421,7 @@ struct CreatureEventAI_Action
         struct
         {
             uint32 movementType;
-            uint32 wanderDistance;
+            uint32 wanderORpathID;
             uint32 unused1;
         } changeMovement;
         // ACTION_T_DYNAMIC_MOVEMENT                        = 49

--- a/src/game/Level2.cpp
+++ b/src/game/Level2.cpp
@@ -2646,7 +2646,7 @@ bool ChatHandler::HandleWpAddCommand(char* args)
 
     Creature* targetCreature = getSelectedCreature();
     WaypointPathOrigin wpDestination = PATH_NO_PATH;        ///< into which storage
-    int32 wpPathId = 0;                                     ///< along which path
+    uint32 wpPathId = 0;                                    ///< along which path
     uint32 wpPointId = 0;                                   ///< pointId if a waypoint was selected, in this case insert after
     Creature* wpOwner;
 
@@ -2714,7 +2714,7 @@ bool ChatHandler::HandleWpAddCommand(char* args)
 
     if (wpDestination == PATH_NO_PATH)                      // No Waypoint selected, parse additional params
     {
-        if (ExtractOptInt32(&args, wpPathId, 0))            // Fill path-id and source
+        if (ExtractOptUInt32(&args, wpPathId, 0))            // Fill path-id and source
         {
             uint32 src = (uint32)PATH_NO_PATH;
             if (ExtractOptUInt32(&args, src, src))
@@ -2752,7 +2752,7 @@ bool ChatHandler::HandleWpAddCommand(char* args)
 
     float x, y, z;
     m_session->GetPlayer()->GetPosition(x, y, z);
-    if (!sWaypointMgr.AddNode(wpOwner->GetEntry(), wpOwner->GetGUIDLow(), wpPointId, wpDestination, x, y, z))
+    if (!sWaypointMgr.AddNode(wpOwner->GetEntry(), wpOwner->GetGUIDLow(), wpPathId, wpPointId, wpDestination, x, y, z, m_session->GetPlayer()->GetOrientation()))
     {
         PSendSysMessage(LANG_WAYPOINT_NOTCREATED, wpPointId, wpOwner->GetGuidStr().c_str(), wpPathId, WaypointManager::GetOriginString(wpDestination).c_str());
         SetSentErrorMessage(true);
@@ -2841,7 +2841,7 @@ bool ChatHandler::HandleWpModifyCommand(char* args)
     Creature* wpOwner;                                      // Who moves along the waypoint
     uint32 wpId = 0;
     WaypointPathOrigin wpSource = PATH_NO_PATH;
-    int32 wpPathId = 0;
+    uint32 wpPathId = 0;
 
     if (targetCreature)
     {
@@ -3047,14 +3047,14 @@ bool ChatHandler::HandleWpShowCommand(char* args)
     std::string subCmd = subCmd_str;                        ///< info, on, off, first, last
 
     uint32 dbGuid = 0;
-    int32 wpPathId = 0;
+    uint32 wpPathId = 0;
     WaypointPathOrigin wpOrigin = PATH_NO_PATH;
 
     // User selected an npc?
     Creature* targetCreature = getSelectedCreature();
     if (targetCreature)
     {
-        if (ExtractOptInt32(&args, wpPathId, 0))            // Fill path-id and source
+        if (ExtractOptUInt32(&args, wpPathId, 0))            // Fill path-id and source
         {
             uint32 src;
             if (ExtractOptUInt32(&args, src, (uint32)PATH_NO_PATH))
@@ -3066,7 +3066,7 @@ bool ChatHandler::HandleWpShowCommand(char* args)
         if (!ExtractUInt32(&args, dbGuid))                  // No creature selected and no dbGuid provided
             return false;
 
-        if (ExtractOptInt32(&args, wpPathId, 0))            // Fill path-id and source
+        if (ExtractOptUInt32(&args, wpPathId, 0))            // Fill path-id and source
         {
             uint32 src = (uint32)PATH_NO_PATH;
             if (ExtractOptUInt32(&args, src, src))
@@ -3244,7 +3244,7 @@ bool ChatHandler::HandleWpExportCommand(char* args)
 
     Creature* wpOwner;
     WaypointPathOrigin wpOrigin = PATH_NO_PATH;
-    int32 wpPathId = 0;
+    uint32 wpPathId = 0;
 
     if (Creature* targetCreature = getSelectedCreature())
     {
@@ -3318,7 +3318,7 @@ bool ChatHandler::HandleWpExportCommand(char* args)
 
     if (wpOrigin == PATH_NO_PATH)                           // No WP selected, Extract optional arguments
     {
-        if (ExtractOptInt32(&args, wpPathId, 0))            // Fill path-id and source
+        if (ExtractOptUInt32(&args, wpPathId, 0))            // Fill path-id and source
         {
             uint32 src = (uint32)PATH_NO_PATH;
             if (ExtractOptUInt32(&args, src, src))

--- a/src/game/MotionMaster.cpp
+++ b/src/game/MotionMaster.cpp
@@ -57,7 +57,7 @@ void MotionMaster::Initialize()
         push(movement == nullptr ? &si_idleMovement : movement);
         top()->Initialize(*m_owner);
         if (top()->GetMovementGeneratorType() == WAYPOINT_MOTION_TYPE)
-            (static_cast<WaypointMovementGenerator<Creature>*>(top()))->InitializeWaypointPath(*((Creature*)(m_owner)), 0, PATH_NO_PATH, 0, 0);
+            (static_cast<WaypointMovementGenerator<Creature>*>(top()))->InitializeWaypointPath(*((Creature*)(m_owner)), m_defaultPathId, PATH_NO_PATH, 0, 0);
     }
     else
         push(&si_idleMovement);
@@ -373,7 +373,7 @@ void MotionMaster::MoveFleeing(Unit* enemy, uint32 time)
     }
 }
 
-void MotionMaster::MoveWaypoint(int32 id /*=0*/, uint32 source /*=0==PATH_NO_PATH*/, uint32 initialDelay /*=0*/, uint32 overwriteEntry /*=0*/)
+void MotionMaster::MoveWaypoint(uint32 pathId /*=0*/, uint32 source /*=0==PATH_NO_PATH*/, uint32 initialDelay /*=0*/, uint32 overwriteEntry /*=0*/)
 {
     if (m_owner->GetTypeId() == TYPEID_UNIT)
     {
@@ -388,7 +388,7 @@ void MotionMaster::MoveWaypoint(int32 id /*=0*/, uint32 source /*=0==PATH_NO_PAT
         DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s start MoveWaypoint()", m_owner->GetGuidStr().c_str());
         WaypointMovementGenerator<Creature>* newWPMMgen = new WaypointMovementGenerator<Creature>(*creature);
         Mutate(newWPMMgen);
-        newWPMMgen->InitializeWaypointPath(*creature, id, (WaypointPathOrigin)source, initialDelay, overwriteEntry);
+        newWPMMgen->InitializeWaypointPath(*creature, pathId, (WaypointPathOrigin)source, initialDelay, overwriteEntry);
     }
     else
     {

--- a/src/game/MotionMaster.h
+++ b/src/game/MotionMaster.h
@@ -69,7 +69,7 @@ class MANGOS_DLL_SPEC MotionMaster : private std::stack<MovementGenerator*>
         typedef std::vector<MovementGenerator*> ExpireList;
 
     public:
-        explicit MotionMaster(Unit* unit) : m_owner(unit), m_expList(nullptr), m_cleanFlag(MMCF_NONE) {}
+        explicit MotionMaster(Unit* unit) : m_owner(unit), m_expList(nullptr), m_cleanFlag(MMCF_NONE), m_defaultPathId(0) {}
         ~MotionMaster();
 
         void Initialize();
@@ -109,7 +109,7 @@ class MANGOS_DLL_SPEC MotionMaster : private std::stack<MovementGenerator*>
         void MovePoint(uint32 id, float x, float y, float z, bool generatePath = true);
         void MoveSeekAssistance(float x, float y, float z);
         void MoveSeekAssistanceDistract(uint32 timer);
-        void MoveWaypoint(int32 id = 0, uint32 source = 0, uint32 initialDelay = 0, uint32 overwriteEntry = 0);
+        void MoveWaypoint(uint32 pathId = 0, uint32 source = 0, uint32 initialDelay = 0, uint32 overwriteEntry = 0);
         void MoveTaxiFlight(uint32 path, uint32 pathnode);
         void MoveDistract(uint32 timeLimit);
         void MoveFall();
@@ -124,6 +124,8 @@ class MANGOS_DLL_SPEC MotionMaster : private std::stack<MovementGenerator*>
         void GetWaypointPathInformation(std::ostringstream& oss) const;
         bool GetDestination(float& x, float& y, float& z) const;
 
+        void SetPathId(uint32 pathId) { m_defaultPathId = pathId; }
+
     private:
         void Mutate(MovementGenerator* m);                  // use Move* functions instead
 
@@ -136,5 +138,7 @@ class MANGOS_DLL_SPEC MotionMaster : private std::stack<MovementGenerator*>
         Unit*       m_owner;
         ExpireList* m_expList;
         uint8       m_cleanFlag;
+
+        uint32      m_defaultPathId;
 };
 #endif

--- a/src/game/Object.cpp
+++ b/src/game/Object.cpp
@@ -1608,7 +1608,7 @@ void WorldObject::AddObjectToRemoveList()
     GetMap()->AddObjectToRemoveList(this);
 }
 
-Creature* WorldObject::SummonCreature(uint32 id, float x, float y, float z, float ang, TempSummonType spwtype, uint32 despwtime, bool asActiveObject, bool setRun)
+Creature* WorldObject::SummonCreature(uint32 id, float x, float y, float z, float ang, TempSummonType spwtype, uint32 despwtime, bool asActiveObject, bool setRun, uint32 pathId)
 {
     CreatureInfo const* cinfo = ObjectMgr::GetCreatureTemplate(id);
     if (!cinfo)
@@ -1641,6 +1641,8 @@ Creature* WorldObject::SummonCreature(uint32 id, float x, float y, float z, floa
 
     // Active state set before added to map
     pCreature->SetActiveObjectState(asActiveObject);
+
+    pCreature->GetMotionMaster()->SetPathId(pathId);
 
     pCreature->Summon(spwtype, despwtime);                  // Also initializes the AI and MMGen
 

--- a/src/game/Object.h
+++ b/src/game/Object.h
@@ -608,7 +608,7 @@ class MANGOS_DLL_SPEC WorldObject : public Object
         void RemoveFromClientUpdateList() override;
         void BuildUpdateData(UpdateDataMapType&) override;
 
-        Creature* SummonCreature(uint32 id, float x, float y, float z, float ang, TempSummonType spwtype, uint32 despwtime, bool asActiveObject = false, bool setRun = false);
+        Creature* SummonCreature(uint32 id, float x, float y, float z, float ang, TempSummonType spwtype, uint32 despwtime, bool asActiveObject = false, bool setRun = false, uint32 pathId = 0);
 
         bool isActiveObject() const { return m_isActiveObject || m_viewPoint.hasViewers(); }
         void SetActiveObjectState(bool active);

--- a/src/game/ScriptMgr.cpp
+++ b/src/game/ScriptMgr.cpp
@@ -890,13 +890,14 @@ void ScriptMgr::LoadCreatureDeathScripts()
 void ScriptMgr::LoadDbScriptStrings()
 {
     sObjectMgr.LoadMangosStrings(WorldDatabase, "db_script_string", MIN_DB_SCRIPT_STRING_ID, MAX_DB_SCRIPT_STRING_ID, true);
-    LoadDbScriptStringTemplates();
 
     std::set<int32> ids;
 
     for (int32 i = MIN_DB_SCRIPT_STRING_ID; i < MAX_DB_SCRIPT_STRING_ID; ++i)
         if (sObjectMgr.GetMangosStringLocale(i))
             ids.insert(i);
+
+    LoadDbScriptStringTemplates(ids);
 
     CheckScriptTexts(sQuestEndScripts, ids);
     CheckScriptTexts(sQuestStartScripts, ids);
@@ -914,7 +915,7 @@ void ScriptMgr::LoadDbScriptStrings()
         sLog.outErrorDb("Table `db_script_string` has unused string id %u", *itr);
 }
 
-void ScriptMgr::LoadDbScriptStringTemplates()
+void ScriptMgr::LoadDbScriptStringTemplates(std::set<int32>& ids)
 {
     sLog.outString("Loading script string templates");
 
@@ -929,6 +930,9 @@ void ScriptMgr::LoadDbScriptStringTemplates()
             uint32 id = fields[0].GetUInt32();
             int32 stringId = fields[1].GetInt32();
             m_stringTemplates[id].push_back(stringId);
+
+            if (ids.find(stringId) != ids.end())
+                ids.erase(stringId);
         }
         while (result->NextRow());
 

--- a/src/game/ScriptMgr.cpp
+++ b/src/game/ScriptMgr.cpp
@@ -1480,7 +1480,7 @@ bool ScriptAction::HandleScriptStep()
             float z = m_script->z;
             float o = m_script->o;
 
-            Creature* pCreature = pSource->SummonCreature(m_script->summonCreature.creatureEntry, x, y, z, o, m_script->summonCreature.despawnDelay ? TEMPSUMMON_TIMED_OOC_OR_DEAD_DESPAWN : TEMPSUMMON_DEAD_DESPAWN, m_script->summonCreature.despawnDelay, (m_script->data_flags & SCRIPT_FLAG_COMMAND_ADDITIONAL) ? true : false, m_script->textId[0] == 1);
+            Creature* pCreature = pSource->SummonCreature(m_script->summonCreature.creatureEntry, x, y, z, o, m_script->summonCreature.despawnDelay ? TEMPSUMMON_TIMED_OOC_OR_DEAD_DESPAWN : TEMPSUMMON_DEAD_DESPAWN, m_script->summonCreature.despawnDelay, (m_script->data_flags & SCRIPT_FLAG_COMMAND_ADDITIONAL) ? true : false, m_script->textId[0] == 1, m_script->summonCreature.pathId);
             if (!pCreature)
             {
                 sLog.outErrorDb(" DB-SCRIPTS: Process table `%s` id %u, command %u failed for creature (entry: %u).", m_table, m_script->id, m_script->command, m_script->summonCreature.creatureEntry);
@@ -1658,17 +1658,17 @@ bool ScriptAction::HandleScriptStep()
                     break;
                 case RANDOM_MOTION_TYPE:
                     if (m_script->data_flags & SCRIPT_FLAG_COMMAND_ADDITIONAL)
-                        ((Creature*)pSource)->GetMotionMaster()->MoveRandomAroundPoint(pSource->GetPositionX(), pSource->GetPositionY(), pSource->GetPositionZ(), float(m_script->movement.wanderDistance));
+                        ((Creature*)pSource)->GetMotionMaster()->MoveRandomAroundPoint(pSource->GetPositionX(), pSource->GetPositionY(), pSource->GetPositionZ(), float(m_script->movement.wanderORpathId));
                     else
                     {
                         float respX, respY, respZ, respO, wander_distance;
                         ((Creature*)pSource)->GetRespawnCoord(respX, respY, respZ, &respO, &wander_distance);
-                        wander_distance = m_script->movement.wanderDistance ? m_script->movement.wanderDistance : wander_distance;
+                        wander_distance = m_script->movement.wanderORpathId ? m_script->movement.wanderORpathId : wander_distance;
                         ((Creature*)pSource)->GetMotionMaster()->MoveRandomAroundPoint(respX, respY, respZ, wander_distance);
                     }
                     break;
                 case WAYPOINT_MOTION_TYPE:
-                    ((Creature*)pSource)->GetMotionMaster()->MoveWaypoint();
+                    ((Creature*)pSource)->GetMotionMaster()->MoveWaypoint(m_script->movement.wanderORpathId);
                     break;
             }
 
@@ -2656,7 +2656,7 @@ void SetExternalWaypointTable(char const* tableName)
     sWaypointMgr.SetExternalWPTable(tableName);
 }
 
-bool AddWaypointFromExternal(uint32 entry, int32 pathId, uint32 pointId, float x, float y, float z, float o, uint32 waittime)
+bool AddWaypointFromExternal(uint32 entry, uint32 pathId, uint32 pointId, float x, float y, float z, float o, uint32 waittime)
 {
     return sWaypointMgr.AddExternalNode(entry, pathId, pointId, x, y, z, o, waittime);
 }

--- a/src/game/ScriptMgr.cpp
+++ b/src/game/ScriptMgr.cpp
@@ -1577,8 +1577,7 @@ bool ScriptAction::HandleScriptStep()
             if (LogIfNotUnit(pSource))
                 break;
 
-            uint32 castFlags = (m_script->data_flags & SCRIPT_FLAG_COMMAND_ADDITIONAL ? TRIGGERED_OLD_TRIGGERED : TRIGGERED_NONE); // TODO: Figure out nice support for other flags using some column
-            ((Unit*)pSource)->CastSpell(((Unit*)pTarget), spell, castFlags);
+            ((Unit*)pSource)->CastSpell(((Unit*)pTarget), spell, m_script->castSpell.castFlags);
 
             break;
         }

--- a/src/game/ScriptMgr.h
+++ b/src/game/ScriptMgr.h
@@ -219,6 +219,7 @@ struct ScriptInfo
         {
             uint32 creatureEntry;                           // datalong
             uint32 despawnDelay;                            // datalong2
+            uint32 pathId;                                  // datalong3
         } summonCreature;
 
         // datalong unused                                  // SCRIPT_COMMAND_OPEN_DOOR (11)
@@ -274,7 +275,7 @@ struct ScriptInfo
         struct                                              // SCRIPT_COMMAND_MOVEMENT (20)
         {
             uint32 movementType;                            // datalong
-            uint32 wanderDistance;                          // datalong2
+            uint32 wanderORpathId;                          // datalong2
         } movement;
 
         struct                                              // SCRIPT_COMMAND_SET_ACTIVEOBJECT (21)
@@ -668,6 +669,6 @@ MANGOS_DLL_SPEC uint32 GetScriptId(const char* name);
 MANGOS_DLL_SPEC char const* GetScriptName(uint32 id);
 MANGOS_DLL_SPEC uint32 GetScriptIdsCount();
 MANGOS_DLL_SPEC void SetExternalWaypointTable(char const* tableName);
-MANGOS_DLL_SPEC bool AddWaypointFromExternal(uint32 entry, int32 pathId, uint32 pointId, float x, float y, float z, float o, uint32 waittime);
+MANGOS_DLL_SPEC bool AddWaypointFromExternal(uint32 entry, uint32 pathId, uint32 pointId, float x, float y, float z, float o, uint32 waittime);
 
 #endif

--- a/src/game/ScriptMgr.h
+++ b/src/game/ScriptMgr.h
@@ -551,7 +551,7 @@ class ScriptMgr
         void LoadCreatureMovementScripts();
 
         void LoadDbScriptStrings();
-        void LoadDbScriptStringTemplates();
+        void LoadDbScriptStringTemplates(std::set<int32>& ids);
 
         void LoadScriptNames();
         void LoadAreaTriggerScripts();

--- a/src/game/ScriptMgr.h
+++ b/src/game/ScriptMgr.h
@@ -155,7 +155,11 @@ struct ScriptInfo
 
     union
     {
-        // datalong unused                                  // SCRIPT_COMMAND_TALK (0)
+        struct                                              // SCRIPT_COMMAND_TALK (0)
+        {
+            uint32 stringTemplateId;                        // datalong
+            uint32 empty1;                                  // datalong2
+        } talk;
 
         struct                                              // SCRIPT_COMMAND_EMOTE (1)
         {
@@ -397,7 +401,7 @@ struct ScriptInfo
 
         struct
         {
-            uint32 data[2];
+            uint32 data[3];
         } raw;
     };
 
@@ -547,6 +551,7 @@ class ScriptMgr
         void LoadCreatureMovementScripts();
 
         void LoadDbScriptStrings();
+        void LoadDbScriptStringTemplates();
 
         void LoadScriptNames();
         void LoadAreaTriggerScripts();
@@ -558,6 +563,9 @@ class ScriptMgr
         const char* GetScriptName(uint32 id) const { return id < m_scriptNames.size() ? m_scriptNames[id].c_str() : ""; }
         uint32 GetScriptId(const char* name) const;
         uint32 GetScriptIdsCount() const { return m_scriptNames.size(); }
+
+        bool CheckScriptStringTemplateId(uint32 id) const { return m_stringTemplates.find(id) != m_stringTemplates.end(); }
+        void GetScriptStringTemplate(uint32 id, std::vector<int32>& stringTemplate) { stringTemplate = m_stringTemplates[id]; }
 
         ScriptLoadResult LoadScriptLibrary(const char* libName);
         void UnloadScriptLibrary();
@@ -596,7 +604,7 @@ class ScriptMgr
     private:
         void CollectPossibleEventIds(std::set<uint32>& eventIds);
         void LoadScripts(ScriptMapMapName& scripts, const char* tablename);
-        static void CheckScriptTexts(ScriptMapMapName const& scripts, std::set<int32>& ids);
+        void CheckScriptTexts(ScriptMapMapName const& scripts, std::set<int32>& ids);
 
         template<class T>
         void GetScriptHookPtr(T& ptr, const char* name)
@@ -607,10 +615,12 @@ class ScriptMgr
         typedef std::vector<std::string> ScriptNameMap;
         typedef std::unordered_map<uint32, uint32> AreaTriggerScriptMap;
         typedef std::unordered_map<uint32, uint32> EventIdScriptMap;
+        typedef std::unordered_map<uint32, std::vector<int32>> ScriptStringTemplateMap;
 
         AreaTriggerScriptMap    m_AreaTriggerScripts;
         EventIdScriptMap        m_EventIdScripts;
 
+        ScriptStringTemplateMap m_stringTemplates;
         ScriptNameMap           m_scriptNames;
         MANGOS_LIBRARY_HANDLE   m_hScriptLib;
 

--- a/src/game/ScriptMgr.h
+++ b/src/game/ScriptMgr.h
@@ -65,8 +65,8 @@ enum ScriptCommand                                          // resSource, resTar
     SCRIPT_COMMAND_REMOVE_AURA              = 14,           // resSource = Unit, datalong = spell_id
     SCRIPT_COMMAND_CAST_SPELL               = 15,           // resSource = Unit, cast spell at resTarget = Unit
                                                             // datalong=spellid
+                                                            // datalong2=castFlags, enum TriggeredCastFlags
                                                             // dataint1-4 optional for random selected spell
-                                                            // data_flags &  SCRIPT_FLAG_COMMAND_ADDITIONAL = cast triggered
     SCRIPT_COMMAND_PLAY_SOUND               = 16,           // resSource = WorldObject, target=any/player, datalong (sound_id), datalong2 (bitmask: 0/1=target-player, 0/2=with distance dependent, 0/4=map wide, 0/8=zone wide; so 1|2 = 3 is target with distance dependent)
     SCRIPT_COMMAND_CREATE_ITEM              = 17,           // source or target must be player, datalong = item entry, datalong2 = amount
     SCRIPT_COMMAND_DESPAWN_SELF             = 18,           // resSource = Creature, datalong = despawn delay
@@ -245,7 +245,7 @@ struct ScriptInfo
         struct                                              // SCRIPT_COMMAND_CAST_SPELL (15)
         {
             uint32 spellId;                                 // datalong
-            uint32 empty;                                   // datalong2
+            uint32 castFlags;                               // datalong2
         } castSpell;
 
         struct                                              // SCRIPT_COMMAND_PLAY_SOUND (16)

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -6525,11 +6525,10 @@ bool Spell::CheckTarget(Unit* target, SpellEffectIndex eff) const
                 m_spellInfo->EffectImplicitTargetB[eff] != TARGET_NARROW_FRONTAL_CONE)
                 return false;
 
-            if (target->IsTaxiFlying())
-                return false;
+			SQLMultiStorage::SQLMSIteratorBounds<SpellTargetEntry> bounds = sSpellScriptTargetStorage.getBounds<SpellTargetEntry>(m_spellInfo->Id);
 
             // Experimental: Test out TC theory that this flag should be Immune to Player
-            if (target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_OOC_NOT_ATTACKABLE) && m_caster->GetTypeId() == TYPEID_PLAYER)
+            if (bounds.first == bounds.second && target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_OOC_NOT_ATTACKABLE) && m_caster->GetTypeId() == TYPEID_PLAYER)
                 return false;
         }
 

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -319,13 +319,11 @@ Spell::Spell(Unit* caster, SpellEntry const* info, uint32 triggeredFlags, Object
 
     m_needAliveTargetMask = 0;
 
-    m_ignoreHitResult = false;
-    m_ignoreUnselectableTarget = m_IsTriggeredSpell;
+    m_ignoreHitResult = !!(triggeredFlags & TRIGGERED_IGNORE_HIT_CALCULATION);
+    m_ignoreUnselectableTarget = m_IsTriggeredSpell | (triggeredFlags & TRIGGERED_IGNORE_UNSELECTABLE_FLAG);
+    m_ignoreUnattackableTarget = triggeredFlags & TRIGGERED_IGNORE_UNATTACKABLE_FLAG;
 
     m_reflectable = IsReflectableSpell(m_spellInfo);
-
-    if (triggeredFlags & TRIGGERED_IGNORE_UNSELECTABLE_FLAG)
-        m_ignoreUnselectableTarget = true;
 
     CleanupTargetList();
 }
@@ -6521,7 +6519,7 @@ bool Spell::CheckTarget(Unit* target, SpellEffectIndex eff) const
         if (target->GetCharmerOrOwnerGuid() != m_caster->GetObjectGuid())
         {
             // any unattackable target skipped
-            if (target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE))
+            if (!m_ignoreUnattackableTarget && target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE))
                 return false;
 
             // unselectable targets skipped in all cases except TARGET_SCRIPT targeting

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -6595,7 +6595,7 @@ bool Spell::CheckTarget(Unit* target, SpellEffectIndex eff) const
         && m_spellInfo->EffectImplicitTargetA[eff] != TARGET_SCRIPT && m_spellInfo->EffectImplicitTargetA[eff] != TARGET_SELF)
         return false;
 
-    if (target->isAlive() == m_spellInfo->HasAttribute(SPELL_ATTR_EX3_CAST_ON_DEAD))
+    if (m_spellInfo->HasAttribute(SPELL_ATTR_EX3_CAST_ON_DEAD) && target->isAlive())
         return false;
 
     if (!IsAllowingDeadTarget(m_spellInfo) && !target->isAlive() && !(target == m_caster && m_spellInfo->HasAttribute(SPELL_ATTR_CASTABLE_WHILE_DEAD)) && m_caster->GetTypeId() == TYPEID_PLAYER)

--- a/src/game/Spell.h
+++ b/src/game/Spell.h
@@ -747,9 +747,8 @@ namespace MaNGOS
             {
                 // there are still more spells which can be casted on dead, but
                 // they are no AOE and don't have such a nice SPELL_ATTR flag
-                if ((i_TargetType != SPELL_TARGETS_ALL && !itr->getSource()->isTargetableForAttack(i_spell.m_spellInfo->HasAttribute(SPELL_ATTR_EX3_CAST_ON_DEAD)))
-                        // mostly phase check
-                        || !itr->getSource()->IsInMap(i_originalCaster))
+                // mostly phase check
+                if (!itr->getSource()->IsInMap(i_originalCaster))
                     continue;
 
                 switch (i_TargetType)

--- a/src/game/Spell.h
+++ b/src/game/Spell.h
@@ -412,6 +412,7 @@ class Spell
         // Trigger flag system
         bool m_ignoreHitResult;
         bool m_ignoreUnselectableTarget;
+        bool m_ignoreUnattackableTarget;
 
         int32 GetCastTime() const { return m_casttime; }
         uint32 GetCastedTime() const { return m_timer; }

--- a/src/game/Unit.h
+++ b/src/game/Unit.h
@@ -330,6 +330,9 @@ enum TriggerCastFlags : uint32
     TRIGGERED_OLD_TRIGGERED                     = 0x00000001,   // Legacy bool support TODO: Restrict usage as much as possible.
     TRIGGERED_IGNORE_HIT_CALCULATION            = 0x00000002,   // Will ignore calculating hit in SpellHitResult
     TRIGGERED_IGNORE_UNSELECTABLE_FLAG          = 0x00000004,   // Ignores UNIT_FLAG_NOT_SELECTABLE in CheckTarget
+    TRIGGERED_INSTANT_CAST                      = 0x00000008,   // Will ignore any cast time set in spell entry
+    TRIGGERED_AUTOREPEAT                        = 0x00000010,   // Will signal spell system that this is internal autorepeat call
+    TRIGGERED_IGNORE_UNATTACKABLE_FLAG          = 0x00000020,   // Ignores UNIT_FLAG_NOT_ATTACKABLE in CheckTarget
     TRIGGERED_FULL_MASK                         = 0xFFFFFFFF
 };
 

--- a/src/game/WaypointManager.h
+++ b/src/game/WaypointManager.h
@@ -26,7 +26,7 @@ enum WaypointPathOrigin
     PATH_NO_PATH            = 0,
     PATH_FROM_GUID          = 1,
     PATH_FROM_ENTRY         = 2,
-    PATH_FROM_EXTERNAL      = 3
+    PATH_FROM_EXTERNAL      = 3,
 };
 
 // Obsolete structure
@@ -141,14 +141,14 @@ class WaypointManager
 
         // Toolbox for .wp add command
         /// Add a node as position pointId. If pointId == 0 then as last point
-        WaypointNode const* AddNode(uint32 entry, uint32 dbGuid, uint32& pointId, WaypointPathOrigin wpDest, float x, float y, float z);
+        WaypointNode const* AddNode(uint32 entry, uint32 dbGuid, uint32 pathId, uint32& pointId, WaypointPathOrigin wpDest, float x, float y, float z, float orientation);
 
         // Toolbox for .wp modify command
-        void DeleteNode(uint32 entry, uint32 dbGuid, uint32 point, int32 pathId, WaypointPathOrigin wpOrigin);
-        void SetNodePosition(uint32 entry, uint32 dbGuid, uint32 point, int32 pathId, WaypointPathOrigin wpOrigin, float x, float y, float z);
-        void SetNodeWaittime(uint32 entry, uint32 dbGuid, uint32 point, int32 pathId, WaypointPathOrigin wpOrigin, uint32 waittime);
-        void SetNodeOrientation(uint32 entry, uint32 dbGuid, uint32 point, int32 pathId, WaypointPathOrigin wpOrigin, float orientation);
-        bool SetNodeScriptId(uint32 entry, uint32 dbGuid, uint32 point, int32 pathId, WaypointPathOrigin wpOrigin, uint32 scriptId);
+        void DeleteNode(uint32 entry, uint32 dbGuid, uint32 point, uint32 pathId, WaypointPathOrigin wpOrigin);
+        void SetNodePosition(uint32 entry, uint32 dbGuid, uint32 point, uint32 pathId, WaypointPathOrigin wpOrigin, float x, float y, float z);
+        void SetNodeWaittime(uint32 entry, uint32 dbGuid, uint32 point, uint32 pathId, WaypointPathOrigin wpOrigin, uint32 waittime);
+        void SetNodeOrientation(uint32 entry, uint32 dbGuid, uint32 point, uint32 pathId, WaypointPathOrigin wpOrigin, float orientation);
+        bool SetNodeScriptId(uint32 entry, uint32 dbGuid, uint32 point, uint32 pathId, WaypointPathOrigin wpOrigin, uint32 scriptId);
 
         // Small Helper for nice output
         static std::string GetOriginString(WaypointPathOrigin origin)
@@ -176,9 +176,22 @@ class WaypointManager
             return itr != m_pathTemplateMap.end() ? &itr->second : nullptr;
         }
 
+        typedef std::unordered_map<uint32 /*guidOrEntry*/, WaypointPath> WaypointPathMap;
+
+        WaypointPathMap* getMapForPathType(WaypointPathOrigin origin)
+        {
+            switch (origin)
+            {
+                case PATH_NO_PATH:          return nullptr;
+                case PATH_FROM_GUID:        return &m_pathMap;
+                case PATH_FROM_ENTRY:       return &m_pathTemplateMap;
+                case PATH_FROM_EXTERNAL:    return &m_externalPathTemplateMap;
+                default:                    return nullptr;
+            }
+        }
+
         void _clearPath(WaypointPath& path);
 
-        typedef std::unordered_map<uint32 /*guidOrEntry*/, WaypointPath> WaypointPathMap;
         WaypointPathMap m_pathMap;
         WaypointPathMap m_pathTemplateMap;
         WaypointPathMap m_externalPathTemplateMap;
@@ -188,6 +201,6 @@ class WaypointManager
 #define sWaypointMgr MaNGOS::Singleton<WaypointManager>::Instance()
 
 /// Accessor for Scripting library
-MANGOS_DLL_SPEC bool AddWaypointFromExternal(uint32 entry, int32 pathId, uint32 pointId, float x, float y, float z, float o, uint32 waittime);
+MANGOS_DLL_SPEC bool AddWaypointFromExternal(uint32 entry, uint32 pathId, uint32 pointId, float x, float y, float z, float o, uint32 waittime);
 
 #endif

--- a/src/game/WaypointMovementGenerator.cpp
+++ b/src/game/WaypointMovementGenerator.cpp
@@ -68,9 +68,9 @@ void WaypointMovementGenerator<Creature>::Initialize(Creature& creature)
     creature.clearUnitState(UNIT_STAT_WAYPOINT_PAUSED);
 }
 
-void WaypointMovementGenerator<Creature>::InitializeWaypointPath(Creature& u, int32 id, WaypointPathOrigin wpSource, uint32 initialDelay, uint32 overwriteEntry)
+void WaypointMovementGenerator<Creature>::InitializeWaypointPath(Creature& u, int32 pathId, WaypointPathOrigin wpSource, uint32 initialDelay, uint32 overwriteEntry)
 {
-    LoadPath(u, id, wpSource, overwriteEntry);
+    LoadPath(u, pathId, wpSource, overwriteEntry);
     i_nextMoveTime.Reset(initialDelay);
     // Start moving if possible
     StartMove(u);

--- a/src/game/WaypointMovementGenerator.h
+++ b/src/game/WaypointMovementGenerator.h
@@ -72,13 +72,13 @@ class MANGOS_DLL_SPEC WaypointMovementGenerator<Creature>
         void Finalize(Creature&);
         void Reset(Creature& u);
         bool Update(Creature& u, const uint32& diff);
-        void InitializeWaypointPath(Creature& u, int32 id, WaypointPathOrigin wpSource, uint32 initialDelay, uint32 overwriteEntry);
+        void InitializeWaypointPath(Creature& u, int32 pathId, WaypointPathOrigin wpSource, uint32 initialDelay, uint32 overwriteEntry);
 
         MovementGeneratorType GetMovementGeneratorType() const { return WAYPOINT_MOTION_TYPE; }
 
         bool GetResetPosition(Creature&, float& /*x*/, float& /*y*/, float& /*z*/, float& /*o*/) const;
         uint32 getLastReachedWaypoint() const { return m_lastReachedWaypoint; }
-        void GetPathInformation(int32& pathId, WaypointPathOrigin& wpOrigin) const { pathId = m_pathId; wpOrigin = m_PathOrigin; }
+        void GetPathInformation(uint32& pathId, WaypointPathOrigin& wpOrigin) const { pathId = m_pathId; wpOrigin = m_PathOrigin; }
         void GetPathInformation(std::ostringstream& oss) const;
 
         void AddToWaypointPauseTime(int32 waitTimeDiff);
@@ -98,7 +98,7 @@ class MANGOS_DLL_SPEC WaypointMovementGenerator<Creature>
         bool m_isArrivalDone;
         uint32 m_lastReachedWaypoint;
 
-        int32 m_pathId;
+        uint32 m_pathId;
         WaypointPathOrigin m_PathOrigin;
 };
 

--- a/src/scriptdev2/system/system.cpp
+++ b/src/scriptdev2/system/system.cpp
@@ -93,7 +93,7 @@ void SystemMgr::LoadScriptWaypoints()
             Field* pFields = pResult->Fetch();
 
             uint32 uiEntry  = pFields[0].GetUInt32();
-            int32 pathId    = 1; // pFields[X].GetInt32();
+            uint32 pathId    = 1; // pFields[X].GetUInt32();
             uint32 pointId  = pFields[1].GetUInt32();
             uint32 delay    = pFields[5].GetUInt32();
 


### PR DESCRIPTION
This enables us to have infinite number of db_script_string for one dbscript entry.

Example of how it works
DELETE FROM dbscript_string_template WHERE id IN(1);
insert into dbscript_string_template values
(1,2000005362),
(1,2000005345);

-- 58199

UPDATE creature SET MovementType=2 WHERE guid = 58199;
DELETE FROM creature_movement WHERE id IN(58199);
INSERT INTO creature_movement VALUES(58199,1,-287.705,2916.198,-58.693,0,58199,0,0,0,0,0,0,0,3.402,0,0);
DELETE FROM dbscripts_on_creature_movement WHERE id IN(58199);
INSERT INTO dbscripts_on_creature_movement VALUES(58199,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,'TEST_STRING_TEMPL');

.tele hellfire
below there is an orc who will now randomly say a string using new tech