### PR TITLE
[SpellAura] Dose flame touched aura on flame sear

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -5724,21 +5724,6 @@ void Aura::PeriodicTick()
                         }
                         break;
                     }
-                    case 46771: 
-                    {                               // Flame Sear (SWP, eredar twins)
-                        if (target->GetTypeId() == TYPEID_PLAYER)
-                        {
-                            if (!target->HasAura(45343) &&
-                                !target->HasAura(47300)) {          // No Dark Flame applied. There are two auras
-                                if (m_periodicTick % 4 == 1) {      // Only doze the aura every 2 ticks (should maybe be one second cooldown)
-                                    target->CastSpell(target, 45348,
-                                                      TRIGGERED_OLD_TRIGGERED, nullptr,
-                                                      this); // apply a doze of Flame Touched
-                                }
-                            }
-                        }
-                        break;
-                     }
                     default:
                         break;
                 }

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -5724,6 +5724,19 @@ void Aura::PeriodicTick()
                         }
                         break;
                     }
+                    case 46771: {                               // Flame Sear
+                        if (target->GetTypeId() == TYPEID_PLAYER) {
+                            if (!target->HasAura(45343) &&
+                                !target->HasAura(47300)) {          // No Dark Flame applied. There are two auras
+                                if (m_periodicTick % 4 == 1) {      // Only doze the aura every 2 ticks (should maybe be one second cooldown)
+                                    target->CastSpell(target, 45348,
+                                                      TRIGGERED_OLD_TRIGGERED, nullptr,
+                                                      this); // apply a doze of Flame Touched
+                                }
+                            }
+                        }
+                        break;
+                     }
                     default:
                         break;
                 }

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -666,7 +666,10 @@ void AreaAura::Update(uint32 diff)
                     holder->SetInUse(false);
                 }
                 else
+                {
                     (*tIter)->AddSpellAuraHolder(holder);
+                    holder->SetState(SPELLAURAHOLDER_STATE_READY);
+                }
 
             }
         }

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -5724,8 +5724,10 @@ void Aura::PeriodicTick()
                         }
                         break;
                     }
-                    case 46771: {                               // Flame Sear
-                        if (target->GetTypeId() == TYPEID_PLAYER) {
+                    case 46771: 
+                    {                               // Flame Sear (SWP, eredar twins)
+                        if (target->GetTypeId() == TYPEID_PLAYER)
+                        {
                             if (!target->HasAura(45343) &&
                                 !target->HasAura(47300)) {          // No Dark Flame applied. There are two auras
                                 if (m_periodicTick % 4 == 1) {      // Only doze the aura every 2 ticks (should maybe be one second cooldown)

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -1716,12 +1716,66 @@ SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(Unit* pVictim, uint32 d
                         return SPELL_AURA_PROC_FAILED;
                     break;
                     // case 45205: break;                   // Copy Offhand Weapon
-                    // case 45343: break;                   // Dark Flame Aura
                     // case 45903: break:                   // Offensive State
                     // case 46146: break:                   // [PH] Ahune  Spanky Hands
                     // case 46146: break;                   // [PH] Ahune  Spanky Hands
-                    // case 47300: break;                   // Dark Flame Aura
                     // case 50051: break;                   // Ethereal Pet Aura
+                    
+                    
+                case 45343: // Dark Flame Aura              procs from alythess
+
+                    if(!procSpell)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    if (this->HasAura(45345))                   // SPELL_DARK_FLAME on player
+                        return SPELL_AURA_PROC_FAILED;
+
+                    if (procSpell->Id == 46771                  // flame sear
+                            || procSpell->Id == 45342           // or conflag
+                            || procSpell->Id == 45235)          // or blaze
+
+                    /*if (procSpell->SchoolMask == SPELL_SCHOOL_MASK_FIRE
+                        && procSpell->Id != SPELL_FLAME_TOUCHED)    // to avoid having flame touched increasing stacks of flame touched*/
+                    {
+                        cooldown = 1;
+                        target = this;
+                        if (this->HasAura(45347))
+                        {
+                            this->RemoveAurasDueToSpell(45347);
+                            trigger_spell_id = 45345;
+                        }
+                        else
+                            trigger_spell_id = 45348;
+                    }
+
+                    break;
+
+                case 47300:                          // Dark Flame Aura proc from scarolash
+
+                    if(!procSpell)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    if (this->HasAura(45345))       // SPELL_DARK_FLAME on player
+                        return SPELL_AURA_PROC_FAILED;
+
+                    if (procSpell->Id == 45256      // confunding blow
+                        || procSpell->Id ==45248    // shadow blades
+                        || procSpell->Id ==45329)   // shadow nova
+                    {
+                        cooldown = 1;
+                        target = this;
+                        if (this->HasAura(45348))
+                        {
+                            this->RemoveAurasDueToSpell(45348);
+                            trigger_spell_id = 45345;
+                        }
+                        else
+                            trigger_spell_id = 45347;
+                    }
+
+                    break;
+
+                    
                     break;
             }
             break;

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -1,6 +1,4 @@
-/*
- * This file is part of the CMaNGOS Project. See AUTHORS file for Copyright information
- *
+/* This file is part of the ScriptDev2 Project. See AUTHORS file for Copyright information
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -16,2550 +14,565 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include "Common.h"
-#include "Log.h"
-#include "ObjectMgr.h"
-#include "SpellMgr.h"
-#include "Player.h"
-#include "Unit.h"
-#include "Spell.h"
-#include "SpellAuras.h"
-#include "Totem.h"
-#include "Creature.h"
-#include "ScriptMgr.h"
-#include "Util.h"
+/* ScriptData
+SDName: boss_eredar_twins
+SD%Complete: 75
+SDComment: A few spells are not working proper yet; Shadow image script needs improvement
+SDCategory: Sunwell Plateau
+EndScriptData */
 
-pAuraProcHandler AuraProcHandler[TOTAL_AURAS] =
+#include "precompiled.h"
+#include "sunwell_plateau.h"
+
+enum
 {
-    &Unit::HandleNULLProc,                                  //  0 SPELL_AURA_NONE
-    &Unit::HandleNULLProc,                                  //  1 SPELL_AURA_BIND_SIGHT
-    &Unit::HandleNULLProc,                                  //  2 SPELL_AURA_MOD_POSSESS
-    &Unit::HandleNULLProc,                                  //  3 SPELL_AURA_PERIODIC_DAMAGE
-    &Unit::HandleDummyAuraProc,                             //  4 SPELL_AURA_DUMMY
-    &Unit::HandleNULLProc,                                  //  5 SPELL_AURA_MOD_CONFUSE
-    &Unit::HandleNULLProc,                                  //  6 SPELL_AURA_MOD_CHARM
-    &Unit::HandleRemoveByDamageChanceProc,                  //  7 SPELL_AURA_MOD_FEAR
-    &Unit::HandleNULLProc,                                  //  8 SPELL_AURA_PERIODIC_HEAL
-    &Unit::HandleNULLProc,                                  //  9 SPELL_AURA_MOD_ATTACKSPEED
-    &Unit::HandleNULLProc,                                  // 10 SPELL_AURA_MOD_THREAT
-    &Unit::HandleNULLProc,                                  // 11 SPELL_AURA_MOD_TAUNT
-    &Unit::HandleNULLProc,                                  // 12 SPELL_AURA_MOD_STUN
-    &Unit::HandleNULLProc,                                  // 13 SPELL_AURA_MOD_DAMAGE_DONE
-    &Unit::HandleNULLProc,                                  // 14 SPELL_AURA_MOD_DAMAGE_TAKEN
-    &Unit::HandleNULLProc,                                  // 15 SPELL_AURA_DAMAGE_SHIELD
-    &Unit::HandleNULLProc,                                  // 16 SPELL_AURA_MOD_STEALTH
-    &Unit::HandleNULLProc,                                  // 17 SPELL_AURA_MOD_STEALTH_DETECT
-    &Unit::HandleInvisibilityAuraProc,                      // 18 SPELL_AURA_MOD_INVISIBILITY
-    &Unit::HandleNULLProc,                                  // 19 SPELL_AURA_MOD_INVISIBILITY_DETECTION
-    &Unit::HandleNULLProc,                                  // 20 SPELL_AURA_OBS_MOD_HEALTH
-    &Unit::HandleNULLProc,                                  // 21 SPELL_AURA_OBS_MOD_MANA
-    &Unit::HandleModResistanceAuraProc,                     // 22 SPELL_AURA_MOD_RESISTANCE
-    &Unit::HandleNULLProc,                                  // 23 SPELL_AURA_PERIODIC_TRIGGER_SPELL
-    &Unit::HandleNULLProc,                                  // 24 SPELL_AURA_PERIODIC_ENERGIZE
-    &Unit::HandleNULLProc,                                  // 25 SPELL_AURA_MOD_PACIFY
-    &Unit::HandleRemoveByDamageChanceProc,                  // 26 SPELL_AURA_MOD_ROOT
-    &Unit::HandleNULLProc,                                  // 27 SPELL_AURA_MOD_SILENCE
-    &Unit::HandleNULLProc,                                  // 28 SPELL_AURA_REFLECT_SPELLS
-    &Unit::HandleNULLProc,                                  // 29 SPELL_AURA_MOD_STAT
-    &Unit::HandleNULLProc,                                  // 30 SPELL_AURA_MOD_SKILL
-    &Unit::HandleNULLProc,                                  // 31 SPELL_AURA_MOD_INCREASE_SPEED
-    &Unit::HandleNULLProc,                                  // 32 SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED
-    &Unit::HandleNULLProc,                                  // 33 SPELL_AURA_MOD_DECREASE_SPEED
-    &Unit::HandleNULLProc,                                  // 34 SPELL_AURA_MOD_INCREASE_HEALTH
-    &Unit::HandleNULLProc,                                  // 35 SPELL_AURA_MOD_INCREASE_ENERGY
-    &Unit::HandleNULLProc,                                  // 36 SPELL_AURA_MOD_SHAPESHIFT
-    &Unit::HandleNULLProc,                                  // 37 SPELL_AURA_EFFECT_IMMUNITY
-    &Unit::HandleNULLProc,                                  // 38 SPELL_AURA_STATE_IMMUNITY
-    &Unit::HandleNULLProc,                                  // 39 SPELL_AURA_SCHOOL_IMMUNITY
-    &Unit::HandleNULLProc,                                  // 40 SPELL_AURA_DAMAGE_IMMUNITY
-    &Unit::HandleNULLProc,                                  // 41 SPELL_AURA_DISPEL_IMMUNITY
-    &Unit::HandleProcTriggerSpellAuraProc,                  // 42 SPELL_AURA_PROC_TRIGGER_SPELL
-    &Unit::HandleProcTriggerDamageAuraProc,                 // 43 SPELL_AURA_PROC_TRIGGER_DAMAGE
-    &Unit::HandleNULLProc,                                  // 44 SPELL_AURA_TRACK_CREATURES
-    &Unit::HandleNULLProc,                                  // 45 SPELL_AURA_TRACK_RESOURCES
-    &Unit::HandleNULLProc,                                  // 46 SPELL_AURA_46
-    &Unit::HandleNULLProc,                                  // 47 SPELL_AURA_MOD_PARRY_PERCENT
-    &Unit::HandleNULLProc,                                  // 48 SPELL_AURA_48
-    &Unit::HandleNULLProc,                                  // 49 SPELL_AURA_MOD_DODGE_PERCENT
-    &Unit::HandleNULLProc,                                  // 50 SPELL_AURA_MOD_BLOCK_SKILL    obsolete?
-    &Unit::HandleNULLProc,                                  // 51 SPELL_AURA_MOD_BLOCK_PERCENT
-    &Unit::HandleNULLProc,                                  // 52 SPELL_AURA_MOD_CRIT_PERCENT
-    &Unit::HandleNULLProc,                                  // 53 SPELL_AURA_PERIODIC_LEECH
-    &Unit::HandleNULLProc,                                  // 54 SPELL_AURA_MOD_HIT_CHANCE
-    &Unit::HandleNULLProc,                                  // 55 SPELL_AURA_MOD_SPELL_HIT_CHANCE
-    &Unit::HandleNULLProc,                                  // 56 SPELL_AURA_TRANSFORM
-    &Unit::HandleNULLProc,                                  // 57 SPELL_AURA_MOD_SPELL_CRIT_CHANCE
-    &Unit::HandleNULLProc,                                  // 58 SPELL_AURA_MOD_INCREASE_SWIM_SPEED
-    &Unit::HandleNULLProc,                                  // 59 SPELL_AURA_MOD_DAMAGE_DONE_CREATURE
-    &Unit::HandleRemoveByDamageChanceProc,                  // 60 SPELL_AURA_MOD_PACIFY_SILENCE
-    &Unit::HandleNULLProc,                                  // 61 SPELL_AURA_MOD_SCALE
-    &Unit::HandleNULLProc,                                  // 62 SPELL_AURA_PERIODIC_HEALTH_FUNNEL
-    &Unit::HandleNULLProc,                                  // 63 SPELL_AURA_PERIODIC_MANA_FUNNEL obsolete?
-    &Unit::HandleNULLProc,                                  // 64 SPELL_AURA_PERIODIC_MANA_LEECH
-    &Unit::HandleModCastingSpeedNotStackAuraProc,           // 65 SPELL_AURA_MOD_CASTING_SPEED_NOT_STACK
-    &Unit::HandleNULLProc,                                  // 66 SPELL_AURA_FEIGN_DEATH
-    &Unit::HandleNULLProc,                                  // 67 SPELL_AURA_MOD_DISARM
-    &Unit::HandleNULLProc,                                  // 68 SPELL_AURA_MOD_STALKED
-    &Unit::HandleNULLProc,                                  // 69 SPELL_AURA_SCHOOL_ABSORB
-    &Unit::HandleNULLProc,                                  // 70 SPELL_AURA_EXTRA_ATTACKS      Useless, used by only one spell that has only visual effect
-    &Unit::HandleNULLProc,                                  // 71 SPELL_AURA_MOD_SPELL_CRIT_CHANCE_SCHOOL
-    &Unit::HandleModPowerCostSchoolAuraProc,                // 72 SPELL_AURA_MOD_POWER_COST_SCHOOL_PCT
-    &Unit::HandleModPowerCostSchoolAuraProc,                // 73 SPELL_AURA_MOD_POWER_COST_SCHOOL
-    &Unit::HandleReflectSpellsSchoolAuraProc,               // 74 SPELL_AURA_REFLECT_SPELLS_SCHOOL
-    &Unit::HandleNULLProc,                                  // 75 SPELL_AURA_MOD_LANGUAGE
-    &Unit::HandleNULLProc,                                  // 76 SPELL_AURA_FAR_SIGHT
-    &Unit::HandleMechanicImmuneResistanceAuraProc,          // 77 SPELL_AURA_MECHANIC_IMMUNITY
-    &Unit::HandleNULLProc,                                  // 78 SPELL_AURA_MOUNTED
-    &Unit::HandleNULLProc,                                  // 79 SPELL_AURA_MOD_DAMAGE_PERCENT_DONE
-    &Unit::HandleNULLProc,                                  // 80 SPELL_AURA_MOD_PERCENT_STAT
-    &Unit::HandleNULLProc,                                  // 81 SPELL_AURA_SPLIT_DAMAGE_PCT
-    &Unit::HandleNULLProc,                                  // 82 SPELL_AURA_WATER_BREATHING
-    &Unit::HandleNULLProc,                                  // 83 SPELL_AURA_MOD_BASE_RESISTANCE
-    &Unit::HandleNULLProc,                                  // 84 SPELL_AURA_MOD_REGEN
-    &Unit::HandleCantTrigger,                               // 85 SPELL_AURA_MOD_POWER_REGEN
-    &Unit::HandleNULLProc,                                  // 86 SPELL_AURA_CHANNEL_DEATH_ITEM
-    &Unit::HandleNULLProc,                                  // 87 SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN
-    &Unit::HandleNULLProc,                                  // 88 SPELL_AURA_MOD_HEALTH_REGEN_PERCENT
-    &Unit::HandleNULLProc,                                  // 89 SPELL_AURA_PERIODIC_DAMAGE_PERCENT
-    &Unit::HandleNULLProc,                                  // 90 SPELL_AURA_MOD_RESIST_CHANCE  Useless
-    &Unit::HandleNULLProc,                                  // 91 SPELL_AURA_MOD_DETECT_RANGE
-    &Unit::HandleNULLProc,                                  // 92 SPELL_AURA_PREVENTS_FLEEING
-    &Unit::HandleNULLProc,                                  // 93 SPELL_AURA_MOD_UNATTACKABLE
-    &Unit::HandleNULLProc,                                  // 94 SPELL_AURA_INTERRUPT_REGEN
-    &Unit::HandleNULLProc,                                  // 95 SPELL_AURA_GHOST
-    &Unit::HandleNULLProc,                                  // 96 SPELL_AURA_SPELL_MAGNET
-    &Unit::HandleManaShieldAuraProc,                        // 97 SPELL_AURA_MANA_SHIELD
-    &Unit::HandleNULLProc,                                  // 98 SPELL_AURA_MOD_SKILL_TALENT
-    &Unit::HandleNULLProc,                                  // 99 SPELL_AURA_MOD_ATTACK_POWER
-    &Unit::HandleNULLProc,                                  //100 SPELL_AURA_AURAS_VISIBLE obsolete? all player can see all auras now
-    &Unit::HandleNULLProc,                                  //101 SPELL_AURA_MOD_RESISTANCE_PCT
-    &Unit::HandleNULLProc,                                  //102 SPELL_AURA_MOD_MELEE_ATTACK_POWER_VERSUS
-    &Unit::HandleNULLProc,                                  //103 SPELL_AURA_MOD_TOTAL_THREAT
-    &Unit::HandleNULLProc,                                  //104 SPELL_AURA_WATER_WALK
-    &Unit::HandleNULLProc,                                  //105 SPELL_AURA_FEATHER_FALL
-    &Unit::HandleNULLProc,                                  //106 SPELL_AURA_HOVER
-    &Unit::HandleNULLProc,                                  //107 SPELL_AURA_ADD_FLAT_MODIFIER
-    &Unit::HandleNULLProc,                                  //108 SPELL_AURA_ADD_PCT_MODIFIER
-    &Unit::HandleNULLProc,                                  //109 SPELL_AURA_ADD_TARGET_TRIGGER
-    &Unit::HandleNULLProc,                                  //110 SPELL_AURA_MOD_POWER_REGEN_PERCENT
-    &Unit::HandleNULLProc,                                  //111 SPELL_AURA_ADD_CASTER_HIT_TRIGGER
-    &Unit::HandleOverrideClassScriptAuraProc,               //112 SPELL_AURA_OVERRIDE_CLASS_SCRIPTS
-    &Unit::HandleNULLProc,                                  //113 SPELL_AURA_MOD_RANGED_DAMAGE_TAKEN
-    &Unit::HandleNULLProc,                                  //114 SPELL_AURA_MOD_RANGED_DAMAGE_TAKEN_PCT
-    &Unit::HandleNULLProc,                                  //115 SPELL_AURA_MOD_HEALING
-    &Unit::HandleNULLProc,                                  //116 SPELL_AURA_MOD_REGEN_DURING_COMBAT
-    &Unit::HandleMechanicImmuneResistanceAuraProc,          //117 SPELL_AURA_MOD_MECHANIC_RESISTANCE
-    &Unit::HandleNULLProc,                                  //118 SPELL_AURA_MOD_HEALING_PCT
-    &Unit::HandleNULLProc,                                  //119 SPELL_AURA_SHARE_PET_TRACKING useless
-    &Unit::HandleNULLProc,                                  //120 SPELL_AURA_UNTRACKABLE
-    &Unit::HandleNULLProc,                                  //121 SPELL_AURA_EMPATHY
-    &Unit::HandleNULLProc,                                  //122 SPELL_AURA_MOD_OFFHAND_DAMAGE_PCT
-    &Unit::HandleNULLProc,                                  //123 SPELL_AURA_MOD_TARGET_RESISTANCE
-    &Unit::HandleNULLProc,                                  //124 SPELL_AURA_MOD_RANGED_ATTACK_POWER
-    &Unit::HandleNULLProc,                                  //125 SPELL_AURA_MOD_MELEE_DAMAGE_TAKEN
-    &Unit::HandleNULLProc,                                  //126 SPELL_AURA_MOD_MELEE_DAMAGE_TAKEN_PCT
-    &Unit::HandleAttackPowerAttackerBonusAuraProc,          //127 SPELL_AURA_RANGED_ATTACK_POWER_ATTACKER_BONUS
-    &Unit::HandleNULLProc,                                  //128 SPELL_AURA_MOD_POSSESS_PET
-    &Unit::HandleNULLProc,                                  //129 SPELL_AURA_MOD_SPEED_ALWAYS
-    &Unit::HandleNULLProc,                                  //130 SPELL_AURA_MOD_MOUNTED_SPEED_ALWAYS
-    &Unit::HandleNULLProc,                                  //131 SPELL_AURA_MOD_RANGED_ATTACK_POWER_VERSUS
-    &Unit::HandleNULLProc,                                  //132 SPELL_AURA_MOD_INCREASE_ENERGY_PERCENT
-    &Unit::HandleNULLProc,                                  //133 SPELL_AURA_MOD_INCREASE_HEALTH_PERCENT
-    &Unit::HandleNULLProc,                                  //134 SPELL_AURA_MOD_MANA_REGEN_INTERRUPT
-    &Unit::HandleNULLProc,                                  //135 SPELL_AURA_MOD_HEALING_DONE
-    &Unit::HandleNULLProc,                                  //136 SPELL_AURA_MOD_HEALING_DONE_PERCENT
-    &Unit::HandleNULLProc,                                  //137 SPELL_AURA_MOD_TOTAL_STAT_PERCENTAGE
-    &Unit::HandleHasteAuraProc,                             //138 SPELL_AURA_MOD_MELEE_HASTE
-    &Unit::HandleNULLProc,                                  //139 SPELL_AURA_FORCE_REACTION
-    &Unit::HandleNULLProc,                                  //140 SPELL_AURA_MOD_RANGED_HASTE
-    &Unit::HandleNULLProc,                                  //141 SPELL_AURA_MOD_RANGED_AMMO_HASTE
-    &Unit::HandleNULLProc,                                  //142 SPELL_AURA_MOD_BASE_RESISTANCE_PCT
-    &Unit::HandleNULLProc,                                  //143 SPELL_AURA_MOD_RESISTANCE_EXCLUSIVE
-    &Unit::HandleNULLProc,                                  //144 SPELL_AURA_SAFE_FALL
-    &Unit::HandleNULLProc,                                  //145 SPELL_AURA_CHARISMA obsolete?
-    &Unit::HandleNULLProc,                                  //146 SPELL_AURA_PERSUADED obsolete?
-    &Unit::HandleNULLProc,                                  //147 SPELL_AURA_MECHANIC_IMMUNITY_MASK
-    &Unit::HandleNULLProc,                                  //148 SPELL_AURA_RETAIN_COMBO_POINTS
-    &Unit::HandleCantTrigger,                               //149 SPELL_AURA_RESIST_PUSHBACK
-    &Unit::HandleNULLProc,                                  //150 SPELL_AURA_MOD_SHIELD_BLOCKVALUE_PCT
-    &Unit::HandleNULLProc,                                  //151 SPELL_AURA_TRACK_STEALTHED
-    &Unit::HandleNULLProc,                                  //152 SPELL_AURA_MOD_DETECTED_RANGE
-    &Unit::HandleNULLProc,                                  //153 SPELL_AURA_SPLIT_DAMAGE_FLAT
-    &Unit::HandleNULLProc,                                  //154 SPELL_AURA_MOD_STEALTH_LEVEL
-    &Unit::HandleNULLProc,                                  //155 SPELL_AURA_MOD_WATER_BREATHING
-    &Unit::HandleNULLProc,                                  //156 SPELL_AURA_MOD_REPUTATION_GAIN
-    &Unit::HandleNULLProc,                                  //157 SPELL_AURA_PET_DAMAGE_MULTI (single test like spell 20782, also single for 214 aura)
-    &Unit::HandleNULLProc,                                  //158 SPELL_AURA_MOD_SHIELD_BLOCKVALUE
-    &Unit::HandleNULLProc,                                  //159 SPELL_AURA_NO_PVP_CREDIT      only for Honorless Target spell
-    &Unit::HandleNULLProc,                                  //160 SPELL_AURA_MOD_AOE_AVOIDANCE
-    &Unit::HandleNULLProc,                                  //161 SPELL_AURA_MOD_HEALTH_REGEN_IN_COMBAT
-    &Unit::HandleNULLProc,                                  //162 SPELL_AURA_POWER_BURN_MANA
-    &Unit::HandleNULLProc,                                  //163 SPELL_AURA_MOD_CRIT_DAMAGE_BONUS
-    &Unit::HandleNULLProc,                                  //164 useless, only one test spell
-    &Unit::HandleAttackPowerAttackerBonusAuraProc,          //165 SPELL_AURA_MELEE_ATTACK_POWER_ATTACKER_BONUS
-    &Unit::HandleNULLProc,                                  //166 SPELL_AURA_MOD_ATTACK_POWER_PCT
-    &Unit::HandleNULLProc,                                  //167 SPELL_AURA_MOD_RANGED_ATTACK_POWER_PCT
-    &Unit::HandleNULLProc,                                  //168 SPELL_AURA_MOD_DAMAGE_DONE_VERSUS
-    &Unit::HandleNULLProc,                                  //169 SPELL_AURA_MOD_CRIT_PERCENT_VERSUS
-    &Unit::HandleNULLProc,                                  //170 SPELL_AURA_DETECT_AMORE       only for Detect Amore spell
-    &Unit::HandleNULLProc,                                  //171 SPELL_AURA_MOD_SPEED_NOT_STACK
-    &Unit::HandleNULLProc,                                  //172 SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK
-    &Unit::HandleNULLProc,                                  //173 SPELL_AURA_ALLOW_CHAMPION_SPELLS  only for Proclaim Champion spell
-    &Unit::HandleNULLProc,                                  //174 SPELL_AURA_MOD_SPELL_DAMAGE_OF_STAT_PERCENT
-    &Unit::HandleNULLProc,                                  //175 SPELL_AURA_MOD_SPELL_HEALING_OF_STAT_PERCENT
-    &Unit::HandleNULLProc,                                  //176 SPELL_AURA_SPIRIT_OF_REDEMPTION   only for Spirit of Redemption spell, die at aura end
-    &Unit::HandleNULLProc,                                  //177 SPELL_AURA_AOE_CHARM
-    &Unit::HandleNULLProc,                                  //178 SPELL_AURA_MOD_DEBUFF_RESISTANCE
-    &Unit::HandleNULLProc,                                  //179 SPELL_AURA_MOD_ATTACKER_SPELL_CRIT_CHANCE
-    &Unit::HandleNULLProc,                                  //180 SPELL_AURA_MOD_FLAT_SPELL_DAMAGE_VERSUS
-    &Unit::HandleNULLProc,                                  //181 SPELL_AURA_MOD_FLAT_SPELL_CRIT_DAMAGE_VERSUS unused
-    &Unit::HandleNULLProc,                                  //182 SPELL_AURA_MOD_RESISTANCE_OF_STAT_PERCENT
-    &Unit::HandleNULLProc,                                  //183 SPELL_AURA_MOD_CRITICAL_THREAT only used in 28746
-    &Unit::HandleNULLProc,                                  //184 SPELL_AURA_MOD_ATTACKER_MELEE_HIT_CHANCE
-    &Unit::HandleNULLProc,                                  //185 SPELL_AURA_MOD_ATTACKER_RANGED_HIT_CHANCE
-    &Unit::HandleNULLProc,                                  //186 SPELL_AURA_MOD_ATTACKER_SPELL_HIT_CHANCE
-    &Unit::HandleNULLProc,                                  //187 SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_CHANCE
-    &Unit::HandleNULLProc,                                  //188 SPELL_AURA_MOD_ATTACKER_RANGED_CRIT_CHANCE
-    &Unit::HandleNULLProc,                                  //189 SPELL_AURA_MOD_RATING
-    &Unit::HandleNULLProc,                                  //190 SPELL_AURA_MOD_FACTION_REPUTATION_GAIN
-    &Unit::HandleNULLProc,                                  //191 SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED
-    &Unit::HandleNULLProc,                                  //192 SPELL_AURA_HASTE_MELEE
-    &Unit::HandleNULLProc,                                  //193 SPELL_AURA_HASTE_ALL (in fact combat (any type attack) speed pct)
-    &Unit::HandleNULLProc,                                  //194 SPELL_AURA_MOD_DEPRICATED_1 not used now (old SPELL_AURA_MOD_SPELL_DAMAGE_OF_INTELLECT)
-    &Unit::HandleNULLProc,                                  //195 SPELL_AURA_MOD_DEPRICATED_2 not used now (old SPELL_AURA_MOD_SPELL_HEALING_OF_INTELLECT)
-    &Unit::HandleNULLProc,                                  //196 SPELL_AURA_MOD_COOLDOWN
-    &Unit::HandleNULLProc,                                  //197 SPELL_AURA_MOD_ATTACKER_SPELL_AND_WEAPON_CRIT_CHANCE
-    &Unit::HandleNULLProc,                                  //198 SPELL_AURA_MOD_ALL_WEAPON_SKILLS
-    &Unit::HandleNULLProc,                                  //199 SPELL_AURA_MOD_INCREASES_SPELL_PCT_TO_HIT
-    &Unit::HandleNULLProc,                                  //200 SPELL_AURA_MOD_XP_PCT
-    &Unit::HandleNULLProc,                                  //201 SPELL_AURA_FLY                             this aura enable flight mode...
-    &Unit::HandleNULLProc,                                  //202 SPELL_AURA_IGNORE_COMBAT_RESULT
-    &Unit::HandleNULLProc,                                  //203 SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_DAMAGE
-    &Unit::HandleNULLProc,                                  //204 SPELL_AURA_MOD_ATTACKER_RANGED_CRIT_DAMAGE
-    &Unit::HandleNULLProc,                                  //205 SPELL_AURA_MOD_ATTACKER_SPELL_CRIT_DAMAGE
-    &Unit::HandleNULLProc,                                  //206 SPELL_AURA_MOD_FLIGHT_SPEED
-    &Unit::HandleNULLProc,                                  //207 SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED
-    &Unit::HandleNULLProc,                                  //208 SPELL_AURA_MOD_FLIGHT_SPEED_STACKING
-    &Unit::HandleNULLProc,                                  //209 SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_STACKING
-    &Unit::HandleNULLProc,                                  //210 SPELL_AURA_MOD_FLIGHT_SPEED_NOT_STACKING
-    &Unit::HandleNULLProc,                                  //211 SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_NOT_STACKING
-    &Unit::HandleNULLProc,                                  //212 SPELL_AURA_MOD_RANGED_ATTACK_POWER_OF_STAT_PERCENT
-    &Unit::HandleNULLProc,                                  //213 SPELL_AURA_MOD_RAGE_FROM_DAMAGE_DEALT implemented in Player::RewardRage
-    &Unit::HandleNULLProc,                                  //214 Tamed Pet Passive
-    &Unit::HandleNULLProc,                                  //215 SPELL_AURA_ARENA_PREPARATION
-    &Unit::HandleNULLProc,                                  //216 SPELL_AURA_HASTE_SPELLS
-    &Unit::HandleNULLProc,                                  //217                                   unused
-    &Unit::HandleNULLProc,                                  //218 SPELL_AURA_HASTE_RANGED
-    &Unit::HandleNULLProc,                                  //219 SPELL_AURA_MOD_MANA_REGEN_FROM_STAT
-    &Unit::HandleNULLProc,                                  //220 SPELL_AURA_MOD_RATING_FROM_STAT
-    &Unit::HandleNULLProc,                                  //221 ignored
-    &Unit::HandleNULLProc,                                  //222 unused
-    &Unit::HandleNULLProc,                                  //223 Cold Stare
-    &Unit::HandleNULLProc,                                  //224 unused
-    &Unit::HandleMendingAuraProc,                           //225 SPELL_AURA_PRAYER_OF_MENDING
-    &Unit::HandleNULLProc,                                  //226 SPELL_AURA_PERIODIC_DUMMY
-    &Unit::HandleNULLProc,                                  //227 SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE
-    &Unit::HandleNULLProc,                                  //228 SPELL_AURA_DETECT_STEALTH
-    &Unit::HandleNULLProc,                                  //229 SPELL_AURA_MOD_AOE_DAMAGE_AVOIDANCE
-    &Unit::HandleNULLProc,                                  //230 Commanding Shout
-    &Unit::HandleProcTriggerSpellAuraProc,                  //231 SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE
-    &Unit::HandleNULLProc,                                  //232 SPELL_AURA_MECHANIC_DURATION_MOD
-    &Unit::HandleNULLProc,                                  //233 set model id to the one of the creature with id m_modifier.m_miscvalue
-    &Unit::HandleNULLProc,                                  //234 SPELL_AURA_MECHANIC_DURATION_MOD_NOT_STACK
-    &Unit::HandleNULLProc,                                  //235 SPELL_AURA_MOD_DISPEL_RESIST
-    &Unit::HandleNULLProc,                                  //236 unused
-    &Unit::HandleNULLProc,                                  //237 SPELL_AURA_MOD_SPELL_DAMAGE_OF_ATTACK_POWER
-    &Unit::HandleNULLProc,                                  //238 SPELL_AURA_MOD_SPELL_HEALING_OF_ATTACK_POWER
-    &Unit::HandleNULLProc,                                  //239 SPELL_AURA_MOD_SCALE_2 only in Noggenfogger Elixir (16595) before 2.3.0 aura 61
-    &Unit::HandleNULLProc,                                  //240 SPELL_AURA_MOD_EXPERTISE
-    &Unit::HandleNULLProc,                                  //241 Forces the player to move forward
-    &Unit::HandleNULLProc,                                  //242 SPELL_AURA_MOD_SPELL_DAMAGE_FROM_HEALING
-    &Unit::HandleNULLProc,                                  //243 used by two test spells
-    &Unit::HandleNULLProc,                                  //244 Comprehend language
-    &Unit::HandleNULLProc,                                  //245 SPELL_AURA_MOD_DURATION_OF_MAGIC_EFFECTS
-    &Unit::HandleNULLProc,                                  //246 unused
-    &Unit::HandleNULLProc,                                  //247 unused
-    &Unit::HandleNULLProc,                                  //248 SPELL_AURA_MOD_COMBAT_RESULT_CHANCE
-    &Unit::HandleNULLProc,                                  //249
-    &Unit::HandleNULLProc,                                  //250 SPELL_AURA_MOD_INCREASE_HEALTH_2
-    &Unit::HandleNULLProc,                                  //251 SPELL_AURA_MOD_ENEMY_DODGE
-    &Unit::HandleNULLProc,                                  //252 unused
-    &Unit::HandleNULLProc,                                  //253 unused
-    &Unit::HandleNULLProc,                                  //254 unused
-    &Unit::HandleNULLProc,                                  //255 unused
-    &Unit::HandleNULLProc,                                  //256 unused
-    &Unit::HandleNULLProc,                                  //257 unused
-    &Unit::HandleNULLProc,                                  //258 unused
-    &Unit::HandleNULLProc,                                  //259 unused
-    &Unit::HandleNULLProc,                                  //260 unused
-    &Unit::HandleNULLProc,                                  //261 SPELL_AURA_261 some phased state (44856 spell)
+    SAY_INTRO_1                             = -1580044,
+    SAY_INTRO_2                             = -1580045,
+    SAY_INTRO_3                             = -1580046,
+    SAY_INTRO_4                             = -1580047,
+    SAY_INTRO_5                             = -1580048,
+    SAY_INTRO_6                             = -1580049,
+    SAY_INTRO_7                             = -1580050,
+    SAY_INTRO_8                             = -1580051,
+
+    SAY_SACROLASH_SHADOW_NOVA               = -1580052,
+    SAY_SACROLASH_EMPOWER                   = -1580053,
+    SAY_SACROLASH_KILL_1                    = -1580054,
+    SAY_SACROLASH_KILL_2                    = -1580055,
+    SAY_SACROLASH_DEAD                      = -1580056,
+    SAY_SACROLASH_BERSERK                   = -1580057,
+
+    SAY_ALYTHESS_CANFLAGRATION              = -1580058,
+    SAY_ALYTHESS_EMPOWER                    = -1580059,
+    SAY_ALYTHESS_KILL_1                     = -1580060,
+    SAY_ALYTHESS_KILL_2                     = -1580061,
+    SAY_ALYTHESS_DEAD                       = -1580062,
+    SAY_ALYTHESS_BERSERK                    = -1580063,
+
+    // Shared spells
+    SPELL_TWINS_ENRAGE                      = 46587,
+    SPELL_EMPOWER                           = 45366,        // Cast on self when the twin sister dies
+    SPELL_DARK_FLAME                        = 45345,
+
+    // Sacrolash spells
+    SPELL_DARK_TOUCHED                      = 45347,        // Player debuff; removed by shadow damage
+    SPELL_SHADOW_BLADES                     = 45248,        // 10 secs
+    SPELL_DARK_STRIKE                       = 45271,
+    SPELL_SHADOW_NOVA                       = 45329,        // 30-35 secs
+    SPELL_CONFOUNDING_BLOW                  = 45256,        // Daze; 25 secs
+    SPELL_SHADOW_NOVA_UNK                   = 45332,        // Unknown
+
+    // Shadow Image spells
+    NPC_SHADOW_IMAGE                        = 25214,
+    SPELL_SHADOWFURY                        = 45270,
+    SPELL_IMAGE_VISUAL                      = 45263,
+
+    // Alythess spells
+    SPELL_PYROGENICS                        = 45230,        // Self buff; 15secs
+    SPELL_FLAME_TOUCHED                     = 45348,        // Player debuff; removed by shadow damage
+    SPELL_CONFLAGRATION                     = 45342,        // 30-35 secs
+    SPELL_BLAZE                             = 45235,        // On main target every 3 secs; should trigger 45236 which leaves a fire on the ground
+    SPELL_FLAME_SEAR                        = 46771,        // A few random targets debuff
+    SPELL_CONFLAGRATION_UNK                 = 45333,        // Unknown
+
+    DARK_FLAME_AURA_ALYTHESS                = 47300,        // Aura buff that make flame touched spell proc - for Alythess
+    DARK_FLAME_AURA_SCAROLASH               = 45343,        // Aura buff that make dark touched spell proc  - for Scarolash
 };
 
-bool Unit::IsTriggeredAtSpellProcEvent(Unit* pVictim, SpellAuraHolder* holder, SpellEntry const* procSpell, uint32 procFlag, uint32 procExtra, WeaponAttackType attType, bool isVictim, SpellProcEventEntry const*& spellProcEvent)
+static const DialogueEntry aIntroDialogue[] =
 {
-    SpellEntry const* spellProto = holder->GetSpellProto();
+    {SAY_INTRO_1, NPC_SACROLASH, 1000},
+    {SAY_INTRO_2, NPC_ALYTHESS,  1500},
+    {SAY_INTRO_3, NPC_SACROLASH, 1500},
+    {SAY_INTRO_4, NPC_ALYTHESS,  1500},
+    {SAY_INTRO_5, NPC_SACROLASH, 1500},
+    {SAY_INTRO_6, NPC_ALYTHESS,  1500},
+    {SAY_INTRO_7, NPC_SACROLASH, 2500},
+    {SAY_INTRO_8, NPC_ALYTHESS,  0},
+    {0, 0, 0},
+};
 
-    // Get proc Event Entry
-    spellProcEvent = sSpellMgr.GetSpellProcEvent(spellProto->Id);
 
-    // Get EventProcFlag
-    uint32 EventProcFlag;
-    if (spellProcEvent && spellProcEvent->procFlags) // if exist get custom spellProcEvent->procFlags
-        EventProcFlag = spellProcEvent->procFlags;
-    else
-        EventProcFlag = spellProto->procFlags;       // else get from spell proto
-    // Continue if no trigger exist
-    if (!EventProcFlag)
-        return false;
+/*######
+## boss_alythess
+######*/
 
-    // Check spellProcEvent data requirements
-    if (!SpellMgr::IsSpellProcEventCanTriggeredBy(spellProcEvent, EventProcFlag, procSpell, procFlag, procExtra))
-        return false;
-
-    // In most cases req get honor or XP from kill
-    if (EventProcFlag & PROC_FLAG_KILL && GetTypeId() == TYPEID_PLAYER)
-    {
-        bool allow = ((Player*)this)->isHonorOrXPTarget(pVictim);
-        // Shadow Word: Death - can trigger from every kill
-        if (holder->GetId() == 32409)
-            allow = true;
-        if (!allow)
-            return false;
-    }
-    // Aura added by spell can`t trigger from self (prevent drop charges/do triggers)
-    // But except periodic triggers (can triggered from self)
-    if (procSpell && procSpell->Id == spellProto->Id && !(EventProcFlag & PROC_FLAG_ON_TAKE_PERIODIC))
-        return false;
-
-    // Check if current equipment allows aura to proc
-    if (!isVictim && GetTypeId() == TYPEID_PLAYER)
-    {
-        if (spellProto->EquippedItemClass == ITEM_CLASS_WEAPON)
-        {
-            Item* item;
-            if (attType == BASE_ATTACK)
-                item = ((Player*)this)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-            else if (attType == OFF_ATTACK)
-                item = ((Player*)this)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
-            else
-                item = ((Player*)this)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_RANGED);
-
-            if (!CanUseEquippedWeapon(attType))
-                return false;
-
-            if (!item || item->IsBroken() || item->GetProto()->Class != ITEM_CLASS_WEAPON || !((1 << item->GetProto()->SubClass) & spellProto->EquippedItemSubClassMask))
-                return false;
-        }
-        else if (spellProto->EquippedItemClass == ITEM_CLASS_ARMOR)
-        {
-            // Check if player is wearing shield
-            Item* item = ((Player*)this)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
-            if (!item || item->IsBroken() || item->GetProto()->Class != ITEM_CLASS_ARMOR || !((1 << item->GetProto()->SubClass) & spellProto->EquippedItemSubClassMask))
-                return false;
-        }
-    }
-    // Get chance from spell
-    float chance = (float)spellProto->procChance;
-    // If in spellProcEvent exist custom chance, chance = spellProcEvent->customChance;
-    if (spellProcEvent && spellProcEvent->customChance)
-        chance = spellProcEvent->customChance;
-    // If PPM exist calculate chance from PPM
-    if (!isVictim && spellProcEvent && spellProcEvent->ppmRate != 0)
-    {
-        uint32 WeaponSpeed = GetAttackTime(attType);
-        chance = GetPPMProcChance(WeaponSpeed, spellProcEvent->ppmRate);
-    }
-    // Apply chance modifier aura
-    if (Player* modOwner = GetSpellModOwner())
-    {
-        modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_CHANCE_OF_SUCCESS, chance);
-    }
-
-    return roll_chance_f(chance);
-}
-
-SpellAuraProcResult Unit::HandleHasteAuraProc(Unit* pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 cooldown)
+struct boss_alythessAI : public ScriptedAI
 {
-    SpellEntry const* hasteSpell = triggeredByAura->GetSpellProto();
-
-    Item* castItem = triggeredByAura->GetCastItemGuid() && GetTypeId() == TYPEID_PLAYER
-                     ? ((Player*)this)->GetItemByGuid(triggeredByAura->GetCastItemGuid()) : nullptr;
-
-    uint32 triggered_spell_id = 0;
-    Unit* target = pVictim;
-    int32 basepoints0 = 0;
-
-    switch (hasteSpell->SpellFamilyName)
+    boss_alythessAI(Creature* pCreature) : ScriptedAI(pCreature),
+        m_introDialogue(aIntroDialogue)
     {
-        case SPELLFAMILY_ROGUE:
+        m_pInstance = ((instance_sunwell_plateau*)pCreature->GetInstanceData());
+        m_introDialogue.InitializeDialogueHelper(m_pInstance);
+        Reset();
+    }
+
+    ScriptedInstance* m_pInstance;
+    DialogueHelper m_introDialogue;
+
+    uint32 m_uiEnrageTimer;
+    uint32 m_uiPyrogenicsTimer;
+    uint32 m_uiConflagrationTimer;
+    uint32 m_uiBlazeTimer;
+    uint32 m_uiFlameSearTimer;
+    bool m_bDidIntro;
+
+    void Reset() override
+    {
+        m_uiEnrageTimer = 6 * MINUTE * IN_MILLISECONDS;
+        m_uiPyrogenicsTimer     = 20000;
+        m_uiConflagrationTimer  = urand(25000, 30000);
+        m_uiBlazeTimer          = 1000;
+        m_uiFlameSearTimer      = 5000;
+        m_bDidIntro = false;
+        DoCastSpellIfCan(m_creature, DARK_FLAME_AURA_ALYTHESS);
+    }
+
+    void JustReachedHome() override
+    {
+        if (m_pInstance)
         {
-            switch (hasteSpell->Id)
+            if (m_pInstance->GetData(TYPE_EREDAR_TWINS) != FAIL)
+                m_pInstance->SetData(TYPE_EREDAR_TWINS, FAIL);
+
+            // Respawn dead sister
+            if (Creature* pSister = m_pInstance->GetSingleCreatureFromStorage(NPC_SACROLASH))
             {
-                // Blade Flurry
-                case 13877:
-                case 33735:
-                {
-                    target = SelectRandomUnfriendlyTarget(pVictim);
-                    if (!target)
-                        return SPELL_AURA_PROC_FAILED;
-                    basepoints0 = damage;
-                    triggered_spell_id = 22482;
-                    break;
-                }
+                if (!pSister->isAlive())
+                    pSister->Respawn();
             }
-            break;
         }
     }
 
-    // processed charge only counting case
-    if (!triggered_spell_id)
-        return SPELL_AURA_PROC_OK;
-
-    SpellEntry const* triggerEntry = sSpellTemplate.LookupEntry<SpellEntry>(triggered_spell_id);
-
-    if (!triggerEntry)
+    void Aggro(Unit* /*pWho*/) override
     {
-        sLog.outError("Unit::HandleHasteAuraProc: Spell %u have nonexistent triggered spell %u", hasteSpell->Id, triggered_spell_id);
-        return SPELL_AURA_PROC_FAILED;
+        if (m_pInstance)
+        {
+            if (m_pInstance->GetData(TYPE_EREDAR_TWINS) != IN_PROGRESS)
+                m_pInstance->SetData(TYPE_EREDAR_TWINS, IN_PROGRESS);
+        }
     }
 
-    // default case
-    if (!target || (target != this && !target->isAlive()))
-        return SPELL_AURA_PROC_FAILED;
-
-    if (cooldown && GetTypeId() == TYPEID_PLAYER && ((Player*)this)->HasSpellCooldown(triggered_spell_id))
-        return SPELL_AURA_PROC_FAILED;
-
-    if (basepoints0)
-        CastCustomSpell(target, triggered_spell_id, &basepoints0, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-    else
-        CastSpell(target, triggered_spell_id, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-
-    if (cooldown && GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->AddSpellCooldown(triggered_spell_id, 0, time(nullptr) + cooldown);
-
-    return SPELL_AURA_PROC_OK;
-}
-
-SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 procFlag, uint32 procEx, uint32 cooldown)
-{
-    SpellEntry const* dummySpell = triggeredByAura->GetSpellProto();
-    SpellEffectIndex effIndex = triggeredByAura->GetEffIndex();
-    int32  triggerAmount = triggeredByAura->GetModifier()->m_amount;
-
-    Item* castItem = triggeredByAura->GetCastItemGuid() && GetTypeId() == TYPEID_PLAYER
-                     ? ((Player*)this)->GetItemByGuid(triggeredByAura->GetCastItemGuid()) : nullptr;
-
-    uint32 triggered_spell_id = 0;
-    Unit* target = pVictim;
-    int32  basepoints[MAX_EFFECT_INDEX] = {0, 0, 0};
-
-    switch (dummySpell->SpellFamilyName)
+    void AttackStart(Unit* pWho) override
     {
-        case SPELLFAMILY_GENERIC:
+        if (m_creature->Attack(pWho, false))
         {
-            switch (dummySpell->Id)
-            {
-                // Eye for an Eye
-                case 9799:
-                case 25988:
-                {
-                    // prevent damage back from weapon special attacks
-                    if (!procSpell || procSpell->DmgClass != SPELL_DAMAGE_CLASS_MAGIC)
-                        return SPELL_AURA_PROC_FAILED;
+            m_creature->AddThreat(pWho);
+            m_creature->SetInCombatWith(pWho);
+            pWho->SetInCombatWith(m_creature);
 
-                    // return damage % to attacker but < 50% own total health
-                    basepoints[0] = triggerAmount * int32(damage) / 100;
-                    if (basepoints[0] > (int32)GetMaxHealth() / 2)
-                        basepoints[0] = (int32)GetMaxHealth() / 2;
-
-                    triggered_spell_id = 25997;
-                    break;
-                }
-                // Sweeping Strikes
-                case 12328:
-                case 18765:
-                case 35429:
-                {
-                    // prevent chain of triggered spell from same triggered spell
-                    if (procSpell && procSpell->Id == 26654)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    target = SelectRandomUnfriendlyTarget(pVictim);
-                    if (!target)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    triggered_spell_id = 26654;
-                    break;
-                }
-                // Twisted Reflection (boss spell)
-                case 21063:
-                    triggered_spell_id = 21064;
-                    break;
-                // Unstable Power
-                case 24658:
-                {
-                    if (!procSpell || procSpell->Id == 24659)
-                        return SPELL_AURA_PROC_FAILED;
-                    // Need remove one 24659 aura
-                    RemoveAuraHolderFromStack(24659);
-                    return SPELL_AURA_PROC_OK;
-                }
-                // Restless Strength
-                case 24661:
-                {
-                    // Need remove one 24662 aura
-                    RemoveAuraHolderFromStack(24662);
-                    return SPELL_AURA_PROC_OK;
-                }
-                // Adaptive Warding (Frostfire Regalia set)
-                case 28764:
-                {
-                    if (!procSpell)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // find Mage Armor
-                    bool found = false;
-                    AuraList const& mRegenInterrupt = GetAurasByType(SPELL_AURA_MOD_MANA_REGEN_INTERRUPT);
-                    for (AuraList::const_iterator iter = mRegenInterrupt.begin(); iter != mRegenInterrupt.end(); ++iter)
-                    {
-                        if (SpellEntry const* iterSpellProto = (*iter)->GetSpellProto())
-                        {
-                            if (iterSpellProto->SpellFamilyName == SPELLFAMILY_MAGE && (iterSpellProto->SpellFamilyFlags & uint64(0x10000000)))
-                            {
-                                found = true;
-                                break;
-                            }
-                        }
-                    }
-                    if (!found)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    switch (GetFirstSchoolInMask(GetSpellSchoolMask(procSpell)))
-                    {
-                        case SPELL_SCHOOL_NORMAL:
-                        case SPELL_SCHOOL_HOLY:
-                            return SPELL_AURA_PROC_FAILED;  // ignored
-                        case SPELL_SCHOOL_FIRE:   triggered_spell_id = 28765; break;
-                        case SPELL_SCHOOL_NATURE: triggered_spell_id = 28768; break;
-                        case SPELL_SCHOOL_FROST:  triggered_spell_id = 28766; break;
-                        case SPELL_SCHOOL_SHADOW: triggered_spell_id = 28769; break;
-                        case SPELL_SCHOOL_ARCANE: triggered_spell_id = 28770; break;
-                        default:
-                            return SPELL_AURA_PROC_FAILED;
-                    }
-
-                    target = this;
-                    break;
-                }
-                // Obsidian Armor (Justice Bearer`s Pauldrons shoulder)
-                case 27539:
-                {
-                    if (!procSpell)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    switch (GetFirstSchoolInMask(GetSpellSchoolMask(procSpell)))
-                    {
-                        case SPELL_SCHOOL_NORMAL:
-                            return SPELL_AURA_PROC_FAILED;  // ignore
-                        case SPELL_SCHOOL_HOLY:   triggered_spell_id = 27536; break;
-                        case SPELL_SCHOOL_FIRE:   triggered_spell_id = 27533; break;
-                        case SPELL_SCHOOL_NATURE: triggered_spell_id = 27538; break;
-                        case SPELL_SCHOOL_FROST:  triggered_spell_id = 27534; break;
-                        case SPELL_SCHOOL_SHADOW: triggered_spell_id = 27535; break;
-                        case SPELL_SCHOOL_ARCANE: triggered_spell_id = 27540; break;
-                        default:
-                            return SPELL_AURA_PROC_FAILED;
-                    }
-
-                    target = this;
-                    break;
-                }
-                // Mana Leech (Passive) (Priest Pet Aura)
-                case 28305:
-                {
-                    // Cast on owner
-                    target = GetOwner();
-                    if (!target)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    basepoints[0] = int32(damage * 2.5f);   // manaregen
-                    triggered_spell_id = 34650;
-                    break;
-                }
-                // Mark of Malice
-                case 33493:
-                {
-                    // Cast finish spell at last charge
-                    if (triggeredByAura->GetHolder()->GetAuraCharges() > 1)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    target = this;
-                    triggered_spell_id = 33494;
-                    break;
-                }
-                // Vampiric Aura (boss spell)
-                case 38196:
-                {
-                    basepoints[0] = 3 * damage;             // 300%
-                    if (basepoints[0] < 0)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    triggered_spell_id = 31285;
-                    target = this;
-                    break;
-                }
-                // Aura of Madness (Darkmoon Card: Madness trinket)
-                //=====================================================
-                // 39511 Sociopath: +35 strength (Paladin, Rogue, Druid, Warrior)
-                // 40997 Delusional: +70 attack power (Rogue, Hunter, Paladin, Warrior, Druid)
-                // 40998 Kleptomania: +35 agility (Warrior, Rogue, Paladin, Hunter, Druid)
-                // 40999 Megalomania: +41 damage/healing (Druid, Shaman, Priest, Warlock, Mage, Paladin)
-                // 41002 Paranoia: +35 spell/melee/ranged crit strike rating (All classes)
-                // 41005 Manic: +35 haste (spell, melee and ranged) (All classes)
-                // 41009 Narcissism: +35 intellect (Druid, Shaman, Priest, Warlock, Mage, Paladin, Hunter)
-                // 41011 Martyr Complex: +35 stamina (All classes)
-                // 41406 Dementia: Every 5 seconds either gives you +5% damage/healing. (Druid, Shaman, Priest, Warlock, Mage, Paladin)
-                // 41409 Dementia: Every 5 seconds either gives you -5% damage/healing. (Druid, Shaman, Priest, Warlock, Mage, Paladin)
-                case 39446:
-                {
-                    if (GetTypeId() != TYPEID_PLAYER)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // Select class defined buff
-                    switch (getClass())
-                    {
-                        case CLASS_PALADIN:                 // 39511,40997,40998,40999,41002,41005,41009,41011,41409
-                        case CLASS_DRUID:                   // 39511,40997,40998,40999,41002,41005,41009,41011,41409
-                        {
-                            uint32 RandomSpell[] = {39511, 40997, 40998, 40999, 41002, 41005, 41009, 41011, 41409};
-                            triggered_spell_id = RandomSpell[urand(0, countof(RandomSpell) - 1)];
-                            break;
-                        }
-                        case CLASS_ROGUE:                   // 39511,40997,40998,41002,41005,41011
-                        case CLASS_WARRIOR:                 // 39511,40997,40998,41002,41005,41011
-                        {
-                            uint32 RandomSpell[] = {39511, 40997, 40998, 41002, 41005, 41011};
-                            triggered_spell_id = RandomSpell[urand(0, countof(RandomSpell) - 1)];
-                            break;
-                        }
-                        case CLASS_PRIEST:                  // 40999,41002,41005,41009,41011,41406,41409
-                        case CLASS_SHAMAN:                  // 40999,41002,41005,41009,41011,41406,41409
-                        case CLASS_MAGE:                    // 40999,41002,41005,41009,41011,41406,41409
-                        case CLASS_WARLOCK:                 // 40999,41002,41005,41009,41011,41406,41409
-                        {
-                            uint32 RandomSpell[] = {40999, 41002, 41005, 41009, 41011, 41406, 41409};
-                            triggered_spell_id = RandomSpell[urand(0, countof(RandomSpell) - 1)];
-                            break;
-                        }
-                        case CLASS_HUNTER:                  // 40997,40999,41002,41005,41009,41011,41406,41409
-                        {
-                            uint32 RandomSpell[] = {40997, 40999, 41002, 41005, 41009, 41011, 41406, 41409};
-                            triggered_spell_id = RandomSpell[urand(0, countof(RandomSpell) - 1)];
-                            break;
-                        }
-                        default:
-                            return SPELL_AURA_PROC_FAILED;
-                    }
-
-                    target = this;
-                    if (roll_chance_i(10))
-                        ((Player*)this)->Say("This is Madness!", LANG_UNIVERSAL);
-                    break;
-                }
-                // Sunwell Exalted Caster Neck (Shattered Sun Pendant of Acumen neck)
-                // cast 45479 Light's Wrath if Exalted by Aldor
-                // cast 45429 Arcane Bolt if Exalted by Scryers
-                case 45481:
-                {
-                    if (GetTypeId() != TYPEID_PLAYER)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // Get Aldor reputation rank
-                    if (((Player*)this)->GetReputationRank(932) == REP_EXALTED)
-                    {
-                        target = this;
-                        triggered_spell_id = 45479;
-                        break;
-                    }
-                    // Get Scryers reputation rank
-                    if (((Player*)this)->GetReputationRank(934) == REP_EXALTED)
-                    {
-                        // triggered at positive/self casts also, current attack target used then
-                        if (IsFriendlyTo(target))
-                        {
-                            target = getVictim();
-                            if (!target)
-                            {
-                                target = ObjectAccessor::GetUnit(*this, ((Player*)this)->GetSelectionGuid());
-                                if (!target)
-                                    return SPELL_AURA_PROC_FAILED;
-                            }
-                            if (IsFriendlyTo(target))
-                                return SPELL_AURA_PROC_FAILED;
-                        }
-
-                        triggered_spell_id = 45429;
-                        break;
-                    }
-                    return SPELL_AURA_PROC_FAILED;
-                }
-                // Sunwell Exalted Melee Neck (Shattered Sun Pendant of Might neck)
-                // cast 45480 Light's Strength if Exalted by Aldor
-                // cast 45428 Arcane Strike if Exalted by Scryers
-                case 45482:
-                {
-                    if (GetTypeId() != TYPEID_PLAYER)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // Get Aldor reputation rank
-                    if (((Player*)this)->GetReputationRank(932) == REP_EXALTED)
-                    {
-                        target = this;
-                        triggered_spell_id = 45480;
-                        break;
-                    }
-                    // Get Scryers reputation rank
-                    if (((Player*)this)->GetReputationRank(934) == REP_EXALTED)
-                    {
-                        triggered_spell_id = 45428;
-                        break;
-                    }
-                    return SPELL_AURA_PROC_FAILED;
-                }
-                // Sunwell Exalted Tank Neck (Shattered Sun Pendant of Resolve neck)
-                // cast 45431 Arcane Insight if Exalted by Aldor
-                // cast 45432 Light's Ward if Exalted by Scryers
-                case 45483:
-                {
-                    if (GetTypeId() != TYPEID_PLAYER)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // Get Aldor reputation rank
-                    if (((Player*)this)->GetReputationRank(932) == REP_EXALTED)
-                    {
-                        target = this;
-                        triggered_spell_id = 45432;
-                        break;
-                    }
-                    // Get Scryers reputation rank
-                    if (((Player*)this)->GetReputationRank(934) == REP_EXALTED)
-                    {
-                        target = this;
-                        triggered_spell_id = 45431;
-                        break;
-                    }
-                    return SPELL_AURA_PROC_FAILED;
-                }
-                // Sunwell Exalted Healer Neck (Shattered Sun Pendant of Restoration neck)
-                // cast 45478 Light's Salvation if Exalted by Aldor
-                // cast 45430 Arcane Surge if Exalted by Scryers
-                case 45484:
-                {
-                    if (GetTypeId() != TYPEID_PLAYER)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // Get Aldor reputation rank
-                    if (((Player*)this)->GetReputationRank(932) == REP_EXALTED)
-                    {
-                        target = this;
-                        triggered_spell_id = 45478;
-                        break;
-                    }
-                    // Get Scryers reputation rank
-                    if (((Player*)this)->GetReputationRank(934) == REP_EXALTED)
-                    {
-                        triggered_spell_id = 45430;
-                        break;
-                    }
-                    return SPELL_AURA_PROC_FAILED;
-                }
-                /*
-                // Sunwell Exalted Caster Neck (??? neck)
-                // cast ??? Light's Wrath if Exalted by Aldor
-                // cast ??? Arcane Bolt if Exalted by Scryers*/
-                case 46569:
-                    return SPELL_AURA_PROC_FAILED;          // old unused version
-            }
-            break;
+            // Only range attack
+            m_creature->GetMotionMaster()->MoveChase(pWho, 10.0f);
         }
-        case SPELLFAMILY_MAGE:
+    }
+
+    void KilledUnit(Unit* /*pVictim*/) override
+    {
+        DoScriptText(urand(0, 1) ? SAY_ALYTHESS_KILL_1 : SAY_ALYTHESS_KILL_2, m_creature);
+    }
+
+    void JustDied(Unit* /*pKiller*/) override
+    {
+        if (m_pInstance)
         {
-            // Magic Absorption
-            if (dummySpell->SpellIconID == 459)             // only this spell have SpellIconID == 459 and dummy aura
+            if (Creature* pSacrolash = m_pInstance->GetSingleCreatureFromStorage(NPC_SACROLASH))
             {
-                if (GetPowerType() != POWER_MANA)
-                    return SPELL_AURA_PROC_FAILED;
-
-                // mana reward
-                basepoints[0] = (triggerAmount * GetMaxPower(POWER_MANA) / 100);
-                target = this;
-                triggered_spell_id = 29442;
-                break;
-            }
-            // Master of Elements
-            if (dummySpell->SpellIconID == 1920)
-            {
-                if (!procSpell)
-                    return SPELL_AURA_PROC_FAILED;
-
-                // mana cost save
-                int32 cost = procSpell->manaCost + procSpell->ManaCostPercentage * GetCreateMana() / 100;
-                basepoints[0] = cost * triggerAmount / 100;
-                if (basepoints[0] <= 0)
-                    return SPELL_AURA_PROC_FAILED;
-
-                target = this;
-                triggered_spell_id = 29077;
-                break;
-            }
-
-            switch (dummySpell->Id)
-            {
-                // Ignite
-                case 11119:
-                case 11120:
-                case 12846:
-                case 12847:
-                case 12848:
+                if (!pSacrolash->isAlive())
                 {
-                    switch (dummySpell->Id)
-                    {
-                        case 11119: basepoints[0] = int32(0.04f * damage); break;
-                        case 11120: basepoints[0] = int32(0.08f * damage); break;
-                        case 12846: basepoints[0] = int32(0.12f * damage); break;
-                        case 12847: basepoints[0] = int32(0.16f * damage); break;
-                        case 12848: basepoints[0] = int32(0.20f * damage); break;
-                        default:
-                            sLog.outError("Unit::HandleDummyAuraProc: non handled spell id: %u (IG)", dummySpell->Id);
-                            return SPELL_AURA_PROC_FAILED;
-                    }
-
-                    triggered_spell_id = 12654;
-                    break;
+                    m_pInstance->SetData(TYPE_EREDAR_TWINS, DONE);
+                    DoScriptText(SAY_ALYTHESS_DEAD, m_creature);
                 }
-                // Combustion
-                case 11129:
-                {
-                    // last charge and crit
-                    if (triggeredByAura->GetHolder()->GetAuraCharges() <= 1 && (procEx & PROC_EX_CRITICAL_HIT))
-                    {
-                        RemoveAurasDueToSpell(28682);       //-> remove Combustion auras
-                        return SPELL_AURA_PROC_OK;          // charge counting (will removed)
-                    }
-
-                    CastSpell(this, 28682, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-                    return (procEx & PROC_EX_CRITICAL_HIT) ? SPELL_AURA_PROC_OK : SPELL_AURA_PROC_FAILED; // charge update only at crit hits, no hidden cooldowns
-                }
-            }
-            break;
-        }
-        case SPELLFAMILY_WARRIOR:
-        {
-            // Retaliation
-            if (dummySpell->IsFitToFamilyMask(uint64(0x0000000800000000)))
-            {
-                // check attack comes not from behind
-                if (pVictim->IsFacingTargetsBack(this))
-                    return SPELL_AURA_PROC_FAILED;
-
-                triggered_spell_id = 22858;
-                break;
-            }
-            // Second Wind
-            if (dummySpell->SpellIconID == 1697)
-            {
-                // only for spells and hit/crit (trigger start always) and not start from self casted spells (5530 Mace Stun Effect for example)
-                if (!procSpell || !(procEx & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)) || this == pVictim)
-                    return SPELL_AURA_PROC_FAILED;
-                // Need stun or root mechanic
-                if (!(GetAllSpellMechanicMask(procSpell) & IMMUNE_TO_ROOT_AND_STUN_MASK))
-                    return SPELL_AURA_PROC_FAILED;
-
-                switch (dummySpell->Id)
-                {
-                    case 29838: triggered_spell_id = 29842; break;
-                    case 29834: triggered_spell_id = 29841; break;
-                    default:
-                        sLog.outError("Unit::HandleDummyAuraProc: non handled spell id: %u (SW)", dummySpell->Id);
-                        return SPELL_AURA_PROC_FAILED;
-                }
-
-                target = this;
-                break;
-            }
-            break;
-        }
-        case SPELLFAMILY_WARLOCK:
-        {
-            // Seed of Corruption
-            if (dummySpell->SpellFamilyFlags & uint64(0x0000001000000000))
-            {
-                Modifier* mod = triggeredByAura->GetModifier();
-                // if damage is more than need or target die from damage deal finish spell
-                if (mod->m_amount <= (int32)damage || GetHealth() <= damage)
-                {
-                    // remember guid before aura delete
-                    ObjectGuid casterGuid = triggeredByAura->GetCasterGuid();
-
-                    // Remove aura (before cast for prevent infinite loop handlers)
-                    RemoveAurasDueToSpell(triggeredByAura->GetId());
-
-                    // Cast finish spell (triggeredByAura already not exist!)
-                    CastSpell(this, 27285, TRIGGERED_OLD_TRIGGERED, castItem, nullptr, casterGuid);
-                    return SPELL_AURA_PROC_OK;              // no hidden cooldown
-                }
-
-                // Damage counting
-                mod->m_amount -= damage;
-                return SPELL_AURA_PROC_OK;
-            }
-            // Seed of Corruption (Mobs cast) - no die req
-            if (!dummySpell->SpellFamilyFlags && dummySpell->SpellIconID == 1932)
-            {
-                Modifier* mod = triggeredByAura->GetModifier();
-                // if damage is more than need deal finish spell
-                if (mod->m_amount <= (int32)damage)
-                {
-                    // remember guid before aura delete
-                    ObjectGuid casterGuid = triggeredByAura->GetCasterGuid();
-
-                    // Remove aura (before cast for prevent infinite loop handlers)
-                    RemoveAurasDueToSpell(triggeredByAura->GetId());
-
-                    // Cast finish spell (triggeredByAura already not exist!)
-                    CastSpell(this, 32865, TRIGGERED_OLD_TRIGGERED, castItem, nullptr, casterGuid);
-                    return SPELL_AURA_PROC_OK;              // no hidden cooldown
-                }
-                // Damage counting
-                mod->m_amount -= damage;
-                return SPELL_AURA_PROC_OK;
-            }
-            switch (dummySpell->Id)
-            {
-                // Nightfall
-                case 18094:
-                case 18095:
-                {
-                    target = this;
-                    triggered_spell_id = 17941;
-                    break;
-                }
-                // Soul Leech
-                case 30293:
-                case 30295:
-                case 30296:
-                {
-                    // health
-                    basepoints[0] = int32(damage * triggerAmount / 100);
-                    target = this;
-                    triggered_spell_id = 30294;
-                    break;
-                }
-                // Shadowflame (Voidheart Raiment set bonus)
-                case 37377:
-                {
-                    triggered_spell_id = 37379;
-                    break;
-                }
-                // Pet Healing (Corruptor Raiment or Rift Stalker Armor)
-                case 37381:
-                {
-                    target = GetPet();
-                    if (!target)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // heal amount
-                    basepoints[0] = damage * triggerAmount / 100;
-                    triggered_spell_id = 37382;
-                    break;
-                }
-                // Shadowflame Hellfire (Voidheart Raiment set bonus)
-                case 39437:
-                {
-                    triggered_spell_id = 37378;
-                    break;
-                }
-            }
-            break;
-        }
-        case SPELLFAMILY_PRIEST:
-        {
-            // Vampiric Touch
-            if (dummySpell->SpellFamilyFlags & uint64(0x0000040000000000))
-            {
-                if (!pVictim || !pVictim->isAlive())
-                    return SPELL_AURA_PROC_FAILED;
-
-                // pVictim is caster of aura
-                if (triggeredByAura->GetCasterGuid() != pVictim->GetObjectGuid())
-                    return SPELL_AURA_PROC_FAILED;
-
-                // energize amount
-                basepoints[0] = triggerAmount * damage / 100;
-                pVictim->CastCustomSpell(pVictim, 34919, &basepoints[0], nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-                return SPELL_AURA_PROC_OK;                  // no hidden cooldown
-            }
-            switch (dummySpell->Id)
-            {
-                // Vampiric Embrace
-                case 15286:
-                {
-                    if (!pVictim || !pVictim->isAlive())
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // pVictim is caster of aura
-                    if (triggeredByAura->GetCasterGuid() != pVictim->GetObjectGuid())
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // heal amount
-                    basepoints[0] = triggerAmount * damage / 100;
-                    pVictim->CastCustomSpell(pVictim, 15290, &basepoints[0], nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-                    return SPELL_AURA_PROC_OK;              // no hidden cooldown
-                }
-                // Priest Tier 6 Trinket (Ashtongue Talisman of Acumen)
-                case 40438:
-                {
-                    // Shadow Word: Pain
-                    if (procSpell->SpellFamilyFlags & uint64(0x0000000000008000))
-                        triggered_spell_id = 40441;
-                    // Renew
-                    else if (procSpell->SpellFamilyFlags & uint64(0x0000000000000010))
-                        triggered_spell_id = 40440;
-                    else
-                        return SPELL_AURA_PROC_FAILED;
-
-                    target = this;
-                    break;
-                }
-                // Oracle Healing Bonus ("Garments of the Oracle" set)
-                case 26169:
-                {
-                    // heal amount
-                    basepoints[0] = int32(damage * 10 / 100);
-                    target = this;
-                    triggered_spell_id = 26170;
-                    break;
-                }
-                // Frozen Shadoweave (Shadow's Embrace set) warning! its not only priest set
-                case 39372:
-                {
-                    if (!procSpell || (GetSpellSchoolMask(procSpell) & (SPELL_SCHOOL_MASK_FROST | SPELL_SCHOOL_MASK_SHADOW)) == 0)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // heal amount
-                    basepoints[0] = damage * triggerAmount / 100;
-                    target = this;
-                    triggered_spell_id = 39373;
-                    break;
-                }
-                // Greater Heal (Vestments of Faith (Priest Tier 3) - 4 pieces bonus)
-                case 28809:
-                {
-                    triggered_spell_id = 28810;
-                    break;
-                }
-            }
-            break;
-        }
-        case SPELLFAMILY_DRUID:
-        {
-            switch (dummySpell->Id)
-            {
-                // Healing Touch (Dreamwalker Raiment set)
-                case 28719:
-                {
-                    // mana back
-                    basepoints[0] = int32(procSpell->manaCost * 30 / 100);
-                    target = this;
-                    triggered_spell_id = 28742;
-                    break;
-                }
-                // Healing Touch Refund (Idol of Longevity trinket)
-                case 28847:
-                {
-                    target = this;
-                    triggered_spell_id = 28848;
-                    break;
-                }
-                // Mana Restore (Malorne Raiment set / Malorne Regalia set)
-                case 37288:
-                case 37295:
-                {
-                    target = this;
-                    triggered_spell_id = 37238;
-                    break;
-                }
-                // Druid Tier 6 Trinket
-                case 40442:
-                {
-                    float  chance;
-
-                    // Starfire
-                    if (procSpell->SpellFamilyFlags & uint64(0x0000000000000004))
-                    {
-                        triggered_spell_id = 40445;
-                        chance = 25.0f;
-                    }
-                    // Rejuvenation
-                    else if (procSpell->SpellFamilyFlags & uint64(0x0000000000000010))
-                    {
-                        triggered_spell_id = 40446;
-                        chance = 25.0f;
-                    }
-                    // Mangle (Bear) and Mangle (Cat)
-                    else if (procSpell->SpellFamilyFlags & uint64(0x0000044000000000))
-                    {
-                        triggered_spell_id = 40452;
-                        chance = 40.0f;
-                    }
-                    else
-                        return SPELL_AURA_PROC_FAILED;
-
-                    if (!roll_chance_f(chance))
-                        return SPELL_AURA_PROC_FAILED;
-
-                    target = this;
-                    break;
-                }
-                // Maim Interrupt
-                case 44835:
-                {
-                    // Deadly Interrupt Effect
-                    triggered_spell_id = 32747;
-                    break;
-                }
-            }
-            break;
-        }
-        case SPELLFAMILY_ROGUE:
-        {
-            switch (dummySpell->Id)
-            {
-                // Clean Escape
-                case 23582:
-                    // triggered spell have same masks and etc with main Vanish spell
-                    if (!procSpell || procSpell->Effect[EFFECT_INDEX_0] == SPELL_EFFECT_NONE)
-                        return SPELL_AURA_PROC_FAILED;
-                    triggered_spell_id = 23583;
-                    break;
-                // Deadly Throw Interrupt
-                case 32748:
-                {
-                    // Prevent cast Deadly Throw Interrupt on self from last effect (apply dummy) of Deadly Throw
-                    if (this == pVictim)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    triggered_spell_id = 32747;
-                    break;
-                }
-            }
-            // Quick Recovery
-            if (dummySpell->SpellIconID == 2116)
-            {
-                if (!procSpell)
-                    return SPELL_AURA_PROC_FAILED;
-
-                // energy cost save
-                basepoints[0] = procSpell->manaCost * triggerAmount / 100;
-                if (basepoints[0] <= 0)
-                    return SPELL_AURA_PROC_FAILED;
-
-                target = this;
-                triggered_spell_id = 31663;
-                break;
-            }
-            break;
-        }
-        case SPELLFAMILY_HUNTER:
-        {
-            // Thrill of the Hunt
-            if (dummySpell->SpellIconID == 2236)
-            {
-                if (!procSpell)
-                    return SPELL_AURA_PROC_FAILED;
-
-                // mana cost save
-                basepoints[0] = procSpell->manaCost * 40 / 100;
-                if (basepoints[0] <= 0)
-                    return SPELL_AURA_PROC_FAILED;
-
-                target = this;
-                triggered_spell_id = 34720;
-                break;
-            }
-            break;
-        }
-        case SPELLFAMILY_PALADIN:
-        {
-            // Seal of Righteousness - melee proc dummy
-            if ((dummySpell->SpellFamilyFlags & uint64(0x000000008000000)) && triggeredByAura->GetEffIndex() == EFFECT_INDEX_0)
-            {
-                if (GetTypeId() != TYPEID_PLAYER)
-                    return SPELL_AURA_PROC_FAILED;
-
-                uint32 spellId;
-                switch (triggeredByAura->GetId())
-                {
-                    case 21084: spellId = 25742; break;     // Rank 1
-                    case 20287: spellId = 25740; break;     // Rank 2
-                    case 20288: spellId = 25739; break;     // Rank 3
-                    case 20289: spellId = 25738; break;     // Rank 4
-                    case 20290: spellId = 25737; break;     // Rank 5
-                    case 20291: spellId = 25736; break;     // Rank 6
-                    case 20292: spellId = 25735; break;     // Rank 7
-                    case 20293: spellId = 25713; break;     // Rank 8
-                    case 27155: spellId = 27156; break;     // Rank 9
-                    default:
-                        sLog.outError("Unit::HandleDummyAuraProc: non handled possibly SoR (Id = %u)", triggeredByAura->GetId());
-                        return SPELL_AURA_PROC_FAILED;
-                }
-                Item* item = ((Player*)this)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-                float speed = (item ? item->GetProto()->Delay : BASE_ATTACK_TIME) / 1000.0f;
-
-                float damageBasePoints;
-                if (item && item->GetProto()->InventoryType == INVTYPE_2HWEAPON)
-                    // two hand weapon
-                    damageBasePoints = 1.20f * triggerAmount * 1.2f * 1.03f * speed / 100.0f + 1;
                 else
-                    // one hand weapon/no weapon
-                    damageBasePoints = 0.85f * ceil(triggerAmount * 1.2f * 1.03f * speed / 100.0f) - 1;
-
-                int32 damagePoint = int32(damageBasePoints + 0.03f * (GetWeaponDamageRange(BASE_ATTACK, MINDAMAGE) + GetWeaponDamageRange(BASE_ATTACK, MAXDAMAGE)) / 2.0f) + 1;
-
-                // apply damage bonuses manually
-                if (damagePoint >= 0)
                 {
-                    damagePoint = SpellDamageBonusDone(pVictim, dummySpell, damagePoint, SPELL_DIRECT_DAMAGE);
-                    damagePoint = pVictim->SpellDamageBonusTaken(this, dummySpell, damagePoint, SPELL_DIRECT_DAMAGE);
-                }
-
-                CastCustomSpell(pVictim, spellId, &damagePoint, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, nullptr, triggeredByAura);
-                return SPELL_AURA_PROC_OK;                  // no hidden cooldown
-            }
-            // Seal of Blood do damage trigger
-            if (dummySpell->SpellFamilyFlags & uint64(0x0000040000000000))
-            {
-                switch (triggeredByAura->GetEffIndex())
-                {
-                    case 0:
-                        triggered_spell_id = 31893;
-                        break;
-                    case 1:
-                    {
-                        // damage
-                        basepoints[0] = triggerAmount * damage / 100;
-                        target = this;
-                        triggered_spell_id = 32221;
-                        break;
-                    }
-                    default:
-                        break;
+                    // Remove loot flag and cast empower
+                    m_creature->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
+                    DoScriptText(SAY_SACROLASH_EMPOWER, pSacrolash);
+                    pSacrolash->InterruptNonMeleeSpells(true);
+                    pSacrolash->CastSpell(pSacrolash, DARK_FLAME_AURA_ALYTHESS, TRIGGERED_NONE);
+                    pSacrolash->CastSpell(pSacrolash, SPELL_EMPOWER, TRIGGERED_NONE);
                 }
             }
-
-            switch (dummySpell->Id)
-            {
-                // Holy Power (Redemption Armor set)
-                case 28789:
-                {
-                    if (!pVictim)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // Set class defined buff
-                    switch (pVictim->getClass())
-                    {
-                        case CLASS_PALADIN:
-                        case CLASS_PRIEST:
-                        case CLASS_SHAMAN:
-                        case CLASS_DRUID:
-                            triggered_spell_id = 28795;     // Increases the friendly target's mana regeneration by $s1 per 5 sec. for $d.
-                            break;
-                        case CLASS_MAGE:
-                        case CLASS_WARLOCK:
-                            triggered_spell_id = 28793;     // Increases the friendly target's spell damage and healing by up to $s1 for $d.
-                            break;
-                        case CLASS_HUNTER:
-                        case CLASS_ROGUE:
-                            triggered_spell_id = 28791;     // Increases the friendly target's attack power by $s1 for $d.
-                            break;
-                        case CLASS_WARRIOR:
-                            triggered_spell_id = 28790;     // Increases the friendly target's armor
-                            break;
-                        default:
-                            return SPELL_AURA_PROC_FAILED;
-                    }
-                    break;
-                }
-                // Spiritual Attunement
-                case 31785:
-                case 33776:
-                {
-                    // if healed by another unit (pVictim)
-                    if (this == pVictim)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // dont count overhealing
-                    uint32 diff = GetMaxHealth() - GetHealth();
-                    if (!diff)
-                        return SPELL_AURA_PROC_FAILED;
-                    basepoints[0] = triggerAmount * (damage > diff ? diff : damage) / 100;
-                    target = this;
-                    triggered_spell_id = 31786;
-                    break;
-                }
-                // Seal of Vengeance (damage calc on apply aura)
-                case 31801:
-                {
-                    if (effIndex != EFFECT_INDEX_0)         // effect 1,2 used by seal unleashing code
-                        return SPELL_AURA_PROC_FAILED;
-
-                    triggered_spell_id = 31803;
-
-                    // Since Patch 2.2.0 Seal of Vengeance does additional damage against fully stacked targets
-                    // Add 5-stack effect from Holy Vengeance
-                    const SpellAuraHolder* existing = target->GetSpellAuraHolder(31803, GetObjectGuid());
-                    if (existing && existing->GetStackAmount() >= 5)
-                        CastSpell(target, 42463, TRIGGERED_OLD_TRIGGERED, nullptr, triggeredByAura);
-                    break;
-                }
-                // Paladin Tier 6 Trinket (Ashtongue Talisman of Zeal)
-                case 40470:
-                {
-                    if (!procSpell)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    float  chance;
-
-                    // Flash of light/Holy light
-                    if (procSpell->SpellFamilyFlags & uint64(0x00000000C0000000))
-                    {
-                        triggered_spell_id = 40471;
-                        chance = 15.0f;
-                    }
-                    // Judgement
-                    else if (procSpell->SpellFamilyFlags & uint64(0x0000000000800000))
-                    {
-                        triggered_spell_id = 40472;
-                        chance = 50.0f;
-                    }
-                    else
-                        return SPELL_AURA_PROC_FAILED;
-
-                    if (!roll_chance_f(chance))
-                        return SPELL_AURA_PROC_FAILED;
-
-                    break;
-                }
-            }
-            break;
-        }
-        case SPELLFAMILY_SHAMAN:
-        {
-            switch (dummySpell->Id)
-            {
-                // Totemic Power (The Earthshatterer set)
-                case 28823:
-                {
-                    if (!pVictim)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // Set class defined buff
-                    switch (pVictim->getClass())
-                    {
-                        case CLASS_PALADIN:
-                        case CLASS_PRIEST:
-                        case CLASS_SHAMAN:
-                        case CLASS_DRUID:
-                            triggered_spell_id = 28824;     // Increases the friendly target's mana regeneration by $s1 per 5 sec. for $d.
-                            break;
-                        case CLASS_MAGE:
-                        case CLASS_WARLOCK:
-                            triggered_spell_id = 28825;     // Increases the friendly target's spell damage and healing by up to $s1 for $d.
-                            break;
-                        case CLASS_HUNTER:
-                        case CLASS_ROGUE:
-                            triggered_spell_id = 28826;     // Increases the friendly target's attack power by $s1 for $d.
-                            break;
-                        case CLASS_WARRIOR:
-                            triggered_spell_id = 28827;     // Increases the friendly target's armor
-                            break;
-                        default:
-                            return SPELL_AURA_PROC_FAILED;
-                    }
-                    break;
-                }
-                // Lesser Healing Wave (Totem of Flowing Water Relic)
-                case 28849:
-                {
-                    target = this;
-                    triggered_spell_id = 28850;
-                    break;
-                }
-                // Windfury Weapon (Passive) 1-5 Ranks
-                case 33757:
-                {
-                    if (GetTypeId() != TYPEID_PLAYER)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    if (!castItem || !castItem->IsEquipped())
-                        return SPELL_AURA_PROC_FAILED;
-
-                    // custom cooldown processing case
-                    if (cooldown && ((Player*)this)->HasSpellCooldown(dummySpell->Id))
-                        return SPELL_AURA_PROC_FAILED;
-
-                    uint32 spellId;
-                    switch (castItem->GetEnchantmentId(EnchantmentSlot(TEMP_ENCHANTMENT_SLOT)))
-                    {
-                        case 283: spellId = 33757; break;   // 1 Rank
-                        case 284: spellId = 33756; break;   // 2 Rank
-                        case 525: spellId = 33755; break;   // 3 Rank
-                        case 1669: spellId = 33754; break;  // 4 Rank
-                        case 2636: spellId = 33727; break;  // 5 Rank
-                        default:
-                        {
-                            sLog.outError("Unit::HandleDummyAuraProc: non handled item enchantment (rank?) %u for spell id: %u (Windfury)",
-                                          castItem->GetEnchantmentId(EnchantmentSlot(TEMP_ENCHANTMENT_SLOT)), dummySpell->Id);
-                            return SPELL_AURA_PROC_FAILED;
-                        }
-                    }
-
-                    SpellEntry const* windfurySpellEntry = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
-                    if (!windfurySpellEntry)
-                    {
-                        sLog.outError("Unit::HandleDummyAuraProc: nonexistent spell id: %u (Windfury)", spellId);
-                        return SPELL_AURA_PROC_FAILED;
-                    }
-
-                    int32 extra_attack_power = CalculateSpellDamage(pVictim, windfurySpellEntry, EFFECT_INDEX_0);
-
-                    // Off-Hand case
-                    if (castItem->GetSlot() == EQUIPMENT_SLOT_OFFHAND)
-                    {
-                        // Value gained from additional AP
-                        basepoints[0] = int32(extra_attack_power / 14.0f * GetAttackTime(OFF_ATTACK) / 1000 / 2);
-                        triggered_spell_id = 33750;
-                    }
-                    // Main-Hand case
-                    else
-                    {
-                        // Value gained from additional AP
-                        basepoints[0] = int32(extra_attack_power / 14.0f * GetAttackTime(BASE_ATTACK) / 1000);
-                        triggered_spell_id = 25504;
-                    }
-
-                    // apply cooldown before cast to prevent processing itself
-                    if (cooldown)
-                        ((Player*)this)->AddSpellCooldown(dummySpell->Id, 0, time(nullptr) + cooldown);
-
-                    // Attack Twice
-                    for (uint32 i = 0; i < 2; ++i)
-                        CastCustomSpell(pVictim, triggered_spell_id, &basepoints[0], nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-
-                    return SPELL_AURA_PROC_OK;
-                }
-                // Shaman Tier 6 Trinket
-                case 40463:
-                {
-                    if (!procSpell)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    float  chance;
-                    if (procSpell->SpellFamilyFlags & uint64(0x0000000000000001))
-                    {
-                        triggered_spell_id = 40465;         // Lightning Bolt
-                        chance = 15.0f;
-                    }
-                    else if (procSpell->SpellFamilyFlags & uint64(0x0000000000000080))
-                    {
-                        triggered_spell_id = 40465;         // Lesser Healing Wave
-                        chance = 10.0f;
-                    }
-                    else if (procSpell->SpellFamilyFlags & uint64(0x0000001000000000))
-                    {
-                        triggered_spell_id = 40466;         // Stormstrike
-                        chance = 50.0f;
-                    }
-                    else
-                        return SPELL_AURA_PROC_FAILED;
-
-                    if (!roll_chance_f(chance))
-                        return SPELL_AURA_PROC_FAILED;
-
-                    target = this;
-                    break;
-                }
-            }
-
-            // Earth Shield
-            if (dummySpell->SpellFamilyFlags & uint64(0x0000040000000000))
-            {
-                if (GetTypeId() != TYPEID_PLAYER)
-                    return SPELL_AURA_PROC_FAILED;
-
-                // heal
-                basepoints[0] = triggerAmount;
-                target = this;
-                triggered_spell_id = 379;
-                break;
-            }
-            // Lightning Overload
-            if (dummySpell->SpellIconID == 2018)            // only this spell have SpellFamily Shaman SpellIconID == 2018 and dummy aura
-            {
-                if (!procSpell || GetTypeId() != TYPEID_PLAYER || !pVictim)
-                    return SPELL_AURA_PROC_FAILED;
-
-                // custom cooldown processing case
-                if (cooldown && GetTypeId() == TYPEID_PLAYER && ((Player*)this)->HasSpellCooldown(dummySpell->Id))
-                    return SPELL_AURA_PROC_FAILED;
-
-                uint32 spellId;
-                // Every Lightning Bolt and Chain Lightning spell have duplicate vs half damage and zero cost
-                switch (procSpell->Id)
-                {
-                    // Lightning Bolt
-                    case   403: spellId = 45284; break;     // Rank  1
-                    case   529: spellId = 45286; break;     // Rank  2
-                    case   548: spellId = 45287; break;     // Rank  3
-                    case   915: spellId = 45288; break;     // Rank  4
-                    case   943: spellId = 45289; break;     // Rank  5
-                    case  6041: spellId = 45290; break;     // Rank  6
-                    case 10391: spellId = 45291; break;     // Rank  7
-                    case 10392: spellId = 45292; break;     // Rank  8
-                    case 15207: spellId = 45293; break;     // Rank  9
-                    case 15208: spellId = 45294; break;     // Rank 10
-                    case 25448: spellId = 45295; break;     // Rank 11
-                    case 25449: spellId = 45296; break;     // Rank 12
-                    // Chain Lightning
-                    case   421: spellId = 45297; break;     // Rank  1
-                    case   930: spellId = 45298; break;     // Rank  2
-                    case  2860: spellId = 45299; break;     // Rank  3
-                    case 10605: spellId = 45300; break;     // Rank  4
-                    case 25439: spellId = 45301; break;     // Rank  5
-                    case 25442: spellId = 45302; break;     // Rank  6
-                    default:
-                        sLog.outError("Unit::HandleDummyAuraProc: non handled spell id: %u (LO)", procSpell->Id);
-                        return SPELL_AURA_PROC_FAILED;
-                }
-
-                // Remove cooldown (Chain Lightning - have Category Recovery time)
-                if (procSpell->SpellFamilyFlags & uint64(0x0000000000000002))
-                    ((Player*)this)->RemoveSpellCooldown(spellId);
-
-                CastSpell(pVictim, spellId, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-
-                if (cooldown && GetTypeId() == TYPEID_PLAYER)
-                    ((Player*)this)->AddSpellCooldown(dummySpell->Id, 0, time(nullptr) + cooldown);
-
-                return SPELL_AURA_PROC_OK;
-            }
-            break;
-        }
-        default:
-            break;
-    }
-
-    // processed charge only counting case
-    if (!triggered_spell_id)
-        return SPELL_AURA_PROC_OK;
-
-    SpellEntry const* triggerEntry = sSpellTemplate.LookupEntry<SpellEntry>(triggered_spell_id);
-
-    if (!triggerEntry)
-    {
-        sLog.outError("Unit::HandleDummyAuraProc: Spell %u have nonexistent triggered spell %u", dummySpell->Id, triggered_spell_id);
-        return SPELL_AURA_PROC_FAILED;
-    }
-
-    // default case
-    if (!target || (target != this && !target->isAlive()))
-        return SPELL_AURA_PROC_FAILED;
-
-    if (cooldown && GetTypeId() == TYPEID_PLAYER && ((Player*)this)->HasSpellCooldown(triggered_spell_id))
-        return SPELL_AURA_PROC_FAILED;
-
-    if (basepoints[EFFECT_INDEX_0] || basepoints[EFFECT_INDEX_1] || basepoints[EFFECT_INDEX_2])
-        CastCustomSpell(target, triggered_spell_id,
-                        basepoints[EFFECT_INDEX_0] ? &basepoints[EFFECT_INDEX_0] : nullptr,
-                        basepoints[EFFECT_INDEX_1] ? &basepoints[EFFECT_INDEX_1] : nullptr,
-                        basepoints[EFFECT_INDEX_2] ? &basepoints[EFFECT_INDEX_2] : nullptr,
-                        TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-    else
-        CastSpell(target, triggered_spell_id, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-
-    if (cooldown && GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->AddSpellCooldown(triggered_spell_id, 0, time(nullptr) + cooldown);
-
-    return SPELL_AURA_PROC_OK;
-}
-
-SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(Unit* pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 procFlags, uint32 procEx, uint32 cooldown)
-{
-    // Get triggered aura spell info
-    SpellEntry const* auraSpellInfo = triggeredByAura->GetSpellProto();
-
-    // Basepoints of trigger aura
-    int32 triggerAmount = triggeredByAura->GetModifier()->m_amount;
-
-    // Set trigger spell id, target, custom basepoints
-    uint32 trigger_spell_id = auraSpellInfo->EffectTriggerSpell[triggeredByAura->GetEffIndex()];
-    Unit*  target = nullptr;
-    int32  basepoints[MAX_EFFECT_INDEX] = {0, 0, 0};
-
-    if (triggeredByAura->GetModifier()->m_auraname == SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE)
-        basepoints[0] = triggerAmount;
-
-    Item* castItem = triggeredByAura->GetCastItemGuid() && GetTypeId() == TYPEID_PLAYER
-                     ? ((Player*)this)->GetItemByGuid(triggeredByAura->GetCastItemGuid()) : nullptr;
-
-    // Try handle unknown trigger spells
-    // Custom requirements (not listed in procEx) Warning! damage dealing after this
-    // Custom triggered spells
-    switch (auraSpellInfo->SpellFamilyName)
-    {
-        case SPELLFAMILY_GENERIC:
-            switch (auraSpellInfo->Id)
-            {
-                // case 191:                            // Elemental Response
-                //    switch (procSpell->School)
-                //    {
-                //        case SPELL_SCHOOL_FIRE:  trigger_spell_id = 34192; break;
-                //        case SPELL_SCHOOL_FROST: trigger_spell_id = 34193; break;
-                //        case SPELL_SCHOOL_ARCANE:trigger_spell_id = 34194; break;
-                //        case SPELL_SCHOOL_NATURE:trigger_spell_id = 34195; break;
-                //        case SPELL_SCHOOL_SHADOW:trigger_spell_id = 34196; break;
-                //        case SPELL_SCHOOL_HOLY:  trigger_spell_id = 34197; break;
-                //        case SPELL_SCHOOL_NORMAL:trigger_spell_id = 34198; break;
-                //    }
-                //    break;
-                // case 5301:  break;                   // Defensive State (DND)
-                // case 7137:  break:                   // Shadow Charge (Rank 1)
-                // case 7377:  break:                   // Take Immune Periodic Damage <Not Working>
-                // case 13358: break;                   // Defensive State (DND)
-                // case 16092: break;                   // Defensive State (DND)
-                // case 18943: break;                   // Double Attack
-                // case 19194: break;                   // Double Attack
-                // case 19817: break;                   // Double Attack
-                // case 19818: break;                   // Double Attack
-                // case 22835: break;                   // Drunken Rage
-                //    trigger_spell_id = 14822; break;
-                case 23780:                                 // Aegis of Preservation (Aegis of Preservation trinket)
-                    trigger_spell_id = 23781;
-                    break;
-                case 24905:                                 // Moonkin Form (Passive)
-                {
-                    // Elune's Touch (instead non-existed triggered spell) 30% from AP
-                    trigger_spell_id = 33926;
-                    basepoints[0] = GetTotalAttackPowerValue(BASE_ATTACK) * 30 / 100;
-                    target = this;
-                    break;
-                }
-                // case 24949: break;                       // Defensive State 2 (DND)
-                case 27522:                                 // Mana Drain Trigger
-                case 40336:                                 // Mana Drain Trigger
-                case 46939:                                 // Black Bow of the Betrayer
-                    // On successful melee or ranged attack gain 8 mana and if possible drain 8 mana from the target.
-                    if (isAlive())
-                        CastSpell(this, 29471, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-                    if (pVictim && pVictim->isAlive())
-                        CastSpell(pVictim, 27526, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-                    return SPELL_AURA_PROC_OK;
-                case 31255:                                 // Deadly Swiftness (Rank 1)
-                {
-                    // whenever you deal damage to a target who is below 20% health.
-                    if (pVictim->GetHealth() > pVictim->GetMaxHealth() / 5)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    target = this;
-                    trigger_spell_id = 22588;
-                    break;
-                }
-                // case 33207: break;                       // Gossip NPC Periodic - Fidget
-                case 33896:                                 // Desperate Defense (Stonescythe Whelp, Stonescythe Alpha, Stonescythe Ambusher)
-                    trigger_spell_id = 33898;
-                    break;
-                // case 34082: break;                   // Advantaged State (DND)
-                // case 34783: break:                   // Spell Reflection
-                // case 35205: break:                   // Vanish
-                // case 35321: break;                   // Gushing Wound
-                // case 36096: break:                   // Spell Reflection
-                // case 36207: break:                   // Steal Weapon
-                // case 36576: break:                   // Shaleskin (Shaleskin Flayer, Shaleskin Ripper) 30023 trigger
-                // case 37030: break;                   // Chaotic Temperament
-                // case 38363: break;                   // Gushing Wound
-                // case 39215: break;                   // Gushing Wound
-                // case 40250: break;                   // Improved Duration
-                // case 40329: break;                   // Demo Shout Sensor
-                // case 40364: break;                   // Entangling Roots Sensor
-                // case 41054: break;                   // Copy Weapon
-                //    trigger_spell_id = 41055; break;
-                // case 41248: break;                   // Consuming Strikes
-                //    trigger_spell_id = 41249; break;
-                // case 43453: break:                   // Rune Ward
-                // case 43504: break;                   // Alterac Valley OnKill Proc Aura
-                case 43820:                                 // Charm of the Witch Doctor (Amani Charm of the Witch Doctor trinket)
-                {
-                    // Pct value stored in dummy
-                    basepoints[0] = pVictim->GetCreateHealth() * auraSpellInfo->CalculateSimpleValue(EFFECT_INDEX_1) / 100;
-                    target = pVictim;
-                    break;
-                }
-                // case 44326: break:                       // Pure Energy Passive
-                // case 44526: break;                       // Hate Monster (Spar) (30 sec)
-                // case 44527: break;                       // Hate Monster (Spar Buddy) (30 sec)
-                // case 44819: break;                       // Hate Monster (Spar Buddy) (>30% Health)
-                // case 44820: break;                       // Hate Monster (Spar) (<30%)
-                case 45057:                                 // Evasive Maneuvers (Commendation of Kael`thas trinket)
-                    // reduce you below $s1% health (in fact in this specific case can proc from any attack while health in result less $s1%)
-                    if (int32(GetHealth()) - int32(damage) >= int32(GetMaxHealth() * triggerAmount / 100))
-                        return SPELL_AURA_PROC_FAILED;
-                    break;
-                    // case 45205: break;                   // Copy Offhand Weapon
-                    // case 45903: break:                   // Offensive State
-                    // case 46146: break:                   // [PH] Ahune  Spanky Hands
-                    // case 46146: break;                   // [PH] Ahune  Spanky Hands
-                    // case 50051: break;                   // Ethereal Pet Aura
-                    
-                    
-                case 45343: // Dark Flame Aura              procs from alythess
-
-                    if(!procSpell)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    if (this->HasAura(45345))                   // SPELL_DARK_FLAME on player
-                        return SPELL_AURA_PROC_FAILED;
-
-                    if (procSpell->Id == 46771                  // flame sear
-                            || procSpell->Id == 45342           // or conflag
-                            || procSpell->Id == 45235)          // or blaze
-
-                    /*if (procSpell->SchoolMask == SPELL_SCHOOL_MASK_FIRE
-                        && procSpell->Id != SPELL_FLAME_TOUCHED)    // to avoid having flame touched increasing stacks of flame touched*/
-                    {
-                        cooldown = 1;
-                        target = this;
-                        if (this->HasAura(45347))
-                        {
-                            this->RemoveAurasDueToSpell(45347);
-                            trigger_spell_id = 45345;
-                        }
-                        else
-                            trigger_spell_id = 45348;
-                    }
-
-                    break;
-
-                case 47300:                          // Dark Flame Aura proc from scarolash
-
-                    if(!procSpell)
-                        return SPELL_AURA_PROC_FAILED;
-
-                    if (this->HasAura(45345))       // SPELL_DARK_FLAME on player
-                        return SPELL_AURA_PROC_FAILED;
-
-                    if (procSpell->Id == 45256      // confunding blow
-                        || procSpell->Id ==45248    // shadow blades
-                        || procSpell->Id ==45329)   // shadow nova
-                    {
-                        cooldown = 1;
-                        target = this;
-                        if (this->HasAura(45348))
-                        {
-                            this->RemoveAurasDueToSpell(45348);
-                            trigger_spell_id = 45345;
-                        }
-                        else
-                            trigger_spell_id = 45347;
-                    }
-
-                    break;
-
-                    
-                    break;
-            }
-            break;
-        case SPELLFAMILY_MAGE:
-            if (auraSpellInfo->SpellIconID == 2127)         // Blazing Speed
-            {
-                switch (auraSpellInfo->Id)
-                {
-                    case 31641:  // Rank 1
-                    case 31642:  // Rank 2
-                        trigger_spell_id = 31643;
-                        break;
-                    default:
-                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u miss possibly Blazing Speed", auraSpellInfo->Id);
-                        return SPELL_AURA_PROC_FAILED;
-                }
-            }
-            else if (auraSpellInfo->Id == 26467)            // Persistent Shield (Scarab Brooch trinket)
-            {
-                // This spell originally trigger 13567 - Dummy Trigger (vs dummy effect)
-                basepoints[0] = damage * 15 / 100;
-                target = pVictim;
-                trigger_spell_id = 26470;
-            }
-            break;
-        case SPELLFAMILY_WARRIOR:
-            // Deep Wounds (replace triggered spells to directly apply DoT), dot spell have familyflags
-            if (!auraSpellInfo->SpellFamilyFlags && auraSpellInfo->SpellIconID == 243)
-            {
-                float weaponDamage;
-                // DW should benefit of attack power, damage percent mods etc.
-                // TODO: check if using offhand damage is correct and if it should be divided by 2
-                if (haveOffhandWeapon() && getAttackTimer(BASE_ATTACK) > getAttackTimer(OFF_ATTACK))
-                    weaponDamage = (GetFloatValue(UNIT_FIELD_MINOFFHANDDAMAGE) + GetFloatValue(UNIT_FIELD_MAXOFFHANDDAMAGE)) / 2;
-                else
-                    weaponDamage = (GetFloatValue(UNIT_FIELD_MINDAMAGE) + GetFloatValue(UNIT_FIELD_MAXDAMAGE)) / 2;
-
-                switch (auraSpellInfo->Id)
-                {
-                    case 12834: basepoints[0] = int32(weaponDamage * 0.2f); break;
-                    case 12849: basepoints[0] = int32(weaponDamage * 0.4f); break;
-                    case 12867: basepoints[0] = int32(weaponDamage * 0.6f); break;
-                    // Impossible case
-                    default:
-                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: DW unknown spell rank %u", auraSpellInfo->Id);
-                        return SPELL_AURA_PROC_FAILED;
-                }
-
-                // 1 tick/sec * 6 sec = 6 ticks
-                basepoints[0] /= 6;
-
-                trigger_spell_id = 12721;
-                break;
-            }
-            // Rampage
-            else if (auraSpellInfo->SpellIconID == 2006 && auraSpellInfo->IsFitToFamilyMask(uint64(0x0000000000100000)))
-            {
-                switch (auraSpellInfo->Id)
-                {
-                    case 29801: trigger_spell_id = 30029; break;       // Rank 1
-                    case 30030: trigger_spell_id = 30031; break;       // Rank 2
-                    case 30033: trigger_spell_id = 30032; break;       // Rank 3
-                    default:
-                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u not handled in Rampage", auraSpellInfo->Id);
-                        return SPELL_AURA_PROC_FAILED;
-                }
-            }
-            break;
-        case SPELLFAMILY_WARLOCK:
-        {
-            // Pyroclasm
-            if (auraSpellInfo->SpellIconID == 1137)
-            {
-                if (!pVictim || !pVictim->isAlive() || pVictim == this || procSpell == nullptr)
-                    return SPELL_AURA_PROC_FAILED;
-                // Calculate spell tick count for spells
-                uint32 tick = 1; // Default tick = 1
-
-                // Hellfire have 15 tick
-                if (procSpell->SpellFamilyFlags & uint64(0x0000000000000040))
-                    tick = 15;
-                // Rain of Fire have 4 tick
-                else if (procSpell->SpellFamilyFlags & uint64(0x0000000000000020))
-                    tick = 4;
-
-                // Calculate chance = baseChance / tick
-                float chance = 0;
-                switch (auraSpellInfo->Id)
-                {
-                    case 18096: chance = 13.0f / tick; break;
-                    case 18073: chance = 26.0f / tick; break;
-                }
-                // Roll chance
-                if (!roll_chance_f(chance))
-                    return SPELL_AURA_PROC_FAILED;
-
-                trigger_spell_id = 18093;
-            }
-            // Drain Soul
-            else if (auraSpellInfo->SpellFamilyFlags & uint64(0x0000000000004000))
-            {
-                Unit::AuraList const& mAddFlatModifier = GetAurasByType(SPELL_AURA_ADD_FLAT_MODIFIER);
-                for (Unit::AuraList::const_iterator i = mAddFlatModifier.begin(); i != mAddFlatModifier.end(); ++i)
-                {
-                    if ((*i)->GetModifier()->m_miscvalue == SPELLMOD_CHANCE_OF_SUCCESS && (*i)->GetSpellProto()->SpellIconID == 113)
-                    {
-                        // basepoints of trigger spell stored in dummyeffect of spellProto
-                        int32 basepoints2 = GetMaxPower(POWER_MANA) * (*i)->GetSpellProto()->CalculateSimpleValue(EFFECT_INDEX_2) / 100;
-                        CastCustomSpell(this, 18371, &basepoints2, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-                        break;
-                    }
-                }
-                // Not remove charge (aura removed on death in any cases)
-                // Need for correct work Drain Soul SPELL_AURA_CHANNEL_DEATH_ITEM aura
-                return SPELL_AURA_PROC_FAILED;
-            }
-            // Cheat Death
-            else if (auraSpellInfo->Id == 28845)
-            {
-                // When your health drops below 20% ....
-                int32 health20 = int32(GetMaxHealth()) / 5;
-                if (int32(GetHealth()) - int32(damage) >= health20 || int32(GetHealth()) < health20)
-                    return SPELL_AURA_PROC_FAILED;
-            }
-            break;
-        }
-        case SPELLFAMILY_PRIEST:
-        {
-            // Greater Heal Refund (Avatar Raiment set)
-            if (auraSpellInfo->Id == 37594)
-            {
-                // Not give if target already have full health
-                if (pVictim->GetHealth() == pVictim->GetMaxHealth())
-                    return SPELL_AURA_PROC_FAILED;
-                // If your Greater Heal brings the target to full health, you gain $37595s1 mana.
-                if (pVictim->GetHealth() + damage < pVictim->GetMaxHealth())
-                    return SPELL_AURA_PROC_FAILED;
-                trigger_spell_id = 37595;
-            }
-            // Shadowguard
-            else if (auraSpellInfo->SpellIconID == 19)
-            {
-                switch (auraSpellInfo->Id)
-                {
-                    case 18137: trigger_spell_id = 28377; break;   // Rank 1
-                    case 19308: trigger_spell_id = 28378; break;   // Rank 2
-                    case 19309: trigger_spell_id = 28379; break;   // Rank 3
-                    case 19310: trigger_spell_id = 28380; break;   // Rank 4
-                    case 19311: trigger_spell_id = 28381; break;   // Rank 5
-                    case 19312: trigger_spell_id = 28382; break;   // Rank 6
-                    case 25477: trigger_spell_id = 28385; break;   // Rank 7
-                    default:
-                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u not handled in SG", auraSpellInfo->Id);
-                        return SPELL_AURA_PROC_FAILED;
-                }
-            }
-            // Blessed Recovery
-            else if (auraSpellInfo->SpellIconID == 1875)
-            {
-                switch (auraSpellInfo->Id)
-                {
-                    case 27811: trigger_spell_id = 27813; break;
-                    case 27815: trigger_spell_id = 27817; break;
-                    case 27816: trigger_spell_id = 27818; break;
-                    default:
-                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u not handled in BR", auraSpellInfo->Id);
-                        return SPELL_AURA_PROC_FAILED;
-                }
-                basepoints[0] = damage * triggerAmount / 100 / 3;
-                target = this;
-            }
-            break;
-        }
-        case SPELLFAMILY_DRUID:
-        {
-            // Leader of the Pack
-            if (auraSpellInfo->Id == 24932)
-            {
-                if (triggerAmount == 0)
-                    return SPELL_AURA_PROC_FAILED;
-                basepoints[0] = triggerAmount * GetMaxHealth() / 100;
-                trigger_spell_id = 34299;
-            }
-            // Druid Forms Trinket
-            else if (auraSpellInfo->Id == 37336)
-            {
-                switch (GetShapeshiftForm())
-                {
-                    case FORM_NONE:     trigger_spell_id = 37344; break;
-                    case FORM_CAT:      trigger_spell_id = 37341; break;
-                    case FORM_BEAR:
-                    case FORM_DIREBEAR: trigger_spell_id = 37340; break;
-                    case FORM_TREE:     trigger_spell_id = 37342; break;
-                    case FORM_MOONKIN:  trigger_spell_id = 37343; break;
-                    default:
-                        return SPELL_AURA_PROC_FAILED;
-                }
-            }
-            break;
-        }
-        case SPELLFAMILY_ROGUE:
-        {
-            if (auraSpellInfo->SpellIconID == 2260)         // Combat Potency
-            {
-                if (!(procFlags & PROC_FLAG_SUCCESSFUL_OFFHAND_HIT))
-                    return SPELL_AURA_PROC_FAILED;
-            }
-
-            break;
-        }
-        case SPELLFAMILY_HUNTER:
-            break;
-        case SPELLFAMILY_PALADIN:
-        {
-            /*
-            // Blessed Life
-            if (auraSpellInfo->SpellIconID == 2137)
-            {
-                switch (auraSpellInfo->Id)
-                {
-                    case 31828:                         // Rank 1
-                    case 31829:                         // Rank 2
-                    case 31830:                         // Rank 3
-                        break;
-                    default:
-                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u miss posibly Blessed Life", auraSpellInfo->Id);
-                        return SPELL_AURA_PROC_FAILED;
-                }
-            }
-            */
-            // Healing Discount
-            if (auraSpellInfo->Id == 37705)
-            {
-                trigger_spell_id = 37706;
-                target = this;
-            }
-            // Judgement of Light and Judgement of Wisdom
-            else if (auraSpellInfo->SpellFamilyFlags & uint64(0x0000000000080000))
-            {
-                switch (auraSpellInfo->Id)
-                {
-                    // Judgement of Light
-                    case 20185: trigger_spell_id = 20267; break; // Rank 1
-                    case 20344: trigger_spell_id = 20341; break; // Rank 2
-                    case 20345: trigger_spell_id = 20342; break; // Rank 3
-                    case 20346: trigger_spell_id = 20343; break; // Rank 4
-                    case 27162: trigger_spell_id = 27163; break; // Rank 5
-                    // Judgement of Wisdom
-                    case 20186: trigger_spell_id = 20268; break; // Rank 1
-                    case 20354: trigger_spell_id = 20352; break; // Rank 2
-                    case 20355: trigger_spell_id = 20353; break; // Rank 3
-                    case 27164: trigger_spell_id = 27165; break; // Rank 4
-                    default:
-                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u miss posibly Judgement of Light/Wisdom", auraSpellInfo->Id);
-                        return SPELL_AURA_PROC_FAILED;
-                }
-                pVictim->CastSpell(pVictim, trigger_spell_id, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-                return SPELL_AURA_PROC_OK;                  // no hidden cooldown
-            }
-            // Illumination
-            else if (auraSpellInfo->SpellIconID == 241)
-            {
-                if (!procSpell)
-                    return SPELL_AURA_PROC_FAILED;
-                // procspell is triggered spell but we need mana cost of original casted spell
-                uint32 originalSpellId = procSpell->Id;
-                // Holy Shock heal
-                if (procSpell->SpellFamilyFlags & uint64(0x0001000000000000))
-                {
-                    switch (procSpell->Id)
-                    {
-                        case 25914: originalSpellId = 20473; break;
-                        case 25913: originalSpellId = 20929; break;
-                        case 25903: originalSpellId = 20930; break;
-                        case 27175: originalSpellId = 27174; break;
-                        case 33074: originalSpellId = 33072; break;
-                        default:
-                            sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u not handled in HShock", procSpell->Id);
-                            return SPELL_AURA_PROC_FAILED;
-                    }
-                }
-                SpellEntry const* originalSpell = sSpellTemplate.LookupEntry<SpellEntry>(originalSpellId);
-                if (!originalSpell)
-                {
-                    sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u unknown but selected as original in Illu", originalSpellId);
-                    return SPELL_AURA_PROC_FAILED;
-                }
-                // percent stored in effect 1 (class scripts) base points
-                int32 cost = originalSpell->manaCost;
-                basepoints[0] = cost * auraSpellInfo->CalculateSimpleValue(EFFECT_INDEX_1) / 100;
-                trigger_spell_id = 20272;
-                target = this;
-            }
-            // Lightning Capacitor
-            else if (auraSpellInfo->Id == 37657)
-            {
-                if (!pVictim || !pVictim->isAlive())
-                    return SPELL_AURA_PROC_FAILED;
-                // stacking
-                CastSpell(this, 37658, TRIGGERED_OLD_TRIGGERED, nullptr, triggeredByAura);
-
-                Aura* dummy = GetDummyAura(37658);
-                // release at 3 aura in stack (cont contain in basepoint of trigger aura)
-                if (!dummy || dummy->GetStackAmount() < uint32(triggerAmount))
-                    return SPELL_AURA_PROC_FAILED;
-
-                RemoveAurasDueToSpell(37658);
-                trigger_spell_id = 37661;
-                target = pVictim;
-            }
-            // Bonus Healing (Crystal Spire of Karabor mace)
-            else if (auraSpellInfo->Id == 40971)
-            {
-                // If your target is below $s1% health
-                if (pVictim->GetHealth() > pVictim->GetMaxHealth() * triggerAmount / 100)
-                    return SPELL_AURA_PROC_FAILED;
-            }
-            break;
-        }
-        case SPELLFAMILY_SHAMAN:
-        {
-            // Lightning Shield (overwrite non existing triggered spell call in spell.dbc
-            if (auraSpellInfo->IsFitToFamilyMask(uint64(0x0000000000000400)) && auraSpellInfo->SpellVisual == 37)
-            {
-                switch (auraSpellInfo->Id)
-                {
-                    case 324:                           // Rank 1
-                        trigger_spell_id = 26364; break;
-                    case 325:                           // Rank 2
-                        trigger_spell_id = 26365; break;
-                    case 905:                           // Rank 3
-                        trigger_spell_id = 26366; break;
-                    case 945:                           // Rank 4
-                        trigger_spell_id = 26367; break;
-                    case 8134:                          // Rank 5
-                        trigger_spell_id = 26369; break;
-                    case 10431:                         // Rank 6
-                        trigger_spell_id = 26370; break;
-                    case 10432:                         // Rank 7
-                        trigger_spell_id = 26363; break;
-                    case 25469:                         // Rank 8
-                        trigger_spell_id = 26371; break;
-                    case 25472:                         // Rank 9
-                        trigger_spell_id = 26372; break;
-                    default:
-                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u not handled in LShield", auraSpellInfo->Id);
-                        return SPELL_AURA_PROC_FAILED;
-                }
-            }
-            // Lightning Shield (The Ten Storms set)
-            else if (auraSpellInfo->Id == 23551)
-            {
-                trigger_spell_id = 23552;
-                target = pVictim;
-            }
-            // Damage from Lightning Shield (The Ten Storms set)
-            else if (auraSpellInfo->Id == 23552)
-                trigger_spell_id = 27635;
-            // Mana Surge (The Earthfury set)
-            else if (auraSpellInfo->Id == 23572)
-            {
-                if (!procSpell)
-                    return SPELL_AURA_PROC_FAILED;
-                basepoints[0] = procSpell->manaCost * 35 / 100;
-                trigger_spell_id = 23571;
-                target = this;
-            }
-            // Nature's Guardian
-            else if (auraSpellInfo->SpellIconID == 2013)
-            {
-                // Check health condition - should drop to less 30% (trigger at any attack with result health less 30%, independent original health state)
-                int32 health30 = int32(GetMaxHealth()) * 3 / 10;
-                if (int32(GetHealth()) - int32(damage) >= health30)
-                    return SPELL_AURA_PROC_FAILED;
-
-                if (pVictim && pVictim->isAlive())
-                    pVictim->getThreatManager().modifyThreatPercent(this, -10);
-
-                basepoints[0] = triggerAmount * GetMaxHealth() / 100;
-                trigger_spell_id = 31616;
-                target = this;
-            }
-            break;
-        }
-        default:
-            break;
-    }
-
-    // All ok. Check current trigger spell
-    SpellEntry const* triggerEntry = sSpellTemplate.LookupEntry<SpellEntry>(trigger_spell_id);
-    if (!triggerEntry)
-    {
-        // Not cast unknown spell
-        // sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u have 0 in EffectTriggered[%d], not handled custom case?",auraSpellInfo->Id,triggeredByAura->GetEffIndex());
-        return SPELL_AURA_PROC_FAILED;
-    }
-
-    // not allow proc extra attack spell at extra attack
-    if (m_extraAttacks && IsSpellHaveEffect(triggerEntry, SPELL_EFFECT_ADD_EXTRA_ATTACKS))
-        return SPELL_AURA_PROC_FAILED;
-
-    // Custom basepoints/target for exist spell
-    // dummy basepoints or other customs
-    switch (trigger_spell_id)
-    {
-        // Cast positive spell on enemy target
-        case 7099:  // Curse of Mending
-        case 39647: // Curse of Mending
-        case 29494: // Temptation
-        case 20233: // Improved Lay on Hands (cast on target)
-        {
-            target = pVictim;
-            break;
-        }
-        // Combo points add triggers (need add combopoint only for main target, and after possible combopoints reset)
-        case 15250: // Rogue Setup
-        {
-            if (!pVictim || pVictim != getVictim())  // applied only for main target
-                return SPELL_AURA_PROC_FAILED;
-            break;                                   // continue normal case
-        }
-        // Finishing moves that add combo points
-        case 14189: // Seal Fate (Netherblade set)
-        case 14157: // Ruthlessness
-        {
-            // Need add combopoint AFTER finishing move (or they get dropped in finish phase)
-            if (Spell* spell = GetCurrentSpell(CURRENT_GENERIC_SPELL))
-            {
-                spell->AddTriggeredSpell(trigger_spell_id);
-                return SPELL_AURA_PROC_OK;
-            }
-            return SPELL_AURA_PROC_FAILED;
-        }
-        // Shamanistic Rage triggered spell
-        case 30824:
-        {
-            basepoints[0] = int32(GetTotalAttackPowerValue(BASE_ATTACK) * triggerAmount / 100);
-            break;
-        }
-        // Enlightenment (trigger only from mana cost spells)
-        case 35095:
-        {
-            if (!procSpell || procSpell->powerType != POWER_MANA || (procSpell->manaCost == 0 && procSpell->ManaCostPercentage == 0 && procSpell->manaCostPerlevel == 0))
-                return SPELL_AURA_PROC_FAILED;
-            break;
         }
     }
 
-    if (cooldown && GetTypeId() == TYPEID_PLAYER && ((Player*)this)->HasSpellCooldown(trigger_spell_id))
-        return SPELL_AURA_PROC_FAILED;
-
-    // try detect target manually if not set
-    if (target == nullptr)
-        target = !(procFlags & (PROC_FLAG_DONE_SPELL_MAGIC_DMG_CLASS_POS | PROC_FLAG_DONE_SPELL_NONE_DMG_CLASS_POS)) && IsPositiveSpellTargetMode(triggerEntry, this, pVictim) ? this : pVictim;
-
-    // default case
-    if (!target || (target != this && !target->isAlive()))
-        return SPELL_AURA_PROC_FAILED;
-    // Quick check for target modes for procs: do not cast offensive procs on friendly targets and in reverse
-    else if (!(procEx & PROC_EX_REFLECT))
+    void UpdateAI(const uint32 uiDiff) override
     {
-        if (IsPositiveSpellTargetMode(triggerEntry, this, target) != IsFriendlyTo(target))
-            return SPELL_AURA_PROC_FAILED;
-    }
-
-    if (basepoints[EFFECT_INDEX_0] || basepoints[EFFECT_INDEX_1] || basepoints[EFFECT_INDEX_2])
-        CastCustomSpell(target, trigger_spell_id,
-                        basepoints[EFFECT_INDEX_0] ? &basepoints[EFFECT_INDEX_0] : nullptr,
-                        basepoints[EFFECT_INDEX_1] ? &basepoints[EFFECT_INDEX_1] : nullptr,
-                        basepoints[EFFECT_INDEX_2] ? &basepoints[EFFECT_INDEX_2] : nullptr,
-                        TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-    else
-        CastSpell(target, trigger_spell_id, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-
-    if (cooldown && GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->AddSpellCooldown(trigger_spell_id, 0, time(nullptr) + cooldown);
-
-    return SPELL_AURA_PROC_OK;
-}
-
-SpellAuraProcResult Unit::HandleProcTriggerDamageAuraProc(Unit* pVictim, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* /*procSpell*/, uint32 /*procFlags*/, uint32 /*procEx*/, uint32 /*cooldown*/)
-{
-    SpellEntry const* spellInfo = triggeredByAura->GetSpellProto();
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "ProcDamageAndSpell: doing %u damage from spell id %u (triggered by auratype %u of spell %u)",
-                     triggeredByAura->GetModifier()->m_amount, spellInfo->Id, triggeredByAura->GetModifier()->m_auraname, triggeredByAura->GetId());
-    SpellNonMeleeDamage damageInfo(this, pVictim, spellInfo->Id, SpellSchoolMask(spellInfo->SchoolMask));
-    CalculateSpellDamage(&damageInfo, triggeredByAura->GetModifier()->m_amount, spellInfo);
-    damageInfo.target->CalculateAbsorbResistBlock(this, &damageInfo, spellInfo);
-    DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE, spellInfo);
-    SendSpellNonMeleeDamageLog(&damageInfo);
-    DealSpellDamage(&damageInfo, true);
-    return SPELL_AURA_PROC_OK;
-}
-
-SpellAuraProcResult Unit::HandleOverrideClassScriptAuraProc(Unit* pVictim, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procEx*/ , uint32 cooldown)
-{
-    int32 scriptId = triggeredByAura->GetModifier()->m_miscvalue;
-
-    if (!pVictim || !pVictim->isAlive())
-        return SPELL_AURA_PROC_FAILED;
-
-    Item* castItem = triggeredByAura->GetCastItemGuid() && GetTypeId() == TYPEID_PLAYER
-                     ? ((Player*)this)->GetItemByGuid(triggeredByAura->GetCastItemGuid()) : nullptr;
-
-    // Basepoints of trigger aura
-    int32 triggerAmount = triggeredByAura->GetModifier()->m_amount;
-
-    uint32 triggered_spell_id = 0;
-
-    switch (scriptId)
-    {
-        case 836:                                           // Improved Blizzard (Rank 1)
+        if (m_pInstance && m_pInstance->GetData(TYPE_EREDAR_TWINS) == SPECIAL)
         {
-            if (!procSpell || procSpell->SpellVisual != 9487)
-                return SPELL_AURA_PROC_FAILED;
-            triggered_spell_id = 12484;
-            break;
-        }
-        case 988:                                           // Improved Blizzard (Rank 2)
-        {
-            if (!procSpell || procSpell->SpellVisual != 9487)
-                return SPELL_AURA_PROC_FAILED;
-            triggered_spell_id = 12485;
-            break;
-        }
-        case 989:                                           // Improved Blizzard (Rank 3)
-        {
-            if (!procSpell || procSpell->SpellVisual != 9487)
-                return SPELL_AURA_PROC_FAILED;
-            triggered_spell_id = 12486;
-            break;
-        }
-        case 4086:                                          // Improved Mend Pet (Rank 1)
-        case 4087:                                          // Improved Mend Pet (Rank 2)
-        {
-            if (!roll_chance_i(triggerAmount))
-                return SPELL_AURA_PROC_FAILED;
-
-            triggered_spell_id = 24406;
-            break;
-        }
-        case 4533:                                          // Dreamwalker Raiment 2 pieces bonus
-        {
-            // Chance 50%
-            if (!roll_chance_i(50))
-                return SPELL_AURA_PROC_FAILED;
-
-            switch (pVictim->GetPowerType())
+            if (!m_bDidIntro)
             {
-                case POWER_MANA:   triggered_spell_id = 28722; break;
-                case POWER_RAGE:   triggered_spell_id = 28723; break;
-                case POWER_ENERGY: triggered_spell_id = 28724; break;
-                default:
-                    return SPELL_AURA_PROC_FAILED;
+                m_introDialogue.StartNextDialogueText(SAY_INTRO_1);
+                m_bDidIntro = true;
             }
-            break;
+            m_introDialogue.DialogueUpdate(uiDiff);
         }
-        case 4537:                                          // Dreamwalker Raiment 6 pieces bonus
-            triggered_spell_id = 28750;                     // Blessing of the Claw
-            break;
-        case 5497:                                          // Improved Mana Gems (Serpent-Coil Braid)
-            triggered_spell_id = 37445;                     // Mana Surge
-            break;
-    }
 
-    // not processed
-    if (!triggered_spell_id)
-        return SPELL_AURA_PROC_OK;
+        if (!m_creature->SelectHostileTarget() || !m_creature->getVictim())
+            return;
 
-    // standard non-dummy case
-    SpellEntry const* triggerEntry = sSpellTemplate.LookupEntry<SpellEntry>(triggered_spell_id);
-
-    if (!triggerEntry)
-    {
-        sLog.outError("Unit::HandleOverrideClassScriptAuraProc: Spell %u triggering for class script id %u", triggered_spell_id, scriptId);
-        return SPELL_AURA_PROC_FAILED;
-    }
-
-    if (cooldown && GetTypeId() == TYPEID_PLAYER && ((Player*)this)->HasSpellCooldown(triggered_spell_id))
-        return SPELL_AURA_PROC_FAILED;
-
-    CastSpell(pVictim, triggered_spell_id, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-
-    if (cooldown && GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->AddSpellCooldown(triggered_spell_id, 0, time(nullptr) + cooldown);
-
-    return SPELL_AURA_PROC_OK;
-}
-
-SpellAuraProcResult Unit::HandleMendingAuraProc(Unit* /*pVictim*/, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
-{
-    // aura can be deleted at casts
-    SpellEntry const* spellProto = triggeredByAura->GetSpellProto();
-    SpellEffectIndex effIdx = triggeredByAura->GetEffIndex();
-    int32 heal = triggeredByAura->GetModifier()->m_amount;
-    ObjectGuid caster_guid = triggeredByAura->GetCasterGuid();
-
-    // jumps
-    int32 jumps = triggeredByAura->GetHolder()->GetAuraCharges() - 1;
-
-    // current aura expire
-    triggeredByAura->GetHolder()->SetAuraCharges(1);        // will removed at next charges decrease
-
-    // next target selection
-    if (jumps > 0 && GetTypeId() == TYPEID_PLAYER && caster_guid.IsPlayer())
-    {
-        float radius;
-        if (spellProto->EffectRadiusIndex[effIdx])
-            radius = GetSpellRadius(sSpellRadiusStore.LookupEntry(spellProto->EffectRadiusIndex[effIdx]));
+        if (m_uiEnrageTimer < uiDiff)
+        {
+            if (DoCastSpellIfCan(m_creature, SPELL_TWINS_ENRAGE) == CAST_OK)
+            {
+                DoScriptText(SAY_ALYTHESS_BERSERK, m_creature);
+                m_uiEnrageTimer = 6 * MINUTE * IN_MILLISECONDS;
+            }
+        }
         else
-            radius = GetSpellMaxRange(sSpellRangeStore.LookupEntry(spellProto->rangeIndex));
+            m_uiEnrageTimer -= uiDiff;
 
-        if (Player* caster = ((Player*)triggeredByAura->GetCaster()))
+        if (m_uiPyrogenicsTimer < uiDiff)
         {
-            caster->ApplySpellMod(spellProto->Id, SPELLMOD_RADIUS, radius, nullptr);
+            if (DoCastSpellIfCan(m_creature, SPELL_PYROGENICS) == CAST_OK)
+                m_uiPyrogenicsTimer = urand(25000, 30000);
+        }
+        else
+            m_uiPyrogenicsTimer -= uiDiff;
 
-            if (Player* target = ((Player*)this)->GetNextRandomRaidMember(radius))
+        if (m_uiConflagrationTimer < uiDiff)
+        {
+            Unit* pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_TOPAGGRO, 3);
+            if (!pTarget)
+                pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0);
+
+            // If sister is dead cast shadownova instead of conflagration
+            bool bSwitchSpell = m_creature->HasAura(SPELL_EMPOWER);
+            if (DoCastSpellIfCan(pTarget, bSwitchSpell ? SPELL_SHADOW_NOVA : SPELL_CONFLAGRATION) == CAST_OK)
             {
-                // aura will applied from caster, but spell casted from current aura holder
-                SpellModifier* mod = new SpellModifier(SPELLMOD_CHARGES, SPELLMOD_FLAT, jumps - 5, spellProto->Id, spellProto->SpellFamilyFlags);
+                if (!bSwitchSpell)
+                    DoScriptText(SAY_ALYTHESS_CANFLAGRATION, m_creature);
 
-                // remove before apply next (locked against deleted)
-                triggeredByAura->SetInUse(true);
-                RemoveAurasByCasterSpell(spellProto->Id, caster->GetObjectGuid());
+                m_uiConflagrationTimer = urand(20000, 25000);
+            }
+        }
+        else
+            m_uiConflagrationTimer -= uiDiff;
 
-                caster->AddSpellMod(mod, true);
-                CastCustomSpell(target, spellProto->Id, &heal, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, nullptr, triggeredByAura, caster->GetObjectGuid());
-                caster->AddSpellMod(mod, false);
-                triggeredByAura->SetInUse(false);
+        if (m_uiFlameSearTimer < uiDiff)
+        {
+            if (DoCastSpellIfCan(m_creature, SPELL_FLAME_SEAR) == CAST_OK)
+                m_uiFlameSearTimer = 10000;
+
+        }
+        else
+            m_uiFlameSearTimer -= uiDiff;
+
+        if (m_uiBlazeTimer < uiDiff)
+        {
+            if (DoCastSpellIfCan(m_creature->getVictim(), SPELL_BLAZE) == CAST_OK)
+                m_uiBlazeTimer = 3000;
+        }
+        else
+            m_uiBlazeTimer -= uiDiff;
+    }
+};
+
+/*######
+## boss_sacrolash
+######*/
+
+struct boss_sacrolashAI : public ScriptedAI
+{
+    boss_sacrolashAI(Creature* pCreature) : ScriptedAI(pCreature)
+    {
+        m_pInstance = ((instance_sunwell_plateau*)pCreature->GetInstanceData());
+        Reset();
+    }
+
+    ScriptedInstance* m_pInstance;
+
+    uint32 m_uiEnrageTimer;
+    uint32 m_uiShadowNovaTimer;
+    uint32 m_uiConfoundingBlowTimer;
+    uint32 m_uiShadowBladesTimer;
+    uint32 m_uiSummonShadowImage;
+
+    void Reset() override
+    {
+        m_uiEnrageTimer = 6 * MINUTE * IN_MILLISECONDS;
+        m_uiShadowNovaTimer      = 15000;
+        m_uiConfoundingBlowTimer = 30000;
+        m_uiShadowBladesTimer    = 15000;
+        m_uiSummonShadowImage    = 10000;
+        DoCastSpellIfCan(m_creature, DARK_FLAME_AURA_SCAROLASH);
+    }
+
+    void JustReachedHome() override
+    {
+        if (m_pInstance)
+        {
+            if (m_pInstance->GetData(TYPE_EREDAR_TWINS) != FAIL)
+                m_pInstance->SetData(TYPE_EREDAR_TWINS, FAIL);
+
+            // Respawn dead sister
+            if (Creature* pSister = m_pInstance->GetSingleCreatureFromStorage(NPC_ALYTHESS))
+            {
+                if (!pSister->isAlive())
+                    pSister->Respawn();
             }
         }
     }
 
-    // heal
-    CastCustomSpell(this, 33110, &heal, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, nullptr, nullptr, caster_guid);
-    return SPELL_AURA_PROC_OK;
-}
-
-SpellAuraProcResult Unit::HandleModCastingSpeedNotStackAuraProc(Unit* /*pVictim*/, uint32 /*damage*/, Aura* /*triggeredByAura*/, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
-{
-    // Skip melee hits or instant cast spells
-    return !(procSpell == nullptr || GetSpellCastTime(procSpell) == 0) ? SPELL_AURA_PROC_OK : SPELL_AURA_PROC_FAILED;
-}
-
-SpellAuraProcResult Unit::HandleReflectSpellsSchoolAuraProc(Unit* /*pVictim*/, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
-{
-    // Skip Melee hits and spells ws wrong school
-    return !(procSpell == nullptr || (triggeredByAura->GetModifier()->m_miscvalue & procSpell->SchoolMask) == 0) ? SPELL_AURA_PROC_OK : SPELL_AURA_PROC_FAILED;
-}
-
-SpellAuraProcResult Unit::HandleModPowerCostSchoolAuraProc(Unit* /*pVictim*/, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
-{
-    // Skip melee hits and spells ws wrong school or zero cost
-    return !(procSpell == nullptr ||
-             (procSpell->manaCost == 0 && procSpell->ManaCostPercentage == 0) ||           // Cost check
-             (triggeredByAura->GetModifier()->m_miscvalue & procSpell->SchoolMask) == 0) ? SPELL_AURA_PROC_OK : SPELL_AURA_PROC_FAILED;  // School check
-}
-
-SpellAuraProcResult Unit::HandleMechanicImmuneResistanceAuraProc(Unit* /*pVictim*/, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
-{
-    // Compare mechanic
-    return !(procSpell == nullptr || procSpell->Mechanic != triggeredByAura->GetModifier()->m_miscvalue)
-           ? SPELL_AURA_PROC_OK : SPELL_AURA_PROC_FAILED;
-}
-
-SpellAuraProcResult Unit::HandleManaShieldAuraProc(Unit* pVictim, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 cooldown)
-{
-    SpellEntry const* dummySpell = triggeredByAura->GetSpellProto();
-
-    Item* castItem = triggeredByAura->GetCastItemGuid() && GetTypeId() == TYPEID_PLAYER
-                     ? ((Player*)this)->GetItemByGuid(triggeredByAura->GetCastItemGuid()) : nullptr;
-
-    uint32 triggered_spell_id = 0;
-    Unit* target = pVictim;
-
-    switch (dummySpell->SpellFamilyName)
+    void Aggro(Unit* /*pWho*/) override
     {
-        case SPELLFAMILY_MAGE:
+        if (m_pInstance)
         {
-            // Incanter's Regalia set (add trigger chance to Mana Shield)
-            if (dummySpell->SpellFamilyFlags & uint64(0x0000000000008000) && HasAura(37424)) // Improved Mana Shield
-            {
-                if (GetTypeId() != TYPEID_PLAYER)
-                    return SPELL_AURA_PROC_FAILED;
-
-                target = this;
-                triggered_spell_id = 37436;
-                break;
-            }
-            break;
+            if (m_pInstance->GetData(TYPE_EREDAR_TWINS) != IN_PROGRESS)
+                m_pInstance->SetData(TYPE_EREDAR_TWINS, IN_PROGRESS);
         }
-        default:
-            break;
     }
 
-    // processed charge only counting case
-    if (!triggered_spell_id)
-        return SPELL_AURA_PROC_FAILED;
-
-    SpellEntry const* triggerEntry = sSpellTemplate.LookupEntry<SpellEntry>(triggered_spell_id);
-
-    if (!triggerEntry)
+    void KilledUnit(Unit* /*pVictim*/) override
     {
-        sLog.outError("Unit::HandleManaShieldAuraProc: Spell %u have nonexistent triggered spell %u", dummySpell->Id, triggered_spell_id);
-        return SPELL_AURA_PROC_FAILED;
+        DoScriptText(urand(0, 1) ? SAY_SACROLASH_KILL_1 : SAY_SACROLASH_KILL_2, m_creature);
     }
 
-    // default case
-    if (!target || (target != this && !target->isAlive()))
-        return SPELL_AURA_PROC_FAILED;
-
-    if (cooldown && GetTypeId() == TYPEID_PLAYER && ((Player*)this)->HasSpellCooldown(triggered_spell_id))
-        return SPELL_AURA_PROC_FAILED;
-
-    CastSpell(target, triggered_spell_id, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
-
-    if (cooldown && GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->AddSpellCooldown(triggered_spell_id, 0, time(nullptr) + cooldown);
-
-    return SPELL_AURA_PROC_OK;
-}
-
-SpellAuraProcResult Unit::HandleAttackPowerAttackerBonusAuraProc(Unit* /*pVictim*/, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
-{
-    SpellEntry const* dummySpell = triggeredByAura->GetSpellProto();
-
-    switch (dummySpell->SpellFamilyName)
+    void JustDied(Unit* /*pKiller*/) override
     {
-        case SPELLFAMILY_HUNTER:
+        if (m_pInstance)
         {
-            // Hunter's Mark (1-4 Ranks)
-            if (dummySpell->SpellFamilyFlags & uint64(0x0000000000000400))
+            if (Creature* pAlythess = m_pInstance->GetSingleCreatureFromStorage(NPC_ALYTHESS))
             {
-                int32 basevalue = triggeredByAura->GetBasePoints();
-
-                triggeredByAura->GetModifier()->m_amount += basevalue / 10;
-                if (triggeredByAura->GetModifier()->m_amount > basevalue * 4)
-                    triggeredByAura->GetModifier()->m_amount = basevalue * 4;
+                if (!pAlythess->isAlive())
+                {
+                    m_pInstance->SetData(TYPE_EREDAR_TWINS, DONE);
+                    DoScriptText(SAY_SACROLASH_DEAD, m_creature);
+                }
+                else
+                {
+                    // Remove loot flag and cast empower
+                    m_creature->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
+                    DoScriptText(SAY_ALYTHESS_EMPOWER, pAlythess);
+                    pAlythess->InterruptNonMeleeSpells(true);
+                    pAlythess->CastSpell(pAlythess, DARK_FLAME_AURA_SCAROLASH, TRIGGERED_NONE);
+                    pAlythess->CastSpell(pAlythess, SPELL_EMPOWER, TRIGGERED_NONE);
+                }
             }
-            break;
         }
-        default:
-            break;
     }
 
-    return SPELL_AURA_PROC_OK;
-}
-
-SpellAuraProcResult Unit::HandleModResistanceAuraProc(Unit* /*pVictim*/, uint32 damage, Aura* triggeredByAura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
-{
-    SpellEntry const* spellInfo = triggeredByAura->GetSpellProto();
-
-    // Inner Fire
-    if (spellInfo->IsFitToFamily(SPELLFAMILY_PRIEST, uint64(0x0000000000002)))
+    // Return a random target which it's not in range of 10 yards of boss
+    Unit* GetRandomTargetAtDist(float fDist)
     {
-        // only at real damage
-        if (!damage)
-            return SPELL_AURA_PROC_FAILED;
+        std::vector<Unit*> m_vRangeTargets;
+
+        ThreatList const& tList = m_creature->getThreatManager().getThreatList();
+        for (ThreatList::const_iterator iter = tList.begin(); iter != tList.end(); ++iter)
+        {
+            if (Unit* pTempTarget = m_creature->GetMap()->GetUnit((*iter)->getUnitGuid()))
+            {
+                if (!pTempTarget->IsWithinDistInMap(m_creature, fDist))
+                    m_vRangeTargets.push_back(pTempTarget);
+            }
+        }
+
+        if (!m_vRangeTargets.empty())
+            return m_vRangeTargets[urand(0, m_vRangeTargets.size() - 1)];
+        else
+            return m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 1);
     }
 
-    return SPELL_AURA_PROC_OK;
-}
-
-SpellAuraProcResult Unit::HandleRemoveByDamageChanceProc(Unit* pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 procFlag, uint32 procEx, uint32 cooldown)
-{
-    // The chance to dispel an aura depends on the damage taken with respect to the casters level.
-    uint32 max_dmg = getLevel() > 8 ? 25 * getLevel() - 150 : 50;
-    float chance = float(damage) / max_dmg * 100.0f;
-    if (roll_chance_f(chance))
+    void JustSummoned(Creature* pSummoned) override
     {
-        triggeredByAura->SetInUse(true);
-        RemoveAurasByCasterSpell(triggeredByAura->GetId(), triggeredByAura->GetCasterGuid());
-        triggeredByAura->SetInUse(false);
-        return SPELL_AURA_PROC_OK;
+        if (pSummoned->GetEntry() == NPC_SHADOW_IMAGE)
+        {
+            pSummoned->CastSpell(pSummoned, SPELL_IMAGE_VISUAL, TRIGGERED_NONE);
+            // Attack random range target
+            if (Unit* pTarget = GetRandomTargetAtDist(10.0f))
+                pSummoned->AI()->AttackStart(pTarget);
+        }
     }
 
-    return SPELL_AURA_PROC_FAILED;
+    void UpdateAI(const uint32 uiDiff) override
+    {
+        if (!m_creature->SelectHostileTarget() || !m_creature->getVictim())
+            return;
+
+        if (m_uiEnrageTimer < uiDiff)
+        {
+            if (DoCastSpellIfCan(m_creature, SPELL_TWINS_ENRAGE) == CAST_OK)
+            {
+                DoScriptText(SAY_SACROLASH_BERSERK, m_creature);
+                m_uiEnrageTimer = 6 * MINUTE * IN_MILLISECONDS;
+            }
+        }
+        else
+            m_uiEnrageTimer -= uiDiff;
+
+        if (m_uiShadowBladesTimer < uiDiff)
+        {
+            if (DoCastSpellIfCan(m_creature, SPELL_SHADOW_BLADES) == CAST_OK)
+                m_uiShadowBladesTimer = urand(13000, 15000);
+        }
+        else
+            m_uiShadowBladesTimer -= uiDiff;
+
+        if (m_uiShadowNovaTimer < uiDiff)
+        {
+            Unit* pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_TOPAGGRO, 2);
+            if (!pTarget)
+                pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0);
+
+            // If sister is dead cast conflagration instead of shadownova
+            bool bSwitchSpell = m_creature->HasAura(SPELL_EMPOWER);
+            if (DoCastSpellIfCan(pTarget, bSwitchSpell ? SPELL_CONFLAGRATION : SPELL_SHADOW_NOVA) == CAST_OK)
+            {
+                if (!bSwitchSpell)
+                    DoScriptText(SAY_SACROLASH_SHADOW_NOVA, m_creature);
+
+                m_uiShadowNovaTimer = urand(30000, 35000);
+            }
+        }
+        else
+            m_uiShadowNovaTimer -= uiDiff;
+
+        if (m_uiConfoundingBlowTimer < uiDiff)
+        {
+            if (DoCastSpellIfCan(m_creature->getVictim(), SPELL_CONFOUNDING_BLOW) == CAST_OK)
+            {
+                // Reset threat
+                if (m_creature->getThreatManager().getThreat(m_creature->getVictim()))
+                    m_creature->getThreatManager().modifyThreatPercent(m_creature->getVictim(), -100);
+
+                m_uiConfoundingBlowTimer = urand(25000, 30000);
+            }
+        }
+        else
+            m_uiConfoundingBlowTimer -= uiDiff;
+
+        if (m_uiSummonShadowImage < uiDiff)
+        {
+            // Summon 3 shadow images at the boss position
+            for (uint8 i = 0; i < 3; ++i)
+                m_creature->SummonCreature(NPC_SHADOW_IMAGE, 0.0f, 0.0f, 0.0f, 0.0f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 3000);
+
+            m_uiSummonShadowImage = urand(10000, 12000);
+        }
+        else
+            m_uiSummonShadowImage -= uiDiff;
+
+        // Overwrite the melee attack in order to apply the dark strike
+        if (m_creature->CanReachWithMeleeAttack(m_creature->getVictim()))
+        {
+            // Make sure our attack is ready and we aren't currently casting
+            if (m_creature->isAttackReady() && !m_creature->IsNonMeleeSpellCasted(false))
+            {
+                DoCastSpellIfCan(m_creature->getVictim(), SPELL_DARK_STRIKE);
+
+                m_creature->AttackerStateUpdate(m_creature->getVictim());
+                m_creature->resetAttackTimer();
+            }
+        }
+    }
+};
+
+/*######
+## npc_shadow_image
+######*/
+
+struct npc_shadow_imageAI : public ScriptedAI
+{
+    npc_shadow_imageAI(Creature* pCreature) : ScriptedAI(pCreature)  { Reset(); }
+
+    uint32 m_uiChosenAbility;
+    uint32 m_uiSuicideTimer;
+    uint32 m_uiAbilityTimer;
+    uint8 m_uiDarkStrikes;
+
+    void Reset() override
+    {
+        // Choose only one spell for attack
+        m_uiChosenAbility = urand(0, 1) ? SPELL_DARK_STRIKE : SPELL_SHADOWFURY;
+        m_uiAbilityTimer = 500;
+        m_uiDarkStrikes = 0;
+        m_uiSuicideTimer = 0;
+    }
+
+    void UpdateAI(const uint32 uiDiff) override
+    {
+        if (!m_creature->SelectHostileTarget() || !m_creature->getVictim())
+            return;
+
+        // Suicide on timer; this is needed because of the cast time
+        if (m_uiSuicideTimer)
+        {
+            if (m_uiSuicideTimer <= uiDiff)
+            {
+                m_creature->DealDamage(m_creature, m_creature->GetHealth(), nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, nullptr, false);
+                return;
+            }
+            else
+                m_uiSuicideTimer -= uiDiff;
+        }
+        else
+        {
+            // Do chosen ability
+            switch (m_uiChosenAbility)
+            {
+                case SPELL_SHADOWFURY:
+                    if (m_uiAbilityTimer < uiDiff)
+                    {
+                        if (m_creature->IsWithinDistInMap(m_creature->getVictim(), INTERACTION_DISTANCE))
+                        {
+                            if (DoCastSpellIfCan(m_creature, SPELL_SHADOWFURY) == CAST_OK)
+                                m_uiSuicideTimer = 1000;
+                        }
+                    }
+                    else
+                        m_uiAbilityTimer -= uiDiff;
+                    break;
+                case SPELL_DARK_STRIKE:
+                    if (m_uiAbilityTimer < uiDiff)
+                    {
+                        if (DoCastSpellIfCan(m_creature->getVictim(), SPELL_DARK_STRIKE) == CAST_OK)
+                        {
+                            ++m_uiDarkStrikes;
+                            // kill itself after 2 strikes
+                            if (m_uiDarkStrikes == 2)
+                                m_uiSuicideTimer = 1000;
+                            else
+                                m_uiAbilityTimer = 1000;
+                        }
+                    }
+                    else
+                        m_uiAbilityTimer -= uiDiff;
+                    break;
+            }
+        }
+    }
+};
+
+CreatureAI* GetAI_boss_alythess(Creature* pCreature)
+{
+    return new boss_alythessAI(pCreature);
 }
 
-SpellAuraProcResult Unit::HandleInvisibilityAuraProc(Unit* pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 procFlag, uint32 procEx, uint32 cooldown)
+CreatureAI* GetAI_boss_sacrolash(Creature* pCreature)
 {
-    if (triggeredByAura->GetSpellProto()->HasAttribute(SPELL_ATTR_PASSIVE) || triggeredByAura->GetSpellProto()->HasAttribute(SPELL_ATTR_NEGATIVE))
-        return SPELL_AURA_PROC_FAILED;
+    return new boss_sacrolashAI(pCreature);
+}
 
-    RemoveAurasDueToSpell(triggeredByAura->GetId());
-    return SPELL_AURA_PROC_OK;
+CreatureAI* GetAI_npc_shadow_image(Creature* pCreature)
+{
+    return new npc_shadow_imageAI(pCreature);
+}
+
+void AddSC_boss_eredar_twins()
+{
+    Script* pNewScript;
+
+    pNewScript = new Script;
+    pNewScript->Name = "boss_alythess";
+    pNewScript->GetAI = &GetAI_boss_alythess;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "boss_sacrolash";
+    pNewScript->GetAI = &GetAI_boss_sacrolash;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "npc_shadow_image";
+    pNewScript->GetAI = &GetAI_npc_shadow_image;
+    pNewScript->RegisterSelf();
 }

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -1,4 +1,6 @@
-/* This file is part of the ScriptDev2 Project. See AUTHORS file for Copyright information
+/*
+ * This file is part of the CMaNGOS Project. See AUTHORS file for Copyright information
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -14,565 +16,10840 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* ScriptData
-SDName: boss_eredar_twins
-SD%Complete: 75
-SDComment: A few spells are not working proper yet; Shadow image script needs improvement
-SDCategory: Sunwell Plateau
-EndScriptData */
+#include "Unit.h"
+#include "Log.h"
+#include "Opcodes.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
+#include "World.h"
+#include "ObjectMgr.h"
+#include "ObjectGuid.h"
+#include "SpellMgr.h"
+#include "Player.h"
+#include "Creature.h"
+#include "Spell.h"
+#include "Group.h"
+#include "SpellAuras.h"
+#include "ObjectAccessor.h"
+#include "AI/CreatureAISelector.h"
+#include "TemporarySummon.h"
+#include "Pet.h"
+#include "Util.h"
+#include "Totem.h"
+#include "BattleGround/BattleGround.h"
+#include "InstanceData.h"
+#include "OutdoorPvP/OutdoorPvP.h"
+#include "MapPersistentStateMgr.h"
+#include "GridNotifiersImpl.h"
+#include "CellImpl.h"
+#include "MovementGenerator.h"
+#include "movement/MoveSplineInit.h"
+#include "movement/MoveSpline.h"
+#include "CreatureLinkingMgr.h"
 
-#include "precompiled.h"
-#include "sunwell_plateau.h"
+#include <math.h>
+#include <array>
 
-enum
+float baseMoveSpeed[MAX_MOVE_TYPE] =
 {
-    SAY_INTRO_1                             = -1580044,
-    SAY_INTRO_2                             = -1580045,
-    SAY_INTRO_3                             = -1580046,
-    SAY_INTRO_4                             = -1580047,
-    SAY_INTRO_5                             = -1580048,
-    SAY_INTRO_6                             = -1580049,
-    SAY_INTRO_7                             = -1580050,
-    SAY_INTRO_8                             = -1580051,
-
-    SAY_SACROLASH_SHADOW_NOVA               = -1580052,
-    SAY_SACROLASH_EMPOWER                   = -1580053,
-    SAY_SACROLASH_KILL_1                    = -1580054,
-    SAY_SACROLASH_KILL_2                    = -1580055,
-    SAY_SACROLASH_DEAD                      = -1580056,
-    SAY_SACROLASH_BERSERK                   = -1580057,
-
-    SAY_ALYTHESS_CANFLAGRATION              = -1580058,
-    SAY_ALYTHESS_EMPOWER                    = -1580059,
-    SAY_ALYTHESS_KILL_1                     = -1580060,
-    SAY_ALYTHESS_KILL_2                     = -1580061,
-    SAY_ALYTHESS_DEAD                       = -1580062,
-    SAY_ALYTHESS_BERSERK                    = -1580063,
-
-    // Shared spells
-    SPELL_TWINS_ENRAGE                      = 46587,
-    SPELL_EMPOWER                           = 45366,        // Cast on self when the twin sister dies
-    SPELL_DARK_FLAME                        = 45345,
-
-    // Sacrolash spells
-    SPELL_DARK_TOUCHED                      = 45347,        // Player debuff; removed by shadow damage
-    SPELL_SHADOW_BLADES                     = 45248,        // 10 secs
-    SPELL_DARK_STRIKE                       = 45271,
-    SPELL_SHADOW_NOVA                       = 45329,        // 30-35 secs
-    SPELL_CONFOUNDING_BLOW                  = 45256,        // Daze; 25 secs
-    SPELL_SHADOW_NOVA_UNK                   = 45332,        // Unknown
-
-    // Shadow Image spells
-    NPC_SHADOW_IMAGE                        = 25214,
-    SPELL_SHADOWFURY                        = 45270,
-    SPELL_IMAGE_VISUAL                      = 45263,
-
-    // Alythess spells
-    SPELL_PYROGENICS                        = 45230,        // Self buff; 15secs
-    SPELL_FLAME_TOUCHED                     = 45348,        // Player debuff; removed by shadow damage
-    SPELL_CONFLAGRATION                     = 45342,        // 30-35 secs
-    SPELL_BLAZE                             = 45235,        // On main target every 3 secs; should trigger 45236 which leaves a fire on the ground
-    SPELL_FLAME_SEAR                        = 46771,        // A few random targets debuff
-    SPELL_CONFLAGRATION_UNK                 = 45333,        // Unknown
-
-    DARK_FLAME_AURA_ALYTHESS                = 47300,        // Aura buff that make flame touched spell proc - for Alythess
-    DARK_FLAME_AURA_SCAROLASH               = 45343,        // Aura buff that make dark touched spell proc  - for Scarolash
+    2.5f,                                                   // MOVE_WALK
+    7.0f,                                                   // MOVE_RUN
+    4.5f,                                                   // MOVE_RUN_BACK
+    4.722222f,                                              // MOVE_SWIM
+    2.5f,                                                   // MOVE_SWIM_BACK
+    3.141594f,                                              // MOVE_TURN_RATE
+    7.0f,                                                   // MOVE_FLIGHT
+    4.5f,                                                   // MOVE_FLIGHT_BACK
 };
 
-static const DialogueEntry aIntroDialogue[] =
+typedef std::array<uint32, NUM_SPELL_PARTIAL_RESISTS> SpellPartialResistChanceEntry;
+typedef std::vector<SpellPartialResistChanceEntry> SpellPartialResistDistribution;
+static inline SpellPartialResistDistribution InitSpellPartialResistDistribution()
 {
-    {SAY_INTRO_1, NPC_SACROLASH, 1000},
-    {SAY_INTRO_2, NPC_ALYTHESS,  1500},
-    {SAY_INTRO_3, NPC_SACROLASH, 1500},
-    {SAY_INTRO_4, NPC_ALYTHESS,  1500},
-    {SAY_INTRO_5, NPC_SACROLASH, 1500},
-    {SAY_INTRO_6, NPC_ALYTHESS,  1500},
-    {SAY_INTRO_7, NPC_SACROLASH, 2500},
-    {SAY_INTRO_8, NPC_ALYTHESS,  0},
-    {0, 0, 0},
-};
-
-
-/*######
-## boss_alythess
-######*/
-
-struct boss_alythessAI : public ScriptedAI
-{
-    boss_alythessAI(Creature* pCreature) : ScriptedAI(pCreature),
-        m_introDialogue(aIntroDialogue)
+    // Precalculated chances for 0-100% mitigation
+    // We use integer random instead of floats, so each chance is premultiplied by 100 (100.00 becomes 10000)
+    const SpellPartialResistDistribution precalculated = {
+        {{10000,0,0,0,0}},
+        {{9700,200,100,0,0}},
+        {{9400,400,200,0,0}},
+        {{9000,800,200,0,0}},
+        {{8700,1000,300,0,0}},
+        {{8400,1200,400,0,0}},
+        {{8200,1300,400,100,0}},
+        {{7900,1500,500,100,0}},
+        {{7600,1700,600,100,0}},
+        {{7300,1900,700,100,0}},
+        {{6900,2300,700,100,0}},
+        {{6600,2500,800,100,0}},
+        {{6300,2700,900,100,0}},
+        {{6000,2900,1000,100,0}},
+        {{5800,3000,1000,200,0}},
+        {{5400,3300,1100,200,0}},
+        {{5100,3600,1100,200,0}},
+        {{4800,3800,1200,200,0}},
+        {{4400,4200,1200,200,0}},
+        {{4100,4400,1300,200,0}},
+        {{3700,4800,1300,200,0}},
+        {{3400,5000,1400,200,0}},
+        {{3100,5200,1500,200,0}},
+        {{3000,5200,1500,200,100}},
+        {{2800,5300,1500,300,100}},
+        {{2500,5500,1600,300,100}},
+        {{2400,5400,1700,400,100}},
+        {{2300,5300,1800,500,100}},
+        {{2200,5100,2100,500,100}},
+        {{2100,5000,2200,600,100}},
+        {{2000,4900,2400,600,100}},
+        {{1900,4700,2600,700,100}},
+        {{1800,4600,2700,800,100}},
+        {{1700,4400,3000,800,100}},
+        {{1600,4300,3100,900,100}},
+        {{1500,4200,3200,1000,100}},
+        {{1400,4100,3300,1100,100}},
+        {{1300,3900,3600,1100,100}},
+        {{1300,3600,3800,1200,100}},
+        {{1200,3500,3900,1300,100}},
+        {{1100,3400,4000,1400,100}},
+        {{1000,3300,4100,1500,100}},
+        {{900,3100,4400,1500,100}},
+        {{800,3000,4500,1600,100}},
+        {{800,2700,4700,1700,100}},
+        {{700,2600,4800,1800,100}},
+        {{600,2500,4900,1900,100}},
+        {{600,2300,5000,1900,200}},
+        {{500,2200,5100,2000,200}},
+        {{300,2200,5300,2000,200}},
+        {{200,2100,5400,2100,200}},
+        {{200,2000,5300,2200,300}},
+        {{200,2000,5100,2200,500}},
+        {{200,1900,5000,2300,600}},
+        {{100,1900,4900,2500,600}},
+        {{100,1800,4800,2600,700}},
+        {{100,1700,4700,2700,800}},
+        {{100,1600,4500,3000,800}},
+        {{100,1500,4400,3100,900}},
+        {{100,1500,4100,3300,1000}},
+        {{100,1400,4000,3400,1100}},
+        {{100,1300,3900,3500,1200}},
+        {{100,1200,3800,3600,1300}},
+        {{100,1100,3600,3900,1300}},
+        {{100,1100,3300,4100,1400}},
+        {{100,1000,3200,4200,1500}},
+        {{100,900,3100,4300,1600}},
+        {{100,800,3000,4400,1700}},
+        {{100,800,2700,4600,1800}},
+        {{100,700,2600,4700,1900}},
+        {{100,600,2400,4900,2000}},
+        {{100,600,2200,5000,2100}},
+        {{100,500,2100,5100,2200}},
+        {{100,500,1800,5300,2300}},
+        {{100,400,1700,5400,2400}},
+        {{100,300,1600,5500,2500}},
+        {{100,300,1500,5300,2800}},
+        {{100,200,1500,5200,3000}},
+        {{0,200,1500,5200,3100}},
+        {{0,200,1400,5000,3400}},
+        {{0,200,1300,4800,3700}},
+        {{0,200,1300,4400,4100}},
+        {{0,200,1200,4200,4400}},
+        {{0,200,1200,3800,4800}},
+        {{0,200,1100,3600,5100}},
+        {{0,200,1100,3300,5400}},
+        {{0,200,1000,3000,5800}},
+        {{0,100,1000,2900,6000}},
+        {{0,100,900,2700,6300}},
+        {{0,100,800,2500,6600}},
+        {{0,100,700,2300,6900}},
+        {{0,100,700,1900,7300}},
+        {{0,100,600,1700,7600}},
+        {{0,100,500,1500,7900}},
+        {{0,100,400,1300,8200}},
+        {{0,0,400,1200,8400}},
+        {{0,0,300,1000,8700}},
+        {{0,0,200,800,9000}},
+        {{0,0,200,400,9400}},
+        {{0,0,100,200,9700}},
+        {{0,0,0,0,10000}},
+    };
+    // Inflate up to two decimal places of chance %: add all intermediate values and 100% value (100*100 + 1)
+    SpellPartialResistDistribution inflated(10001, {{}});
+    for (size_t row = 0; row < precalculated.size(); ++row)
     {
-        m_pInstance = ((instance_sunwell_plateau*)pCreature->GetInstanceData());
-        m_introDialogue.InitializeDialogueHelper(m_pInstance);
-        Reset();
-    }
-
-    ScriptedInstance* m_pInstance;
-    DialogueHelper m_introDialogue;
-
-    uint32 m_uiEnrageTimer;
-    uint32 m_uiPyrogenicsTimer;
-    uint32 m_uiConflagrationTimer;
-    uint32 m_uiBlazeTimer;
-    uint32 m_uiFlameSearTimer;
-    bool m_bDidIntro;
-
-    void Reset() override
-    {
-        m_uiEnrageTimer = 6 * MINUTE * IN_MILLISECONDS;
-        m_uiPyrogenicsTimer     = 20000;
-        m_uiConflagrationTimer  = urand(25000, 30000);
-        m_uiBlazeTimer          = 1000;
-        m_uiFlameSearTimer      = 5000;
-        m_bDidIntro = false;
-        DoCastSpellIfCan(m_creature, DARK_FLAME_AURA_ALYTHESS);
-    }
-
-    void JustReachedHome() override
-    {
-        if (m_pInstance)
+        const size_t next = (row + 1);
+        const size_t shift = (row * 100);
+        const auto &source = precalculated.at(row);
+        // Check if this is the last one first
+        if (next == precalculated.size())
         {
-            if (m_pInstance->GetData(TYPE_EREDAR_TWINS) != FAIL)
-                m_pInstance->SetData(TYPE_EREDAR_TWINS, FAIL);
-
-            // Respawn dead sister
-            if (Creature* pSister = m_pInstance->GetSingleCreatureFromStorage(NPC_SACROLASH))
+            for (uint8 column = SPELL_PARTIAL_RESIST_NONE; column < NUM_SPELL_PARTIAL_RESISTS; ++column)
+                inflated[shift][column] = source.at(column);
+            break;
+        }
+        const auto &ahead = precalculated.at(next);
+        for (size_t intermediate = 0; intermediate < 100; ++intermediate)
+        {
+            const size_t index = (shift + intermediate);
+            auto &values = inflated[index];
+            for (uint8 column = SPELL_PARTIAL_RESIST_NONE; column < NUM_SPELL_PARTIAL_RESISTS; ++column)
             {
-                if (!pSister->isAlive())
-                    pSister->Respawn();
+                const uint32 base = source.at(column);
+                const uint32 upcoming = ahead.at(column);
+                const int64 diff = (int64(upcoming) - base);
+                // Use bigger types signed math to avoid potential erratic behavior on some compilers...
+                values[column] = uint32(std::max(0.0, (base + std::round(diff * (intermediate / double(100.0))))));
             }
         }
     }
+    return inflated;
+}
 
-    void Aggro(Unit* /*pWho*/) override
+static const SpellPartialResistDistribution SPELL_PARTIAL_RESIST_DISTRIBUTION = InitSpellPartialResistDistribution();
+
+////////////////////////////////////////////////////////////
+// Methods of class MovementInfo
+
+void MovementInfo::Read(ByteBuffer& data)
+{
+    data >> moveFlags;
+    data >> moveFlags2;
+    data >> time;
+    data >> pos.x;
+    data >> pos.y;
+    data >> pos.z;
+    data >> pos.o;
+
+    if (HasMovementFlag(MOVEFLAG_ONTRANSPORT))
     {
-        if (m_pInstance)
+        data >> t_guid;
+        data >> t_pos.x;
+        data >> t_pos.y;
+        data >> t_pos.z;
+        data >> t_pos.o;
+        data >> t_time;
+    }
+
+    if (HasMovementFlag(MovementFlags(MOVEFLAG_SWIMMING | MOVEFLAG_FLYING2)))
+    {
+        data >> s_pitch;
+    }
+
+    data >> fallTime;
+
+    if (HasMovementFlag(MOVEFLAG_FALLING))
+    {
+        data >> jump.velocity;
+        data >> jump.sinAngle;
+        data >> jump.cosAngle;
+        data >> jump.xyspeed;
+    }
+
+    if (HasMovementFlag(MOVEFLAG_SPLINE_ELEVATION))
+    {
+        data >> u_unk1;
+    }
+}
+
+void MovementInfo::Write(ByteBuffer& data) const
+{
+    data << moveFlags;
+    data << moveFlags2;
+    data << time;
+    data << pos.x;
+    data << pos.y;
+    data << pos.z;
+    data << pos.o;
+
+    if (HasMovementFlag(MOVEFLAG_ONTRANSPORT))
+    {
+        data << t_guid;
+        data << t_pos.x;
+        data << t_pos.y;
+        data << t_pos.z;
+        data << t_pos.o;
+        data << t_time;
+    }
+
+    if (HasMovementFlag(MovementFlags(MOVEFLAG_SWIMMING | MOVEFLAG_FLYING2)))
+    {
+        data << s_pitch;
+    }
+
+    data << fallTime;
+
+    if (HasMovementFlag(MOVEFLAG_FALLING))
+    {
+        data << jump.velocity;
+        data << jump.sinAngle;
+        data << jump.cosAngle;
+        data << jump.xyspeed;
+    }
+
+    if (HasMovementFlag(MOVEFLAG_SPLINE_ELEVATION))
+    {
+        data << u_unk1;
+    }
+}
+
+////////////////////////////////////////////////////////////
+// Methods of class GlobalCooldownMgr
+
+bool GlobalCooldownMgr::HasGlobalCooldown(SpellEntry const* spellInfo) const
+{
+    GlobalCooldownList::const_iterator itr = m_GlobalCooldowns.find(spellInfo->StartRecoveryCategory);
+    return itr != m_GlobalCooldowns.end() && itr->second.duration && WorldTimer::getMSTimeDiff(itr->second.cast_time, WorldTimer::getMSTime()) < itr->second.duration;
+}
+
+void GlobalCooldownMgr::AddGlobalCooldown(SpellEntry const* spellInfo, uint32 gcd)
+{
+    m_GlobalCooldowns[spellInfo->StartRecoveryCategory] = GlobalCooldown(gcd, WorldTimer::getMSTime());
+}
+
+void GlobalCooldownMgr::CancelGlobalCooldown(SpellEntry const* spellInfo)
+{
+    m_GlobalCooldowns[spellInfo->StartRecoveryCategory].duration = 0;
+}
+
+////////////////////////////////////////////////////////////
+// Methods of class Unit
+
+Unit::Unit() :
+    movespline(new Movement::MoveSpline()),
+    m_charmInfo(nullptr),
+    i_motionMaster(this),
+    m_regenTimer(0),
+    m_combatData(new CombatData(this))
+{
+    m_objectType |= TYPEMASK_UNIT;
+    m_objectTypeId = TYPEID_UNIT;
+    // 2.3.2 - 0x70
+    m_updateFlag = (UPDATEFLAG_HIGHGUID | UPDATEFLAG_LIVING | UPDATEFLAG_HAS_POSITION);
+
+    m_attackTimer[BASE_ATTACK]   = 0;
+    m_attackTimer[OFF_ATTACK]    = 0;
+    m_attackTimer[RANGED_ATTACK] = 0;
+    m_modAttackSpeedPct[BASE_ATTACK] = 1.0f;
+    m_modAttackSpeedPct[OFF_ATTACK] = 1.0f;
+    m_modAttackSpeedPct[RANGED_ATTACK] = 1.0f;
+
+    m_extraAttacks = 0;
+
+    m_state = 0;
+    m_deathState = ALIVE;
+
+    for (uint32 i = 0; i < CURRENT_MAX_SPELL; ++i)
+        m_currentSpells[i] = nullptr;
+
+    m_castCounter = 0;
+
+    // m_Aura = nullptr;
+    // m_AurasCheck = 2000;
+    // m_removeAuraTimer = 4;
+    m_spellAuraHoldersUpdateIterator = m_spellAuraHolders.end();
+    m_AuraFlags = 0;
+
+    m_Visibility = VISIBILITY_ON;
+    m_AINotifyScheduled = false;
+
+    m_detectInvisibilityMask = 0;
+    m_invisibilityMask = 0;
+    m_transform = 0;
+    m_canModifyStats = false;
+
+    for (int i = 0; i < MAX_SPELL_IMMUNITY; ++i)
+        m_spellImmune[i].clear();
+    for (int i = 0; i < UNIT_MOD_END; ++i)
+    {
+        m_auraModifiersGroup[i][BASE_VALUE] = 0.0f;
+        m_auraModifiersGroup[i][BASE_EXCLUSIVE] = 0.0f;
+        m_auraModifiersGroup[i][BASE_PCT] = 1.0f;
+        m_auraModifiersGroup[i][TOTAL_VALUE] = 0.0f;
+        m_auraModifiersGroup[i][TOTAL_PCT] = 1.0f;
+    }
+
+    // implement 50% base damage from offhand
+    m_auraModifiersGroup[UNIT_MOD_DAMAGE_OFFHAND][TOTAL_PCT] = 0.5f;
+
+    for (int i = 0; i < MAX_ATTACK; ++i)
+    {
+        m_weaponDamage[i][MINDAMAGE] = BASE_MINDAMAGE;
+        m_weaponDamage[i][MAXDAMAGE] = BASE_MAXDAMAGE;
+    }
+    for (int i = 0; i < MAX_STATS; ++i)
+        m_createStats[i] = 0.0f;
+
+    m_attacking = nullptr;
+    m_modMeleeHitChance = 0.0f;
+    m_modRangedHitChance = 0.0f;
+    m_modSpellHitChance = 0.0f;
+    for (int i = 0; i < MAX_SPELL_SCHOOL; ++i)
+        m_modSpellCritChance[i] = 0.0f;
+
+    for (int i = 0; i < MAX_ATTACK; ++i)
+        m_modCritChance[i] = 0.0f;
+    m_modDodgeChance = 0.0f;
+    m_modParryChance = 0.0f;
+    m_modBlockChance = 0.0f;
+
+    m_canDodge = true;
+    m_canParry = true;
+    m_canBlock = true;
+
+    m_CombatTimer = 0;
+    m_lastManaUseTimer = 0;
+
+    // m_victimThreat = 0.0f;
+    for (int i = 0; i < MAX_SPELL_SCHOOL; ++i)
+        m_threatModifier[i] = 1.0f;
+    m_isSorted = true;
+    for (int i = 0; i < MAX_MOVE_TYPE; ++i)
+        m_speed_rate[i] = 1.0f;
+
+    // remove aurastates allowing special moves
+    for (int i = 0; i < MAX_REACTIVE; ++i)
+        m_reactiveTimer[i] = 0;
+
+    m_isCreatureLinkingTrigger = false;
+    m_isSpawningLinked = false;
+}
+
+Unit::~Unit()
+{
+    // set current spells as deletable
+    for (uint32 i = 0; i < CURRENT_MAX_SPELL; ++i)
+    {
+        if (m_currentSpells[i])
         {
-            if (m_pInstance->GetData(TYPE_EREDAR_TWINS) != IN_PROGRESS)
-                m_pInstance->SetData(TYPE_EREDAR_TWINS, IN_PROGRESS);
+            m_currentSpells[i]->SetReferencedFromCurrent(false);
+            m_currentSpells[i] = nullptr;
         }
     }
 
-    void AttackStart(Unit* pWho) override
-    {
-        if (m_creature->Attack(pWho, false))
-        {
-            m_creature->AddThreat(pWho);
-            m_creature->SetInCombatWith(pWho);
-            pWho->SetInCombatWith(m_creature);
+    delete m_combatData;
+    delete m_charmInfo;
+    delete movespline;
 
-            // Only range attack
-            m_creature->GetMotionMaster()->MoveChase(pWho, 10.0f);
+    // those should be already removed at "RemoveFromWorld()" call
+    MANGOS_ASSERT(m_gameObj.size() == 0);
+    MANGOS_ASSERT(m_dynObjGUIDs.size() == 0);
+    MANGOS_ASSERT(m_deletedAuras.size() == 0);
+    MANGOS_ASSERT(m_deletedHolders.size() == 0);
+}
+
+void Unit::Update(uint32 update_diff, uint32 p_time)
+{
+    if (!IsInWorld())
+        return;
+
+    /*if(p_time > m_AurasCheck)
+    {
+    m_AurasCheck = 2000;
+    _UpdateAura();
+    }else
+    m_AurasCheck -= p_time;*/
+
+    // WARNING! Order of execution here is important, do not change.
+    // Spells must be processed with event system BEFORE they go to _UpdateSpells.
+    // Or else we may have some SPELL_STATE_FINISHED spells stalled in pointers, that is bad.
+    m_Events.Update(update_diff);
+    _UpdateSpells(update_diff);
+
+    CleanupDeletedAuras();
+
+    if (m_lastManaUseTimer)
+    {
+        if (update_diff >= m_lastManaUseTimer)
+            m_lastManaUseTimer = 0;
+        else
+            m_lastManaUseTimer -= update_diff;
+    }
+
+    if (!CanHaveThreatList() && isInCombat())
+    {
+        // update combat timer only for players and pets (they have no threat list)
+        // Check UNIT_STAT_MELEE_ATTACKING or UNIT_STAT_CHASE (without UNIT_STAT_FOLLOW in this case) so pets can reach far away
+        // targets without stopping half way there and running off.
+        // These flags are reset after target dies or another command is given.
+        if (getHostileRefManager().isEmpty())
+        {
+            // m_CombatTimer set at aura start and it will be freeze until aura removing
+            if (m_CombatTimer <= update_diff)
+                CombatStop();
+            else
+                m_CombatTimer -= update_diff;
         }
     }
 
-    void KilledUnit(Unit* /*pVictim*/) override
+    if (uint32 base_att = getAttackTimer(BASE_ATTACK))
     {
-        DoScriptText(urand(0, 1) ? SAY_ALYTHESS_KILL_1 : SAY_ALYTHESS_KILL_2, m_creature);
+        setAttackTimer(BASE_ATTACK, (update_diff >= base_att ? 0 : base_att - update_diff));
     }
 
-    void JustDied(Unit* /*pKiller*/) override
+    if (uint32 base_att = getAttackTimer(OFF_ATTACK))
     {
-        if (m_pInstance)
+        setAttackTimer(OFF_ATTACK, (update_diff >= base_att ? 0 : base_att - update_diff));
+    }
+
+    // update abilities available only for fraction of time
+    UpdateReactives(update_diff);
+
+    UpdateSplineMovement(p_time);
+    i_motionMaster.UpdateMotion(p_time);
+
+    if (AI() && isAlive())
+        AI()->UpdateAI(p_time);   // AI not react good at real update delays (while freeze in non-active part of map)
+
+    if (isAlive())
+    {
+        ModifyAuraState(AURA_STATE_HEALTHLESS_20_PERCENT, GetHealth() < GetMaxHealth() * 0.20f);
+        ModifyAuraState(AURA_STATE_HEALTHLESS_35_PERCENT, GetHealth() < GetMaxHealth() * 0.35f);
+    }
+}
+
+bool Unit::UpdateMeleeAttackingState()
+{
+    Unit* victim = getVictim();
+    if (!victim || IsNonMeleeSpellCasted(false))
+        return false;
+
+    if (!isAttackReady(BASE_ATTACK) && !(isAttackReady(OFF_ATTACK) && haveOffhandWeapon()))
+        return false;
+
+    uint8 swingError = 0;
+    if (!CanReachWithMeleeAttack(victim))
+    {
+        setAttackTimer(BASE_ATTACK, 100);
+        setAttackTimer(OFF_ATTACK, 100);
+        swingError = 1;
+    }
+    // 120 degrees of radiant range
+    else if (!HasInArc(2 * M_PI_F / 3, victim))
+    {
+        setAttackTimer(BASE_ATTACK, 100);
+        setAttackTimer(OFF_ATTACK, 100);
+        swingError = 2;
+    }
+    else
+    {
+        if (isAttackReady(BASE_ATTACK))
         {
-            if (Creature* pSacrolash = m_pInstance->GetSingleCreatureFromStorage(NPC_SACROLASH))
+            // prevent base and off attack in same time, delay attack at 0.2 sec
+            if (haveOffhandWeapon())
             {
-                if (!pSacrolash->isAlive())
-                {
-                    m_pInstance->SetData(TYPE_EREDAR_TWINS, DONE);
-                    DoScriptText(SAY_ALYTHESS_DEAD, m_creature);
-                }
+                if (getAttackTimer(OFF_ATTACK) < ATTACK_DISPLAY_DELAY)
+                    setAttackTimer(OFF_ATTACK, ATTACK_DISPLAY_DELAY);
+            }
+            AttackerStateUpdate(victim, BASE_ATTACK);
+            resetAttackTimer(BASE_ATTACK);
+        }
+        if (haveOffhandWeapon() && isAttackReady(OFF_ATTACK))
+        {
+            // prevent base and off attack in same time, delay attack at 0.2 sec
+            uint32 base_att = getAttackTimer(BASE_ATTACK);
+            if (base_att < ATTACK_DISPLAY_DELAY)
+                setAttackTimer(BASE_ATTACK, ATTACK_DISPLAY_DELAY);
+            // do attack
+            AttackerStateUpdate(victim, OFF_ATTACK);
+            resetAttackTimer(OFF_ATTACK);
+        }
+    }
+
+    Player* player = (GetTypeId() == TYPEID_PLAYER ? (Player*)this : nullptr);
+    if (player && swingError != player->LastSwingErrorMsg())
+    {
+        if (swingError == 1)
+            player->SendAttackSwingNotInRange();
+        else if (swingError == 2)
+            player->SendAttackSwingBadFacingAttack();
+        player->SwingErrorMsg(swingError);
+    }
+
+    return !!swingError;
+}
+
+bool Unit::haveOffhandWeapon() const
+{
+    if (!CanUseEquippedWeapon(OFF_ATTACK))
+        return false;
+
+    if (GetTypeId() == TYPEID_PLAYER)
+        return !!((Player*)this)->GetWeaponForAttack(OFF_ATTACK, true, true);
+    else
+    {
+        uint8 itemClass = GetByteValue(UNIT_VIRTUAL_ITEM_INFO + (1 * 2) + 0, VIRTUAL_ITEM_INFO_0_OFFSET_CLASS);
+        if (itemClass == ITEM_CLASS_WEAPON)
+            return true;
+
+        return false;
+    }
+}
+
+void Unit::SendHeartBeat()
+{
+    m_movementInfo.UpdateTime(WorldTimer::getMSTime());
+    WorldPacket data(MSG_MOVE_HEARTBEAT, 64);
+    data << GetPackGUID();
+    data << m_movementInfo;
+    SendMessageToSet(data, true);
+}
+
+void Unit::resetAttackTimer(WeaponAttackType type)
+{
+    m_attackTimer[type] = uint32(GetAttackTime(type) * m_modAttackSpeedPct[type]);
+}
+
+float Unit::GetCombatReach(Unit const* pVictim, bool forMeleeRange /*=true*/, float flat_mod /*=0.0f*/) const
+{
+    // The measured values show BASE_MELEE_OFFSET in (1.3224, 1.342)
+    float reach = GetFloatValue(UNIT_FIELD_COMBATREACH) + pVictim->GetFloatValue(UNIT_FIELD_COMBATREACH) +
+                  BASE_MELEERANGE_OFFSET + flat_mod;
+
+    if (forMeleeRange && reach < ATTACK_DISTANCE)
+        reach = ATTACK_DISTANCE;
+
+    return reach;
+}
+
+float Unit::GetCombatDistance(Unit const* target, bool forMeleeRange) const
+{
+    float radius = GetCombatReach(target, forMeleeRange);
+
+    float dx = GetPositionX() - target->GetPositionX();
+    float dy = GetPositionY() - target->GetPositionY();
+    float dz = GetPositionZ() - target->GetPositionZ();
+    float dist = sqrt((dx * dx) + (dy * dy) + (dz * dz)) - radius;
+
+    return (dist > 0.0f ? dist : 0.0f);
+}
+
+bool Unit::CanReachWithMeleeAttack(Unit const* pVictim, float flat_mod /*= 0.0f*/) const
+{
+    MANGOS_ASSERT(pVictim);
+
+    float reach = GetCombatReach(pVictim, true, flat_mod);
+
+    // This check is not related to bounding radius
+    float dx = GetPositionX() - pVictim->GetPositionX();
+    float dy = GetPositionY() - pVictim->GetPositionY();
+    float dz = GetPositionZ() - pVictim->GetPositionZ();
+
+    return dx * dx + dy * dy + dz * dz < reach * reach;
+}
+
+void Unit::RemoveSpellsCausingAura(AuraType auraType)
+{
+    for (AuraList::const_iterator iter = m_modAuras[auraType].begin(); iter != m_modAuras[auraType].end();)
+    {
+        RemoveAurasDueToSpell((*iter)->GetId());
+        iter = m_modAuras[auraType].begin();
+    }
+}
+
+void Unit::RemoveSpellsCausingAura(AuraType auraType, SpellAuraHolder* except)
+{
+    for (AuraList::const_iterator iter = m_modAuras[auraType].begin(); iter != m_modAuras[auraType].end();)
+    {
+        // skip `except` aura
+        if ((*iter)->GetHolder() == except)
+        {
+            ++iter;
+            continue;
+        }
+
+        RemoveAurasDueToSpell((*iter)->GetId(), except);
+        iter = m_modAuras[auraType].begin();
+    }
+}
+
+void Unit::RemoveSpellsCausingAura(AuraType auraType, ObjectGuid casterGuid)
+{
+    for (AuraList::const_iterator iter = m_modAuras[auraType].begin(); iter != m_modAuras[auraType].end();)
+    {
+        if ((*iter)->GetCasterGuid() == casterGuid)
+        {
+            RemoveAuraHolderFromStack((*iter)->GetId(), 1, casterGuid);
+            iter = m_modAuras[auraType].begin();
+        }
+        else
+            ++iter;
+    }
+}
+
+void Unit::DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb, DamageEffectType damagetype, SpellEntry const* spellProto)
+{
+    if (!pVictim->isAlive() || pVictim->IsTaxiFlying() || (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode()))
+    {
+        if (absorb)
+            *absorb += damage;
+        damage = 0;
+        return;
+    }
+
+    // You don't lose health from damage taken from another player while in a sanctuary
+    // You still see it in the combat log though
+    if (!IsAllowedDamageInArea(pVictim))
+    {
+        if (absorb)
+            *absorb += damage;
+        damage = 0;
+    }
+
+    uint32 originalDamage = damage;
+
+    // Script Event damage Deal
+    if (AI())
+        AI()->DamageDeal(pVictim, damage, damagetype, spellProto);
+    // Script Event damage taken
+    if (pVictim->AI())
+        pVictim->AI()->DamageTaken(this, damage, damagetype, spellProto);
+
+    if (absorb && originalDamage > damage)
+        *absorb += (originalDamage - damage);
+}
+
+uint32 Unit::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDamage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask, SpellEntry const* spellProto, bool durabilityLoss)
+{
+    // remove affects from attacker at any non-DoT damage (including 0 damage)
+    if (damagetype != DOT)
+    {
+        if (damagetype != SELF_DAMAGE_ROGUE_FALL)
+            RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
+        RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+
+        if (pVictim->GetTypeId() == TYPEID_PLAYER && !pVictim->IsStandState() && !pVictim->hasUnitState(UNIT_STAT_STUNNED))
+            pVictim->SetStandState(UNIT_STAND_STATE_STAND);
+    }
+
+    if (!damage)
+    {
+        // Rage from physical damage received .
+        if (cleanDamage && cleanDamage->damage && (damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL) && pVictim->GetTypeId() == TYPEID_PLAYER && (pVictim->GetPowerType() == POWER_RAGE))
+            ((Player*)pVictim)->RewardRage(cleanDamage->damage, 0, false);
+
+        return 0;
+    }
+
+    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamageStart");
+
+    uint32 health = pVictim->GetHealth();
+    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "deal dmg:%d to health:%d ", damage, health);
+
+    // Rage from Damage made (only from direct weapon damage)
+    if (cleanDamage && damagetype == DIRECT_DAMAGE && this != pVictim && GetTypeId() == TYPEID_PLAYER && (GetPowerType() == POWER_RAGE))
+    {
+        uint32 weaponSpeedHitFactor;
+
+        switch (cleanDamage->attackType)
+        {
+            case BASE_ATTACK:
+            {
+                if (cleanDamage->hitOutCome == MELEE_HIT_CRIT)
+                    weaponSpeedHitFactor = uint32(GetAttackTime(cleanDamage->attackType) / 1000.0f * 7);
                 else
-                {
-                    // Remove loot flag and cast empower
-                    m_creature->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
-                    DoScriptText(SAY_SACROLASH_EMPOWER, pSacrolash);
-                    pSacrolash->InterruptNonMeleeSpells(true);
-                    pSacrolash->CastSpell(pSacrolash, DARK_FLAME_AURA_ALYTHESS, TRIGGERED_NONE);
-                    pSacrolash->CastSpell(pSacrolash, SPELL_EMPOWER, TRIGGERED_NONE);
-                }
+                    weaponSpeedHitFactor = uint32(GetAttackTime(cleanDamage->attackType) / 1000.0f * 3.5f);
+
+                ((Player*)this)->RewardRage(damage, weaponSpeedHitFactor, true);
+
+                break;
             }
-        }
-    }
-
-    void UpdateAI(const uint32 uiDiff) override
-    {
-        if (m_pInstance && m_pInstance->GetData(TYPE_EREDAR_TWINS) == SPECIAL)
-        {
-            if (!m_bDidIntro)
+            case OFF_ATTACK:
             {
-                m_introDialogue.StartNextDialogueText(SAY_INTRO_1);
-                m_bDidIntro = true;
-            }
-            m_introDialogue.DialogueUpdate(uiDiff);
-        }
-
-        if (!m_creature->SelectHostileTarget() || !m_creature->getVictim())
-            return;
-
-        if (m_uiEnrageTimer < uiDiff)
-        {
-            if (DoCastSpellIfCan(m_creature, SPELL_TWINS_ENRAGE) == CAST_OK)
-            {
-                DoScriptText(SAY_ALYTHESS_BERSERK, m_creature);
-                m_uiEnrageTimer = 6 * MINUTE * IN_MILLISECONDS;
-            }
-        }
-        else
-            m_uiEnrageTimer -= uiDiff;
-
-        if (m_uiPyrogenicsTimer < uiDiff)
-        {
-            if (DoCastSpellIfCan(m_creature, SPELL_PYROGENICS) == CAST_OK)
-                m_uiPyrogenicsTimer = urand(25000, 30000);
-        }
-        else
-            m_uiPyrogenicsTimer -= uiDiff;
-
-        if (m_uiConflagrationTimer < uiDiff)
-        {
-            Unit* pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_TOPAGGRO, 3);
-            if (!pTarget)
-                pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0);
-
-            // If sister is dead cast shadownova instead of conflagration
-            bool bSwitchSpell = m_creature->HasAura(SPELL_EMPOWER);
-            if (DoCastSpellIfCan(pTarget, bSwitchSpell ? SPELL_SHADOW_NOVA : SPELL_CONFLAGRATION) == CAST_OK)
-            {
-                if (!bSwitchSpell)
-                    DoScriptText(SAY_ALYTHESS_CANFLAGRATION, m_creature);
-
-                m_uiConflagrationTimer = urand(20000, 25000);
-            }
-        }
-        else
-            m_uiConflagrationTimer -= uiDiff;
-
-        if (m_uiFlameSearTimer < uiDiff)
-        {
-            if (DoCastSpellIfCan(m_creature, SPELL_FLAME_SEAR) == CAST_OK)
-                m_uiFlameSearTimer = 10000;
-
-        }
-        else
-            m_uiFlameSearTimer -= uiDiff;
-
-        if (m_uiBlazeTimer < uiDiff)
-        {
-            if (DoCastSpellIfCan(m_creature->getVictim(), SPELL_BLAZE) == CAST_OK)
-                m_uiBlazeTimer = 3000;
-        }
-        else
-            m_uiBlazeTimer -= uiDiff;
-    }
-};
-
-/*######
-## boss_sacrolash
-######*/
-
-struct boss_sacrolashAI : public ScriptedAI
-{
-    boss_sacrolashAI(Creature* pCreature) : ScriptedAI(pCreature)
-    {
-        m_pInstance = ((instance_sunwell_plateau*)pCreature->GetInstanceData());
-        Reset();
-    }
-
-    ScriptedInstance* m_pInstance;
-
-    uint32 m_uiEnrageTimer;
-    uint32 m_uiShadowNovaTimer;
-    uint32 m_uiConfoundingBlowTimer;
-    uint32 m_uiShadowBladesTimer;
-    uint32 m_uiSummonShadowImage;
-
-    void Reset() override
-    {
-        m_uiEnrageTimer = 6 * MINUTE * IN_MILLISECONDS;
-        m_uiShadowNovaTimer      = 15000;
-        m_uiConfoundingBlowTimer = 30000;
-        m_uiShadowBladesTimer    = 15000;
-        m_uiSummonShadowImage    = 10000;
-        DoCastSpellIfCan(m_creature, DARK_FLAME_AURA_SCAROLASH);
-    }
-
-    void JustReachedHome() override
-    {
-        if (m_pInstance)
-        {
-            if (m_pInstance->GetData(TYPE_EREDAR_TWINS) != FAIL)
-                m_pInstance->SetData(TYPE_EREDAR_TWINS, FAIL);
-
-            // Respawn dead sister
-            if (Creature* pSister = m_pInstance->GetSingleCreatureFromStorage(NPC_ALYTHESS))
-            {
-                if (!pSister->isAlive())
-                    pSister->Respawn();
-            }
-        }
-    }
-
-    void Aggro(Unit* /*pWho*/) override
-    {
-        if (m_pInstance)
-        {
-            if (m_pInstance->GetData(TYPE_EREDAR_TWINS) != IN_PROGRESS)
-                m_pInstance->SetData(TYPE_EREDAR_TWINS, IN_PROGRESS);
-        }
-    }
-
-    void KilledUnit(Unit* /*pVictim*/) override
-    {
-        DoScriptText(urand(0, 1) ? SAY_SACROLASH_KILL_1 : SAY_SACROLASH_KILL_2, m_creature);
-    }
-
-    void JustDied(Unit* /*pKiller*/) override
-    {
-        if (m_pInstance)
-        {
-            if (Creature* pAlythess = m_pInstance->GetSingleCreatureFromStorage(NPC_ALYTHESS))
-            {
-                if (!pAlythess->isAlive())
-                {
-                    m_pInstance->SetData(TYPE_EREDAR_TWINS, DONE);
-                    DoScriptText(SAY_SACROLASH_DEAD, m_creature);
-                }
+                if (cleanDamage->hitOutCome == MELEE_HIT_CRIT)
+                    weaponSpeedHitFactor = uint32(GetAttackTime(cleanDamage->attackType) / 1000.0f * 3.5f);
                 else
+                    weaponSpeedHitFactor = uint32(GetAttackTime(cleanDamage->attackType) / 1000.0f * 1.75f);
+
+                ((Player*)this)->RewardRage(damage, weaponSpeedHitFactor, true);
+
+                break;
+            }
+            case RANGED_ATTACK:
+                break;
+        }
+    }
+
+    // no xp,health if type 8 /critters/
+    if (pVictim->GetTypeId() == TYPEID_UNIT && pVictim->GetCreatureType() == CREATURE_TYPE_CRITTER)
+    {
+        // TODO: fix this part
+        // Critter may not die of damage taken, instead expect it to run away (no fighting back)
+        // If (this) is TYPEID_PLAYER, (this) will enter combat w/victim, but after some time, automatically leave combat.
+        // It is unclear how it should work for other cases.
+        DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamage critter, critter dies");
+
+        ((Creature*)pVictim)->SetLootRecipient(this);
+
+        JustKilledCreature((Creature*)pVictim, nullptr);
+        pVictim->SetHealth(0);
+
+        return damage;
+    }
+
+    // duel ends when player has 1 or less hp
+    bool duel_hasEnded = false;
+    if (pVictim->GetTypeId() == TYPEID_PLAYER && ((Player*)pVictim)->duel && damage >= (health - 1))
+    {
+        // prevent kill only if killed in duel and killed by opponent or opponent controlled creature
+        if (((Player*)pVictim)->duel->opponent == this || ((Player*)pVictim)->duel->opponent->GetObjectGuid() == GetOwnerGuid())
+            damage = health - 1;
+
+        duel_hasEnded = true;
+    }
+
+    // Get in CombatState
+    if (pVictim != this && damagetype != DOT && (!spellProto || (!IsPositiveSpellTargetMode(spellProto, this, pVictim) && !spellProto->HasAttribute(SPELL_ATTR_EX3_NO_INITIAL_AGGRO))))
+    {
+        SetInCombatWith(pVictim);
+        pVictim->SetInCombatWith(this);
+
+        if (Player* attackedPlayer = pVictim->GetCharmerOrOwnerPlayerOrPlayerItself())
+            SetContestedPvP(attackedPlayer);
+    }
+
+    if (GetTypeId() == TYPEID_PLAYER && this != pVictim)
+    {
+        Player* killer = ((Player*)this);
+
+        // in bg, count dmg if victim is also a player
+        if (pVictim->GetTypeId() == TYPEID_PLAYER)
+        {
+            if (BattleGround* bg = killer->GetBattleGround())
+            {
+                // FIXME: kept by compatibility. don't know in BG if the restriction apply.
+                bg->UpdatePlayerScore(killer, SCORE_DAMAGE_DONE, damage);
+            }
+        }
+    }
+
+    if (pVictim->GetTypeId() == TYPEID_UNIT && !((Creature*)pVictim)->IsPet() && !((Creature*)pVictim)->HasLootRecipient())
+        ((Creature*)pVictim)->SetLootRecipient(this);
+
+    if (health <= damage)
+    {
+        DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamage %s Killed %s", GetGuidStr().c_str(), pVictim->GetGuidStr().c_str());
+
+        /*
+         *                      Preparation: Who gets credit for killing whom, invoke SpiritOfRedemtion?
+         */
+        // for loot will be used only if group_tap == nullptr
+        Player* player_tap = GetCharmerOrOwnerPlayerOrPlayerItself();
+        Group* group_tap = nullptr;
+
+        // in creature kill case group/player tap stored for creature
+        if (pVictim->GetTypeId() == TYPEID_UNIT)
+        {
+            group_tap = ((Creature*)pVictim)->GetGroupLootRecipient();
+
+            if (Player* recipient = ((Creature*)pVictim)->GetOriginalLootRecipient())
+                player_tap = recipient;
+        }
+        // in player kill case group tap selected by player_tap (killer-player itself, or charmer, or owner, etc)
+        else
+        {
+            if (player_tap)
+                group_tap = player_tap->GetGroup();
+        }
+
+        // Spirit of Redemtion Talent
+        bool damageFromSpiritOfRedemtionTalent = spellProto && spellProto->Id == 27795;
+        // if talent known but not triggered (check priest class for speedup check)
+        Aura* spiritOfRedemtionTalentReady = nullptr;
+        if (!damageFromSpiritOfRedemtionTalent &&           // not called from SPELL_AURA_SPIRIT_OF_REDEMPTION
+                pVictim->GetTypeId() == TYPEID_PLAYER && pVictim->getClass() == CLASS_PRIEST)
+        {
+            AuraList const& vDummyAuras = pVictim->GetAurasByType(SPELL_AURA_DUMMY);
+            for (AuraList::const_iterator itr = vDummyAuras.begin(); itr != vDummyAuras.end(); ++itr)
+            {
+                if ((*itr)->GetSpellProto()->SpellIconID == 1654)
                 {
-                    // Remove loot flag and cast empower
-                    m_creature->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
-                    DoScriptText(SAY_ALYTHESS_EMPOWER, pAlythess);
-                    pAlythess->InterruptNonMeleeSpells(true);
-                    pAlythess->CastSpell(pAlythess, DARK_FLAME_AURA_SCAROLASH, TRIGGERED_NONE);
-                    pAlythess->CastSpell(pAlythess, SPELL_EMPOWER, TRIGGERED_NONE);
+                    spiritOfRedemtionTalentReady = *itr;
+                    break;
                 }
             }
         }
-    }
 
-    // Return a random target which it's not in range of 10 yards of boss
-    Unit* GetRandomTargetAtDist(float fDist)
+        /*
+         *                      Generic Actions (ProcEvents, Combat-Log, Kill Rewards, Stop Combat)
+         */
+        // call kill spell proc event (before real die and combat stop to triggering auras removed at death/combat stop)
+        if (player_tap && player_tap != pVictim)
+        {
+            player_tap->ProcDamageAndSpell(pVictim, PROC_FLAG_KILL, PROC_FLAG_KILLED, PROC_EX_NONE, 0);
+
+            WorldPacket data(SMSG_PARTYKILLLOG, (8 + 8));   // send event PARTY_KILL
+            data << player_tap->GetObjectGuid();            // player with killing blow
+            data << pVictim->GetObjectGuid();               // victim
+
+            if (group_tap)
+                group_tap->BroadcastPacket(data, false, group_tap->GetMemberGroup(player_tap->GetObjectGuid()), player_tap->GetObjectGuid());
+
+            player_tap->SendDirectMessage(data);
+        }
+        else if (GetTypeId() == TYPEID_UNIT && this != pVictim)
+            ProcDamageAndSpell(pVictim, PROC_FLAG_KILL, PROC_FLAG_KILLED, PROC_EX_NONE, 0);
+
+        // Reward player, his pets, and group/raid members
+        if (player_tap != pVictim)
+        {
+            if (group_tap)
+                group_tap->RewardGroupAtKill(pVictim, player_tap);
+            else if (player_tap)
+                player_tap->RewardSinglePlayerAtKill(pVictim);
+        }
+
+        /*
+         *                      Actions for the killer
+         */
+        if (spiritOfRedemtionTalentReady)
+        {
+            DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamage: Spirit of Redemtion ready");
+
+            // save value before aura remove
+            uint32 ressSpellId = pVictim->GetUInt32Value(PLAYER_SELF_RES_SPELL);
+            if (!ressSpellId)
+                ressSpellId = ((Player*)pVictim)->GetResurrectionSpellId();
+
+            // Remove all expected to remove at death auras (most important negative case like DoT or periodic triggers)
+            pVictim->RemoveAllAurasOnDeath();
+
+            // restore for use at real death
+            pVictim->SetUInt32Value(PLAYER_SELF_RES_SPELL, ressSpellId);
+
+            // FORM_SPIRITOFREDEMPTION and related auras
+            pVictim->CastSpell(pVictim, 27827, TRIGGERED_OLD_TRIGGERED, nullptr, spiritOfRedemtionTalentReady);
+        }
+        else
+            pVictim->SetHealth(0);
+
+        // Call KilledUnit for creatures
+        if (AI())
+            AI()->KilledUnit(pVictim);
+
+        // Call AI OwnerKilledUnit (for any current summoned minipet/guardian/protector)
+        PetOwnerKilledUnit(pVictim);
+
+        /*
+         *                      Actions for the victim
+         */
+        if (pVictim->GetTypeId() == TYPEID_PLAYER)          // Killed player
+        {
+            Player* playerVictim = (Player*)pVictim;
+
+            // remember victim PvP death for corpse type and corpse reclaim delay
+            // at original death (not at SpiritOfRedemtionTalent timeout)
+            if (!damageFromSpiritOfRedemtionTalent)
+                playerVictim->SetPvPDeath(player_tap != nullptr);
+
+            // 10% durability loss on death
+            // only if not player and not controlled by player pet. And not at BG
+            if (durabilityLoss && !player_tap && !playerVictim->InBattleGround())
+            {
+                DEBUG_LOG("DealDamage: Killed %s, looing 10 percents durability", pVictim->GetGuidStr().c_str());
+                playerVictim->DurabilityLossAll(0.10f, false);
+                // durability lost message
+                WorldPacket data(SMSG_DURABILITY_DAMAGE_DEATH, 0);
+                playerVictim->GetSession()->SendPacket(data);
+            }
+
+            if (!spiritOfRedemtionTalentReady)              // Before informing Battleground
+            {
+                DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "SET JUST_DIED");
+                pVictim->SetDeathState(JUST_DIED);
+            }
+
+            // playerVictim was in duel, duel must be interrupted
+            // last damage from non duel opponent or non opponent controlled creature
+            if (duel_hasEnded)
+            {
+                playerVictim->duel->opponent->CombatStopWithPets(true);
+                playerVictim->CombatStopWithPets(true);
+
+                playerVictim->DuelComplete(DUEL_INTERRUPTED);
+            }
+
+            if (player_tap)                                 // PvP kill
+            {
+                if (BattleGround* bg = playerVictim->GetBattleGround())
+                {
+                    bg->HandleKillPlayer(playerVictim, player_tap);
+                }
+                else if (pVictim != this)
+                {
+                    // selfkills are not handled in outdoor pvp scripts
+                    if (OutdoorPvP* outdoorPvP = sOutdoorPvPMgr.GetScript(playerVictim->GetCachedZoneId()))
+                        outdoorPvP->HandlePlayerKill(player_tap, playerVictim);
+                }
+            }
+        }
+        else                                                // Killed creature
+            JustKilledCreature((Creature*)pVictim, player_tap);
+
+        // stop combat
+        DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamageAttackStop");
+        pVictim->CombatStop();
+        pVictim->getHostileRefManager().deleteReferences();
+    }
+    else                                                    // if (health <= damage)
     {
-        std::vector<Unit*> m_vRangeTargets;
+        DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamageAlive");
 
-        ThreatList const& tList = m_creature->getThreatManager().getThreatList();
-        for (ThreatList::const_iterator iter = tList.begin(); iter != tList.end(); ++iter)
+        pVictim->ModifyHealth(- (int32)damage);
+
+        if (damagetype != DOT)
         {
-            if (Unit* pTempTarget = m_creature->GetMap()->GetUnit((*iter)->getUnitGuid()))
+            if (!getVictim())
             {
-                if (!pTempTarget->IsWithinDistInMap(m_creature, fDist))
-                    m_vRangeTargets.push_back(pTempTarget);
+                // if not have main target then attack state with target (including AI call)
+                // start melee attacks only after melee hit
+                Attack(pVictim, (damagetype == DIRECT_DAMAGE));
+            }
+
+            // if damage pVictim call AI reaction
+            pVictim->AttackedBy(this);
+        }
+
+        if (damagetype == DIRECT_DAMAGE || damagetype == SPELL_DIRECT_DAMAGE)
+        {
+            if (!spellProto || !(spellProto->AuraInterruptFlags & AURA_INTERRUPT_FLAG_DIRECT_DAMAGE))
+                pVictim->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_DIRECT_DAMAGE);
+        }
+        if (pVictim->GetTypeId() != TYPEID_PLAYER)
+        {
+            float threat = damage * sSpellMgr.GetSpellThreatMultiplier(spellProto);
+            pVictim->AddThreat(this, threat, (cleanDamage && cleanDamage->hitOutCome == MELEE_HIT_CRIT), damageSchoolMask, spellProto);
+        }
+        else                                                // victim is a player
+        {
+            // Rage from damage received
+            if (this != pVictim && pVictim->GetPowerType() == POWER_RAGE)
+            {
+                uint32 rage_damage = damage + (cleanDamage ? cleanDamage->damage : 0);
+                ((Player*)pVictim)->RewardRage(rage_damage, 0, false);
+            }
+
+            // random durability for items (HIT TAKEN)
+            if (roll_chance_f(sWorld.getConfig(CONFIG_FLOAT_RATE_DURABILITY_LOSS_DAMAGE)))
+            {
+                EquipmentSlots slot = EquipmentSlots(urand(0, EQUIPMENT_SLOT_END - 1));
+                ((Player*)pVictim)->DurabilityPointLossForEquipSlot(slot);
             }
         }
 
-        if (!m_vRangeTargets.empty())
-            return m_vRangeTargets[urand(0, m_vRangeTargets.size() - 1)];
-        else
-            return m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 1);
+        if (GetTypeId() == TYPEID_PLAYER)
+        {
+            // random durability for items (HIT DONE)
+            if (roll_chance_f(sWorld.getConfig(CONFIG_FLOAT_RATE_DURABILITY_LOSS_DAMAGE)))
+            {
+                EquipmentSlots slot = EquipmentSlots(urand(0, EQUIPMENT_SLOT_END - 1));
+                ((Player*)this)->DurabilityPointLossForEquipSlot(slot);
+            }
+        }
+
+        if ((damagetype == DIRECT_DAMAGE || damagetype == SPELL_DIRECT_DAMAGE || damagetype == DOT)
+            && !(spellProto && spellProto->HasAttribute(SPELL_ATTR_EX4_DAMAGE_DOESNT_BREAK_AURAS)))
+        {
+            int32 auraInterruptFlags = AURA_INTERRUPT_FLAG_DAMAGE;
+            if (damagetype != DOT)
+                auraInterruptFlags = (auraInterruptFlags | AURA_INTERRUPT_FLAG_DIRECT_DAMAGE);
+
+            SpellAuraHolderMap& vInterrupts = pVictim->GetSpellAuraHolderMap();
+            std::vector<uint32> cleanupHolder;
+
+            for (auto aura : vInterrupts)
+            {
+                if (spellProto && spellProto->Id == aura.second->GetId()) // Not drop auras added by self
+                    continue;
+
+                const SpellEntry* se = aura.second->GetSpellProto();
+
+                if (!se)
+                    continue;
+
+                if (se->AuraInterruptFlags & auraInterruptFlags)
+                    cleanupHolder.push_back(aura.second->GetId());
+            }
+
+            for (auto aura : cleanupHolder)
+                pVictim->RemoveAurasDueToSpell(aura);
+        }
+
+        if (damagetype != NODAMAGE && damage && pVictim->GetTypeId() == TYPEID_PLAYER)
+        {
+            if (damagetype != DOT)
+            {
+                for (uint32 i = CURRENT_FIRST_NON_MELEE_SPELL; i < CURRENT_MAX_SPELL; ++i)
+                {
+                    // skip channeled spell (processed differently below)
+                    if (i == CURRENT_CHANNELED_SPELL)
+                        continue;
+
+                    if (Spell* spell = pVictim->GetCurrentSpell(CurrentSpellTypes(i)))
+                    {
+                        if (spell->getState() == SPELL_STATE_PREPARING)
+                        {
+                            if (spell->m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_ABORT_ON_DMG)
+                                pVictim->InterruptSpell(CurrentSpellTypes(i));
+                            else
+                                spell->Delayed();
+                        }
+                    }
+                }
+            }
+
+            if (Spell* spell = pVictim->m_currentSpells[CURRENT_CHANNELED_SPELL])
+            {
+                if (spell->getState() == SPELL_STATE_CASTING)
+                {
+                    uint32 channelInterruptFlags = spell->m_spellInfo->ChannelInterruptFlags;
+                    if (channelInterruptFlags & CHANNEL_FLAG_DELAY)
+                    {
+                        if (pVictim != this)                // don't shorten the duration of channeling if you damage yourself
+                            spell->DelayedChannel();
+                    }
+                    else if ((channelInterruptFlags & (CHANNEL_FLAG_DAMAGE | CHANNEL_FLAG_DAMAGE2)))
+                    {
+                        DETAIL_LOG("Spell %u canceled at damage!", spell->m_spellInfo->Id);
+                        pVictim->InterruptSpell(CURRENT_CHANNELED_SPELL);
+                    }
+                }
+                else if (spell->getState() == SPELL_STATE_DELAYED)
+                    // break channeled spell in delayed state on damage
+                {
+                    DETAIL_LOG("Spell %u canceled at damage!", spell->m_spellInfo->Id);
+                    pVictim->InterruptSpell(CURRENT_CHANNELED_SPELL);
+                }
+            }
+        }
+
+        // last damage from duel opponent
+        if (duel_hasEnded)
+        {
+            MANGOS_ASSERT(pVictim->GetTypeId() == TYPEID_PLAYER);
+            Player* he = (Player*)pVictim;
+
+            MANGOS_ASSERT(he->duel);
+
+            he->SetHealth(1);
+
+            he->duel->opponent->CombatStopWithPets(true);
+            he->CombatStopWithPets(true);
+
+            he->CastSpell(he, 7267, TRIGGERED_OLD_TRIGGERED);                  // beg
+            he->DuelComplete(DUEL_WON);
+        }
     }
 
-    void JustSummoned(Creature* pSummoned) override
+    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamageEnd returned %d damage", damage);
+
+    return damage;
+}
+
+struct PetOwnerKilledUnitHelper
+{
+    explicit PetOwnerKilledUnitHelper(Unit* pVictim) : m_victim(pVictim) {}
+    void operator()(Unit* pTarget) const
     {
-        if (pSummoned->GetEntry() == NPC_SHADOW_IMAGE)
+        if (pTarget->GetTypeId() == TYPEID_UNIT)
         {
-            pSummoned->CastSpell(pSummoned, SPELL_IMAGE_VISUAL, TRIGGERED_NONE);
-            // Attack random range target
-            if (Unit* pTarget = GetRandomTargetAtDist(10.0f))
-                pSummoned->AI()->AttackStart(pTarget);
+            if (pTarget->AI())
+                pTarget->AI()->OwnerKilledUnit(m_victim);
         }
     }
 
-    void UpdateAI(const uint32 uiDiff) override
-    {
-        if (!m_creature->SelectHostileTarget() || !m_creature->getVictim())
-            return;
-
-        if (m_uiEnrageTimer < uiDiff)
-        {
-            if (DoCastSpellIfCan(m_creature, SPELL_TWINS_ENRAGE) == CAST_OK)
-            {
-                DoScriptText(SAY_SACROLASH_BERSERK, m_creature);
-                m_uiEnrageTimer = 6 * MINUTE * IN_MILLISECONDS;
-            }
-        }
-        else
-            m_uiEnrageTimer -= uiDiff;
-
-        if (m_uiShadowBladesTimer < uiDiff)
-        {
-            if (DoCastSpellIfCan(m_creature, SPELL_SHADOW_BLADES) == CAST_OK)
-                m_uiShadowBladesTimer = urand(13000, 15000);
-        }
-        else
-            m_uiShadowBladesTimer -= uiDiff;
-
-        if (m_uiShadowNovaTimer < uiDiff)
-        {
-            Unit* pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_TOPAGGRO, 2);
-            if (!pTarget)
-                pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0);
-
-            // If sister is dead cast conflagration instead of shadownova
-            bool bSwitchSpell = m_creature->HasAura(SPELL_EMPOWER);
-            if (DoCastSpellIfCan(pTarget, bSwitchSpell ? SPELL_CONFLAGRATION : SPELL_SHADOW_NOVA) == CAST_OK)
-            {
-                if (!bSwitchSpell)
-                    DoScriptText(SAY_SACROLASH_SHADOW_NOVA, m_creature);
-
-                m_uiShadowNovaTimer = urand(30000, 35000);
-            }
-        }
-        else
-            m_uiShadowNovaTimer -= uiDiff;
-
-        if (m_uiConfoundingBlowTimer < uiDiff)
-        {
-            if (DoCastSpellIfCan(m_creature->getVictim(), SPELL_CONFOUNDING_BLOW) == CAST_OK)
-            {
-                // Reset threat
-                if (m_creature->getThreatManager().getThreat(m_creature->getVictim()))
-                    m_creature->getThreatManager().modifyThreatPercent(m_creature->getVictim(), -100);
-
-                m_uiConfoundingBlowTimer = urand(25000, 30000);
-            }
-        }
-        else
-            m_uiConfoundingBlowTimer -= uiDiff;
-
-        if (m_uiSummonShadowImage < uiDiff)
-        {
-            // Summon 3 shadow images at the boss position
-            for (uint8 i = 0; i < 3; ++i)
-                m_creature->SummonCreature(NPC_SHADOW_IMAGE, 0.0f, 0.0f, 0.0f, 0.0f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 3000);
-
-            m_uiSummonShadowImage = urand(10000, 12000);
-        }
-        else
-            m_uiSummonShadowImage -= uiDiff;
-
-        // Overwrite the melee attack in order to apply the dark strike
-        if (m_creature->CanReachWithMeleeAttack(m_creature->getVictim()))
-        {
-            // Make sure our attack is ready and we aren't currently casting
-            if (m_creature->isAttackReady() && !m_creature->IsNonMeleeSpellCasted(false))
-            {
-                DoCastSpellIfCan(m_creature->getVictim(), SPELL_DARK_STRIKE);
-
-                m_creature->AttackerStateUpdate(m_creature->getVictim());
-                m_creature->resetAttackTimer();
-            }
-        }
-    }
+    Unit* m_victim;
 };
 
-/*######
-## npc_shadow_image
-######*/
-
-struct npc_shadow_imageAI : public ScriptedAI
+void Unit::JustKilledCreature(Creature* victim, Player* responsiblePlayer)
 {
-    npc_shadow_imageAI(Creature* pCreature) : ScriptedAI(pCreature)  { Reset(); }
+    victim->m_deathState = DEAD;                            // so that isAlive, isDead return expected results in the called hooks of JustKilledCreature
+    // must be used only shortly before SetDeathState(JUST_DIED) and only for Creatures or Pets
 
-    uint32 m_uiChosenAbility;
-    uint32 m_uiSuicideTimer;
-    uint32 m_uiAbilityTimer;
-    uint8 m_uiDarkStrikes;
-
-    void Reset() override
+    // some critters required for quests (need normal entry instead possible heroic in any cases)
+    if (victim->GetCreatureType() == CREATURE_TYPE_CRITTER && GetTypeId() == TYPEID_PLAYER)
     {
-        // Choose only one spell for attack
-        m_uiChosenAbility = urand(0, 1) ? SPELL_DARK_STRIKE : SPELL_SHADOWFURY;
-        m_uiAbilityTimer = 500;
-        m_uiDarkStrikes = 0;
-        m_uiSuicideTimer = 0;
+        if (CreatureInfo const* normalInfo = ObjectMgr::GetCreatureTemplate(victim->GetEntry()))
+            ((Player*)this)->KilledMonster(normalInfo, victim->GetObjectGuid());
     }
 
-    void UpdateAI(const uint32 uiDiff) override
+    // Interrupt channeling spell when a Possessed Summoned is killed
+    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(victim->GetUInt32Value(UNIT_CREATED_BY_SPELL));
+    if (spellInfo && spellInfo->HasAttribute(SPELL_ATTR_EX_FARSIGHT) && spellInfo->HasAttribute(SPELL_ATTR_EX_CHANNELED_1))
     {
-        if (!m_creature->SelectHostileTarget() || !m_creature->getVictim())
-            return;
-
-        // Suicide on timer; this is needed because of the cast time
-        if (m_uiSuicideTimer)
+        Unit* creator = GetMap()->GetUnit(victim->GetCreatorGuid());
+        if (creator && creator->GetCharmGuid() == victim->GetObjectGuid())
         {
-            if (m_uiSuicideTimer <= uiDiff)
+            Spell* channeledSpell = creator->GetCurrentSpell(CURRENT_CHANNELED_SPELL);
+            if (channeledSpell && channeledSpell->m_spellInfo->Id == spellInfo->Id)
+                creator->InterruptNonMeleeSpells(false);
+        }
+    }
+
+    /* ******************************* Inform various hooks ************************************ */
+    // Inform victim's AI
+    if (victim->AI())
+        victim->AI()->JustDied(this);
+
+    // Inform Owner
+    Unit* pOwner = victim->GetCharmerOrOwner();
+    if (victim->IsTemporarySummon())
+    {
+        TemporarySummon* pSummon = (TemporarySummon*)victim;
+        if (pSummon->GetSummonerGuid().IsCreature())
+            if (Creature* pSummoner = victim->GetMap()->GetCreature(pSummon->GetSummonerGuid()))
+                if (pSummoner->AI())
+                    pSummoner->AI()->SummonedCreatureJustDied(victim);
+    }
+    else if (pOwner && pOwner->AI())
+        pOwner->AI()->SummonedCreatureJustDied(victim);
+
+    // Inform Instance Data and Linking
+    if (InstanceData* mapInstance = victim->GetInstanceData())
+        mapInstance->OnCreatureDeath(victim);
+
+    if (responsiblePlayer)                                  // killedby Player, inform BG
+        if (BattleGround* bg = responsiblePlayer->GetBattleGround())
+            bg->HandleKillUnit(victim, responsiblePlayer);
+
+    // Notify the outdoor pvp script
+    if (OutdoorPvP* outdoorPvP = sOutdoorPvPMgr.GetScript(responsiblePlayer ? responsiblePlayer->GetCachedZoneId() : GetZoneId()))
+        outdoorPvP->HandleCreatureDeath(victim);
+
+    // Start creature death script
+    GetMap()->ScriptsStart(sCreatureDeathScripts, victim->GetEntry(), victim, responsiblePlayer ? responsiblePlayer : this);
+
+    if (victim->IsLinkingEventTrigger())
+        victim->GetMap()->GetCreatureLinkingHolder()->DoCreatureLinkingEvent(LINKING_EVENT_DIE, victim);
+
+    // Dungeon specific stuff
+    if (victim->GetInstanceId())
+    {
+        Map* m = victim->GetMap();
+        Player* creditedPlayer = GetCharmerOrOwnerPlayerOrPlayerItself();
+        // TODO: do instance binding anyway if the charmer/owner is offline
+
+        if (m->IsDungeon() && creditedPlayer)
+        {
+            if (m->IsRaidOrHeroicDungeon())
             {
-                m_creature->DealDamage(m_creature, m_creature->GetHealth(), nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, nullptr, false);
-                return;
+                if (victim->GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_INSTANCE_BIND)
+                    ((DungeonMap*)m)->PermBindAllPlayers(creditedPlayer);
             }
             else
-                m_uiSuicideTimer -= uiDiff;
+            {
+                DungeonPersistentState* save = ((DungeonMap*)m)->GetPersistanceState();
+                // the reset time is set but not added to the scheduler
+                // until the players leave the instance
+                time_t resettime = victim->GetRespawnTimeEx() + 2 * HOUR;
+                if (save->GetResetTime() < resettime)
+                    save->SetResetTime(resettime);
+            }
+        }
+    }
+
+    bool isPet = victim->IsPet();
+
+    /* ********************************* Set Death finally ************************************* */
+    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "SET JUST_DIED");
+    victim->SetDeathState(JUST_DIED);                       // if !spiritOfRedemtionTalentReady always true for unit
+
+    if (isPet)
+        return;                                             // Pets might have been unsummoned at this place, do not handle them further!
+
+    /* ******************************** Prepare loot if can ************************************ */
+    victim->DeleteThreatList();
+
+    // only lootable if it has loot or can drop gold
+    victim->PrepareBodyLootState();
+}
+
+void Unit::PetOwnerKilledUnit(Unit* pVictim)
+{
+    // for minipet and guardians (including protector)
+    CallForAllControlledUnits(PetOwnerKilledUnitHelper(pVictim), CONTROLLED_MINIPET | CONTROLLED_GUARDIANS);
+}
+
+void Unit::CastStop(uint32 except_spellid)
+{
+    for (uint32 i = CURRENT_FIRST_NON_MELEE_SPELL; i < CURRENT_MAX_SPELL; ++i)
+        if (m_currentSpells[i] && m_currentSpells[i]->m_spellInfo->Id != except_spellid)
+            InterruptSpell(CurrentSpellTypes(i), false);
+}
+
+SpellCastResult Unit::CastSpell(Unit* Victim, uint32 spellId, uint32 triggeredFlags, Item* castItem, Aura* triggeredByAura, ObjectGuid originalCaster, SpellEntry const* triggeredBy)
+{
+    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
+
+    if (!spellInfo)
+    {
+        if (triggeredByAura)
+            sLog.outError("CastSpell: unknown spell id %i by caster: %s triggered by aura %u (eff %u)", spellId, GetGuidStr().c_str(), triggeredByAura->GetId(), triggeredByAura->GetEffIndex());
+        else
+            sLog.outError("CastSpell: unknown spell id %i by caster: %s", spellId, GetGuidStr().c_str());
+        return SPELL_NOT_FOUND;
+    }
+
+    return CastSpell(Victim, spellInfo, triggeredFlags, castItem, triggeredByAura, originalCaster, triggeredBy);
+}
+
+SpellCastResult Unit::CastSpell(Unit* Victim, SpellEntry const* spellInfo, uint32 triggeredFlags, Item* castItem, Aura* triggeredByAura, ObjectGuid originalCaster, SpellEntry const* triggeredBy)
+{
+    if (!spellInfo)
+    {
+        if (triggeredByAura)
+            sLog.outError("CastSpell: unknown spell by caster: %s triggered by aura %u (eff %u)", GetGuidStr().c_str(), triggeredByAura->GetId(), triggeredByAura->GetEffIndex());
+        else
+            sLog.outError("CastSpell: unknown spell by caster: %s", GetGuidStr().c_str());
+
+        return SPELL_NOT_FOUND;
+    }
+
+    if (castItem)
+        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: cast Item spellId - %i", spellInfo->Id);
+
+    if (triggeredByAura)
+    {
+        if (!originalCaster)
+            originalCaster = triggeredByAura->GetCasterGuid();
+
+        triggeredBy = triggeredByAura->GetSpellProto();
+    }
+
+    Spell* spell = new Spell(this, spellInfo, triggeredFlags, originalCaster, triggeredBy);
+
+    SpellCastTargets targets;
+    targets.setUnitTarget(Victim);
+
+    if (spellInfo->Targets & TARGET_FLAG_DEST_LOCATION)
+        targets.setDestination(Victim->GetPositionX(), Victim->GetPositionY(), Victim->GetPositionZ());
+    if (spellInfo->Targets & TARGET_FLAG_SOURCE_LOCATION)
+        if (WorldObject* caster = spell->GetCastingObject())
+            targets.setSource(caster->GetPositionX(), caster->GetPositionY(), caster->GetPositionZ());
+
+    spell->m_CastItem = castItem;
+    return spell->SpellStart(&targets, triggeredByAura);
+}
+
+SpellCastResult Unit::CastCustomSpell(Unit* Victim, uint32 spellId, int32 const* bp0, int32 const* bp1, int32 const* bp2, uint32 triggeredFlags, Item* castItem, Aura* triggeredByAura, ObjectGuid originalCaster, SpellEntry const* triggeredBy)
+{
+    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
+
+    if (!spellInfo)
+    {
+        if (triggeredByAura)
+            sLog.outError("CastCustomSpell: unknown spell id %i by caster: %s triggered by aura %u (eff %u)", spellId, GetGuidStr().c_str(), triggeredByAura->GetId(), triggeredByAura->GetEffIndex());
+        else
+            sLog.outError("CastCustomSpell: unknown spell id %i by caster: %s", spellId, GetGuidStr().c_str());
+        return SPELL_NOT_FOUND;
+    }
+
+    return CastCustomSpell(Victim, spellInfo, bp0, bp1, bp2, triggeredFlags, castItem, triggeredByAura, originalCaster, triggeredBy);
+}
+
+SpellCastResult Unit::CastCustomSpell(Unit* Victim, SpellEntry const* spellInfo, int32 const* bp0, int32 const* bp1, int32 const* bp2, uint32 triggeredFlags, Item* castItem, Aura* triggeredByAura, ObjectGuid originalCaster, SpellEntry const* triggeredBy)
+{
+    if (!spellInfo)
+    {
+        if (triggeredByAura)
+            sLog.outError("CastCustomSpell: unknown spell by caster: %s triggered by aura %u (eff %u)", GetGuidStr().c_str(), triggeredByAura->GetId(), triggeredByAura->GetEffIndex());
+        else
+            sLog.outError("CastCustomSpell: unknown spell by caster: %s", GetGuidStr().c_str());
+        return SPELL_NOT_FOUND;
+    }
+
+    if (castItem)
+        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: cast Item spellId - %i", spellInfo->Id);
+
+    if (triggeredByAura)
+    {
+        if (!originalCaster)
+            originalCaster = triggeredByAura->GetCasterGuid();
+
+        triggeredBy = triggeredByAura->GetSpellProto();
+    }
+
+    Spell* spell = new Spell(this, spellInfo, triggeredFlags, originalCaster, triggeredBy);
+
+    if (bp0)
+        spell->m_currentBasePoints[EFFECT_INDEX_0] = *bp0;
+
+    if (bp1)
+        spell->m_currentBasePoints[EFFECT_INDEX_1] = *bp1;
+
+    if (bp2)
+        spell->m_currentBasePoints[EFFECT_INDEX_2] = *bp2;
+
+    SpellCastTargets targets;
+    targets.setUnitTarget(Victim);
+    spell->m_CastItem = castItem;
+
+    if (spellInfo->Targets & TARGET_FLAG_DEST_LOCATION)
+        targets.setDestination(Victim->GetPositionX(), Victim->GetPositionY(), Victim->GetPositionZ());
+    if (spellInfo->Targets & TARGET_FLAG_SOURCE_LOCATION)
+        if (WorldObject* caster = spell->GetCastingObject())
+            targets.setSource(caster->GetPositionX(), caster->GetPositionY(), caster->GetPositionZ());
+
+    return spell->SpellStart(&targets, triggeredByAura);
+}
+
+// used for scripting
+SpellCastResult Unit::CastSpell(float x, float y, float z, uint32 spellId, uint32 triggeredFlags, Item* castItem, Aura* triggeredByAura, ObjectGuid originalCaster, SpellEntry const* triggeredBy)
+{
+    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
+
+    if (!spellInfo)
+    {
+        if (triggeredByAura)
+            sLog.outError("CastSpell(x,y,z): unknown spell id %i by caster: %s triggered by aura %u (eff %u)", spellId, GetGuidStr().c_str(), triggeredByAura->GetId(), triggeredByAura->GetEffIndex());
+        else
+            sLog.outError("CastSpell(x,y,z): unknown spell id %i by caster: %s", spellId, GetGuidStr().c_str());
+        return SPELL_NOT_FOUND;
+    }
+
+    return CastSpell(x, y, z, spellInfo, triggeredFlags, castItem, triggeredByAura, originalCaster, triggeredBy);
+}
+
+// used for scripting
+SpellCastResult Unit::CastSpell(float x, float y, float z, SpellEntry const* spellInfo, uint32 triggeredFlags, Item* castItem, Aura* triggeredByAura, ObjectGuid originalCaster, SpellEntry const* triggeredBy)
+{
+    if (!spellInfo)
+    {
+        if (triggeredByAura)
+            sLog.outError("CastSpell(x,y,z): unknown spell by caster: %s triggered by aura %u (eff %u)", GetGuidStr().c_str(), triggeredByAura->GetId(), triggeredByAura->GetEffIndex());
+        else
+            sLog.outError("CastSpell(x,y,z): unknown spell by caster: %s", GetGuidStr().c_str());
+        return SPELL_NOT_FOUND;
+    }
+
+    if (castItem)
+        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: cast Item spellId - %i", spellInfo->Id);
+
+    if (triggeredByAura)
+    {
+        if (!originalCaster)
+            originalCaster = triggeredByAura->GetCasterGuid();
+
+        triggeredBy = triggeredByAura->GetSpellProto();
+    }
+
+    Spell* spell = new Spell(this, spellInfo, triggeredFlags, originalCaster, triggeredBy);
+
+    SpellCastTargets targets;
+
+    if (spellInfo->Targets & TARGET_FLAG_DEST_LOCATION)
+        targets.setDestination(x, y, z);
+    if (spellInfo->Targets & TARGET_FLAG_SOURCE_LOCATION)
+        targets.setSource(x, y, z);
+
+    // Spell cast with x,y,z but without dbc target-mask, set destination
+    if (!(targets.m_targetMask & (TARGET_FLAG_DEST_LOCATION | TARGET_FLAG_SOURCE_LOCATION)))
+        targets.setDestination(x, y, z);
+
+    spell->m_CastItem = castItem;
+    return spell->SpellStart(&targets, triggeredByAura);
+}
+
+// Obsolete func need remove, here only for comotability vs another patches
+uint32 Unit::SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage)
+{
+    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellID);
+    SpellNonMeleeDamage damageInfo(this, pVictim, spellInfo->Id, SpellSchoolMask(spellInfo->SchoolMask));
+    CalculateSpellDamage(&damageInfo, damage, spellInfo);
+    damageInfo.target->CalculateAbsorbResistBlock(this, &damageInfo, spellInfo);
+    DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE, spellInfo);
+    SendSpellNonMeleeDamageLog(&damageInfo);
+    DealSpellDamage(&damageInfo, true);
+    return damageInfo.damage;
+}
+
+void Unit::CalculateSpellDamage(SpellNonMeleeDamage* damageInfo, int32 damage, SpellEntry const* spellInfo, WeaponAttackType attackType)
+{
+    SpellSchoolMask damageSchoolMask = damageInfo->schoolMask;
+    Unit* pVictim = damageInfo->target;
+
+    if (damage < 0)
+        return;
+
+    if (!this || !pVictim)
+        return;
+
+    // units which are not alive cannot deal damage except for dying creatures
+    if ((!this->isAlive() || !pVictim->isAlive()) && (this->GetTypeId() != TYPEID_UNIT || this->getDeathState() != DEAD))
+        return;
+
+    // Check spell crit chance
+    bool crit = IsSpellCrit(pVictim, spellInfo, damageSchoolMask, attackType);
+
+    // damage bonus (per damage class)
+    switch (spellInfo->DmgClass)
+    {
+        // Melee and Ranged Spells
+        case SPELL_DAMAGE_CLASS_RANGED:
+        case SPELL_DAMAGE_CLASS_MELEE:
+        {
+            // Calculate damage bonus
+            damage = MeleeDamageBonusDone(pVictim, damage, attackType, spellInfo, SPELL_DIRECT_DAMAGE);
+            damage = pVictim->MeleeDamageBonusTaken(this, damage, attackType, spellInfo, SPELL_DIRECT_DAMAGE);
+        }
+        break;
+        // Magical Attacks
+        case SPELL_DAMAGE_CLASS_NONE:
+        case SPELL_DAMAGE_CLASS_MAGIC:
+        {
+            // Calculate damage bonus
+            damage = SpellDamageBonusDone(pVictim, spellInfo, damage, SPELL_DIRECT_DAMAGE);
+            damage = pVictim->SpellDamageBonusTaken(this, spellInfo, damage, SPELL_DIRECT_DAMAGE);
+        }
+        break;
+    }
+
+    // if crit add critical bonus
+    if (crit)
+    {
+        damageInfo->HitInfo |= SPELL_HIT_TYPE_CRIT;
+        damage = CalculateCritAmount(pVictim, damage, spellInfo);
+    }
+
+    // damage mitigation
+    if (damage > 0)
+    {
+        // physical damage => armor
+        if (damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL)
+            damage = CalcArmorReducedDamage(pVictim, damage);
+    }
+    else
+        damage = 0;
+    damageInfo->damage = damage;
+}
+
+void Unit::DealSpellDamage(SpellNonMeleeDamage* damageInfo, bool durabilityLoss)
+{
+    if (!damageInfo)
+        return;
+
+    Unit* pVictim = damageInfo->target;
+
+    if (!this || !pVictim)
+        return;
+
+    if (!pVictim->isAlive() || pVictim->IsTaxiFlying() || (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode()))
+        return;
+
+    SpellEntry const* spellProto = sSpellTemplate.LookupEntry<SpellEntry>(damageInfo->SpellID);
+    if (spellProto == nullptr)
+    {
+        sLog.outError("Unit::DealSpellDamage have wrong damageInfo->SpellID: %u", damageInfo->SpellID);
+        return;
+    }
+
+    // You don't lose health from damage taken from another player while in a sanctuary
+    // You still see it in the combat log though
+    if (!IsAllowedDamageInArea(pVictim))
+        return;
+
+    // update at damage Judgement aura duration that applied by attacker at victim
+    if (damageInfo->damage && spellProto->Id == 35395)
+    {
+        SpellAuraHolderMap const& vAuras = pVictim->GetSpellAuraHolderMap();
+        for (SpellAuraHolderMap::const_iterator itr = vAuras.begin(); itr != vAuras.end(); ++itr)
+        {
+            SpellEntry const* spellInfo = (*itr).second->GetSpellProto();
+            if (spellInfo->HasAttribute(SPELL_ATTR_EX3_CANT_MISS) && spellInfo->SpellFamilyName == SPELLFAMILY_PALADIN && ((*itr).second->GetCasterGuid() == GetObjectGuid()))
+                (*itr).second->RefreshHolder();
+        }
+    }
+
+    // Call default DealDamage (send critical in hit info for threat calculation)
+    CleanDamage cleanDamage(0, BASE_ATTACK, damageInfo->HitInfo & SPELL_HIT_TYPE_CRIT ? MELEE_HIT_CRIT : MELEE_HIT_NORMAL);
+    DealDamage(pVictim, damageInfo->damage, &cleanDamage, SPELL_DIRECT_DAMAGE, damageInfo->schoolMask, spellProto, durabilityLoss);
+}
+
+// TODO for melee need create structure as in
+void Unit::CalculateMeleeDamage(Unit* pVictim, CalcDamageInfo* damageInfo, WeaponAttackType attackType /*= BASE_ATTACK*/)
+{
+    damageInfo->attacker         = this;
+    damageInfo->target           = pVictim;
+    damageInfo->damageSchoolMask = GetMeleeDamageSchoolMask();
+    damageInfo->attackType       = attackType;
+    damageInfo->damage           = 0;
+    damageInfo->cleanDamage      = 0;
+    damageInfo->absorb           = 0;
+    damageInfo->resist           = 0;
+    damageInfo->blocked_amount   = 0;
+
+    damageInfo->TargetState      = VICTIMSTATE_UNAFFECTED;
+    damageInfo->HitInfo          = HITINFO_NORMALSWING;
+    damageInfo->procAttacker     = PROC_FLAG_NONE;
+    damageInfo->procVictim       = PROC_FLAG_NONE;
+    damageInfo->procEx           = PROC_EX_NONE;
+    damageInfo->hitOutCome       = MELEE_HIT_EVADE;
+
+    if (!this || !pVictim)
+        return;
+    if (!this->isAlive() || !pVictim->isAlive())
+        return;
+
+    // Select HitInfo/procAttacker/procVictim flag based on attack type
+    switch (attackType)
+    {
+        case BASE_ATTACK:
+            damageInfo->procAttacker = PROC_FLAG_SUCCESSFUL_MELEE_HIT;
+            damageInfo->procVictim   = PROC_FLAG_TAKEN_MELEE_HIT;
+            damageInfo->HitInfo      = HITINFO_NORMALSWING2;
+            break;
+        case OFF_ATTACK:
+            damageInfo->procAttacker = PROC_FLAG_SUCCESSFUL_MELEE_HIT | PROC_FLAG_SUCCESSFUL_OFFHAND_HIT;
+            damageInfo->procVictim   = PROC_FLAG_TAKEN_MELEE_HIT;//|PROC_FLAG_TAKEN_OFFHAND_HIT // not used
+            damageInfo->HitInfo = HITINFO_LEFTSWING;
+            break;
+        case RANGED_ATTACK:
+            damageInfo->procAttacker = PROC_FLAG_SUCCESSFUL_RANGED_HIT;
+            damageInfo->procVictim   = PROC_FLAG_TAKEN_RANGED_HIT;
+            damageInfo->HitInfo = HITINFO_UNK3;             // test (dev note: test what? HitInfo flag possibly not confirmed.)
+            break;
+        default:
+            break;
+    }
+
+    // Physical Immune check
+    if (damageInfo->target->IsImmuneToDamage(damageInfo->damageSchoolMask))
+    {
+        damageInfo->HitInfo       |= HITINFO_NORMALSWING;
+        damageInfo->TargetState    = VICTIMSTATE_IS_IMMUNE;
+
+        damageInfo->procEx |= PROC_EX_IMMUNE;
+        damageInfo->damage         = 0;
+        damageInfo->cleanDamage    = 0;
+        return;
+    }
+    uint32 damage = CalculateDamage(damageInfo->attackType, false);
+    // Add melee damage bonus
+    damage = MeleeDamageBonusDone(damageInfo->target, damage, damageInfo->attackType);
+    damage = damageInfo->target->MeleeDamageBonusTaken(this, damage, damageInfo->attackType);
+
+    // Calculate armor reduction
+    damageInfo->damage = CalcArmorReducedDamage(damageInfo->target, damage);
+    damageInfo->cleanDamage += damage - damageInfo->damage;
+
+    damageInfo->hitOutCome = RollMeleeOutcomeAgainst(damageInfo->target, damageInfo->attackType, damageInfo->damageSchoolMask);
+
+    // Disable parry or dodge for ranged attack
+    if (damageInfo->attackType == RANGED_ATTACK)
+    {
+        if (damageInfo->hitOutCome == MELEE_HIT_PARRY) damageInfo->hitOutCome = MELEE_HIT_NORMAL;
+        if (damageInfo->hitOutCome == MELEE_HIT_DODGE) damageInfo->hitOutCome = MELEE_HIT_MISS;
+    }
+
+    switch (damageInfo->hitOutCome)
+    {
+        case MELEE_HIT_EVADE:
+        {
+            damageInfo->HitInfo    |= HITINFO_MISS | HITINFO_SWINGNOHITSOUND;
+            damageInfo->TargetState = VICTIMSTATE_EVADES;
+
+            damageInfo->procEx |= PROC_EX_EVADE;
+            damageInfo->damage = 0;
+            damageInfo->cleanDamage = 0;
+            return;
+        }
+        case MELEE_HIT_MISS:
+        {
+            damageInfo->HitInfo    |= HITINFO_MISS;
+            damageInfo->TargetState = VICTIMSTATE_UNAFFECTED;
+
+            damageInfo->procEx |= PROC_EX_MISS;
+            damageInfo->damage = 0;
+            damageInfo->cleanDamage = 0;
+            break;
+        }
+        case MELEE_HIT_NORMAL:
+            damageInfo->TargetState = VICTIMSTATE_NORMAL;
+            damageInfo->procEx |= PROC_EX_NORMAL_HIT;
+            break;
+        case MELEE_HIT_CRIT:
+        {
+            damageInfo->HitInfo     |= HITINFO_CRITICALHIT;
+            damageInfo->TargetState  = VICTIMSTATE_NORMAL;
+            damageInfo->procEx |= PROC_EX_CRITICAL_HIT;
+            CalculateCritAmount(damageInfo);
+            break;
+        }
+        case MELEE_HIT_PARRY:
+            damageInfo->TargetState  = VICTIMSTATE_PARRY;
+            damageInfo->procEx      |= PROC_EX_PARRY;
+            damageInfo->cleanDamage += damageInfo->damage;
+            damageInfo->damage = 0;
+            break;
+
+        case MELEE_HIT_DODGE:
+            damageInfo->TargetState  = VICTIMSTATE_DODGE;
+            damageInfo->procEx      |= PROC_EX_DODGE;
+            damageInfo->cleanDamage += damageInfo->damage;
+            damageInfo->damage = 0;
+            break;
+        case MELEE_HIT_BLOCK:
+        {
+            damageInfo->TargetState = VICTIMSTATE_NORMAL;
+            damageInfo->procEx     |= PROC_EX_BLOCK;
+            damageInfo->blocked_amount = damageInfo->target->GetShieldBlockValue();
+            if (damageInfo->blocked_amount >= damageInfo->damage)
+            {
+                damageInfo->TargetState = VICTIMSTATE_BLOCKS;
+                damageInfo->blocked_amount = damageInfo->damage;
+            }
+            else
+                damageInfo->procEx |= PROC_EX_NORMAL_HIT;   // Partial blocks can still cause attacker procs
+
+            damageInfo->damage      -= damageInfo->blocked_amount;
+            damageInfo->cleanDamage += damageInfo->blocked_amount;
+            break;
+        }
+        case MELEE_HIT_GLANCING:
+        {
+            damageInfo->HitInfo |= HITINFO_GLANCING;
+            damageInfo->TargetState = VICTIMSTATE_NORMAL;
+            damageInfo->procEx |= PROC_EX_NORMAL_HIT;
+            // calculate base values and mods
+            float baseLowEnd = 1.3f;
+            float baseHighEnd = 1.2f;
+            switch (getClass())                             // lowering base values for casters
+            {
+                case CLASS_SHAMAN:
+                case CLASS_PRIEST:
+                case CLASS_MAGE:
+                case CLASS_WARLOCK:
+                case CLASS_DRUID:
+                    baseLowEnd  -= 0.7f;
+                    baseHighEnd -= 0.3f;
+                    break;
+            }
+
+            float maxLowEnd = 0.6f;
+            switch (getClass())                             // upper for melee classes
+            {
+                case CLASS_WARRIOR:
+                case CLASS_ROGUE:
+                    maxLowEnd = 0.91f;                      // If the attacker is a melee class then instead the lower value of 0.91
+            }
+
+            // calculate values
+            int32 attackerRating = GetWeaponSkillValue(damageInfo->attackType);
+            attackerRating = static_cast<std::uint32_t>(attackerRating) > getLevel() * 5 ? getLevel() * 5 : attackerRating; // cap rating at level * 5, done in 2.0.1
+            int32 diff = damageInfo->target->GetDefenseSkillValue() - attackerRating;
+            float lowEnd  = baseLowEnd - (0.05f * diff);
+            float highEnd = baseHighEnd - (0.03f * diff);
+
+            // apply max/min bounds
+            if (lowEnd < 0.01f)                             // the low end must not go bellow 0.01f
+                lowEnd = 0.01f;
+            else if (lowEnd > maxLowEnd)                    // the smaller value of this and 0.6 is kept as the low end
+                lowEnd = maxLowEnd;
+
+            if (highEnd < 0.2f)                             // high end limits
+                highEnd = 0.2f;
+            if (highEnd > 0.99f)
+                highEnd = 0.99f;
+
+            if (lowEnd > highEnd)                           // prevent negative range size
+                lowEnd = highEnd;
+
+            float reducePercent = lowEnd + rand_norm_f() * (highEnd - lowEnd);
+
+            damageInfo->cleanDamage += damageInfo->damage - uint32(reducePercent *  damageInfo->damage);
+            damageInfo->damage   = uint32(reducePercent *  damageInfo->damage);
+            break;
+        }
+        case MELEE_HIT_CRUSHING:
+        {
+            damageInfo->HitInfo     |= HITINFO_CRUSHING;
+            damageInfo->TargetState  = VICTIMSTATE_NORMAL;
+            damageInfo->procEx |= PROC_EX_NORMAL_HIT;
+            // 150% normal damage
+            damageInfo->damage += (damageInfo->damage / 2);
+            break;
+        }
+        default:
+
+            break;
+    }
+
+    // Calculate absorb resist
+    if (int32(damageInfo->damage) > 0)
+    {
+        damageInfo->procVictim |= PROC_FLAG_TAKEN_ANY_DAMAGE;
+
+        // Calculate absorb & resists
+        damageInfo->target->CalculateDamageAbsorbAndResist(this, damageInfo->damageSchoolMask, DIRECT_DAMAGE, damageInfo->damage, &damageInfo->absorb, &damageInfo->resist, true);
+        damageInfo->damage -= damageInfo->absorb + damageInfo->resist;
+        if (damageInfo->absorb)
+        {
+            damageInfo->HitInfo |= HITINFO_ABSORB;
+            damageInfo->procEx |= PROC_EX_ABSORB;
+        }
+        if (damageInfo->resist)
+            damageInfo->HitInfo |= HITINFO_RESIST;
+    }
+    else // Umpossible get negative result but....
+        damageInfo->damage = 0;
+}
+
+void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
+{
+    if (!damageInfo)
+        return;
+
+    Unit* pVictim = damageInfo->target;
+
+    if (!this || !pVictim)
+        return;
+
+    if (!pVictim->isAlive() || pVictim->IsTaxiFlying() || (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode()))
+        return;
+
+    // You don't lose health from damage taken from another player while in a sanctuary
+    // You still see it in the combat log though
+    if (!IsAllowedDamageInArea(pVictim))
+        return;
+
+    // Hmmmm dont like this emotes client must by self do all animations
+    if (damageInfo->HitInfo & HITINFO_CRITICALHIT)
+        pVictim->HandleEmoteCommand(EMOTE_ONESHOT_WOUNDCRITICAL);
+    if (damageInfo->blocked_amount && damageInfo->TargetState != VICTIMSTATE_BLOCKS)
+        pVictim->HandleEmoteCommand(EMOTE_ONESHOT_PARRYSHIELD);
+
+    if (damageInfo->TargetState == VICTIMSTATE_PARRY)
+    {
+        if (pVictim->GetTypeId() != TYPEID_UNIT ||
+            !(((Creature*)pVictim)->GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_NO_PARRY_HASTEN))
+        {
+            // Get attack timers
+            float offtime = float(pVictim->getAttackTimer(OFF_ATTACK));
+            float basetime = float(pVictim->getAttackTimer(BASE_ATTACK));
+            // Reduce attack time
+            if (pVictim->haveOffhandWeapon() && offtime < basetime)
+            {
+                float percent20 = pVictim->GetAttackTime(OFF_ATTACK) * 0.20f;
+                float percent60 = 3.0f * percent20;
+                if (offtime > percent20 && offtime <= percent60)
+                {
+                    pVictim->setAttackTimer(OFF_ATTACK, uint32(percent20));
+                }
+                else if (offtime > percent60)
+                {
+                    offtime -= 2.0f * percent20;
+                    pVictim->setAttackTimer(OFF_ATTACK, uint32(offtime));
+                }
+            }
+            else
+            {
+                float percent20 = pVictim->GetAttackTime(BASE_ATTACK) * 0.20f;
+                float percent60 = 3.0f * percent20;
+                if (basetime > percent20 && basetime <= percent60)
+                {
+                    pVictim->setAttackTimer(BASE_ATTACK, uint32(percent20));
+                }
+                else if (basetime > percent60)
+                {
+                    basetime -= 2.0f * percent20;
+                    pVictim->setAttackTimer(BASE_ATTACK, uint32(basetime));
+                }
+            }
+        }
+    }
+
+    // Call default DealDamage
+    CleanDamage cleanDamage(damageInfo->cleanDamage, damageInfo->attackType, damageInfo->hitOutCome);
+    DealDamage(pVictim, damageInfo->damage, &cleanDamage, DIRECT_DAMAGE, damageInfo->damageSchoolMask, nullptr, durabilityLoss);
+
+    // If this attack by an NPC dealt some damage from behind to a player, it has a chance to daze victim
+    if (damageInfo->damage && CanDazeInCombat(pVictim) && roll_chance_f(CalculateEffectiveDazeChance(pVictim, damageInfo->attackType)))
+        CastSpell(pVictim, 1604, TRIGGERED_OLD_TRIGGERED);
+
+    // update at damage Judgement aura duration that applied by attacker at victim
+    if (damageInfo->damage)
+    {
+        SpellAuraHolderMap const& vAuras = pVictim->GetSpellAuraHolderMap();
+        for (SpellAuraHolderMap::const_iterator itr = vAuras.begin(); itr != vAuras.end(); ++itr)
+        {
+            SpellEntry const* spellInfo = (*itr).second->GetSpellProto();
+            if (spellInfo->HasAttribute(SPELL_ATTR_EX3_CANT_MISS) && spellInfo->SpellFamilyName == SPELLFAMILY_PALADIN && ((*itr).second->GetCasterGuid() == GetObjectGuid()))
+                (*itr).second->RefreshHolder();
+        }
+    }
+
+    // If not miss
+    if (!(damageInfo->HitInfo & HITINFO_MISS))
+    {
+        // on weapon hit casts
+        if (GetTypeId() == TYPEID_PLAYER && pVictim->isAlive())
+            ((Player*)this)->CastItemCombatSpell(pVictim, damageInfo->attackType);
+
+        // If not immune
+        if (damageInfo->TargetState != VICTIMSTATE_IS_IMMUNE)
+        {
+            // victim's damage shield
+            std::set<Aura*> alreadyDone;
+            AuraList const& vDamageShields = pVictim->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
+            for (AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)
+            {
+                if (alreadyDone.find(*i) == alreadyDone.end())
+                {
+                    alreadyDone.insert(*i);
+                    uint32 damage = (*i)->GetModifier()->m_amount;
+                    SpellEntry const* i_spellProto = (*i)->GetSpellProto();
+                    // Calculate absorb resist ??? no data in opcode for this possibly unable to absorb or resist?
+                    // uint32 absorb;
+                    // uint32 resist;
+                    // CalcAbsorbResist(pVictim, SpellSchools(spellProto->School), SPELL_DIRECT_DAMAGE, damage, &absorb, &resist);
+                    // damage-=absorb + resist;
+
+                    pVictim->DealDamageMods(this, damage, nullptr, SPELL_DIRECT_DAMAGE, i_spellProto);
+
+                    WorldPacket data(SMSG_SPELLDAMAGESHIELD, (8 + 8 + 4 + 4 + 4));
+                    data << pVictim->GetObjectGuid();
+                    data << GetObjectGuid();
+                    data << uint32(i_spellProto->Id);
+                    data << uint32(damage);                  // Damage
+                    data << uint32(i_spellProto->SchoolMask);
+                    pVictim->SendMessageToSet(data, true);
+
+                    pVictim->DealDamage(this, damage, nullptr, SPELL_DIRECT_DAMAGE, GetSpellSchoolMask(i_spellProto), i_spellProto, true);
+
+                    i = vDamageShields.begin();
+                }
+                else
+                    ++i;
+            }
+        }
+    }
+}
+
+
+void Unit::HandleEmoteCommand(uint32 emote_id)
+{
+    WorldPacket data(SMSG_EMOTE, 4 + 8);
+    data << uint32(emote_id);
+    data << GetObjectGuid();
+    SendMessageToSet(data, true);
+}
+
+void Unit::HandleEmoteState(uint32 emote_id)
+{
+    SetUInt32Value(UNIT_NPC_EMOTESTATE, emote_id);
+}
+
+void Unit::HandleEmote(uint32 emote_id)
+{
+    if (!emote_id)
+        HandleEmoteState(0);
+    else if (EmotesEntry const* emoteEntry = sEmotesStore.LookupEntry(emote_id))
+    {
+        if (emoteEntry->EmoteType)                          // 1,2 states, 0 command
+            HandleEmoteState(emote_id);
+        else
+            HandleEmoteCommand(emote_id);
+    }
+}
+
+uint32 Unit::CalcArmorReducedDamage(Unit* pVictim, const uint32 damage)
+{
+    float armor = (float)pVictim->GetArmor();
+
+    // Ignore enemy armor by armor penetration
+    armor -= GetResistancePenetration(SPELL_SCHOOL_NORMAL);
+
+    if (armor < 0.0f)
+        armor = 0.0f;
+
+    float levelModifier = (float)getLevel();
+    if (levelModifier > 59)
+        levelModifier = levelModifier + (4.5f * (levelModifier - 59));
+
+    float tmpvalue = 0.1f * armor / (8.5f * levelModifier + 40);
+    tmpvalue = tmpvalue / (1.0f + tmpvalue);
+
+    if (tmpvalue < 0.0f)
+        tmpvalue = 0.0f;
+    if (tmpvalue > 0.75f)
+        tmpvalue = 0.75f;
+
+    uint32 newdamage = uint32(damage - (damage * tmpvalue));
+
+    return (newdamage > 1) ? newdamage : 1;
+}
+
+void Unit::CalculateDamageAbsorbAndResist(Unit* pCaster, SpellSchoolMask schoolMask, DamageEffectType damagetype, const uint32 damage, uint32* absorb, uint32* resist, bool canReflect, bool ignoreResists, bool binary)
+{
+    if (!pCaster || !isAlive() || !damage)
+        return;
+
+    // Magic damage, check for resists
+    if (!ignoreResists && (schoolMask & SPELL_SCHOOL_MASK_MAGIC) && (!binary || damagetype == DOT))
+    {
+        const float percent = CalculateEffectiveMagicResistancePercent(pCaster, schoolMask);
+        const SpellPartialResistChanceEntry &chances = SPELL_PARTIAL_RESIST_DISTRIBUTION.at(uint32(percent * 100));
+        // We choose which portion of damage is resisted below, none by default
+        uint8 portion = SPELL_PARTIAL_RESIST_NONE;
+        // If we got to this point, we already rolled for full resist on hit
+        // We do a roll between remaining chances
+        const uint8 outcomes = (NUM_SPELL_PARTIAL_RESISTS - 1);
+        const uint32 roll = urand(1, (10000 - chances.at(SPELL_PARTIAL_RESIST_PCT_100)));
+        Die<SpellPartialResist, SPELL_PARTIAL_RESIST_NONE, outcomes> die;
+        for (uint8 outcome = SPELL_PARTIAL_RESIST_NONE; outcome < outcomes; ++outcome)
+            die.chance[outcome] = chances.at(outcome);
+        portion = die.roll(roll);
+        const uint32 amount = uint32(damage * (portion * (1.0f / float(outcomes))));
+        // We already rolled for full resist on hit, so we need to deal at least *some* amount of damage...
+        *resist = (amount >= damage) ? (damage - 1) : amount;
+    }
+    else
+        *resist = 0;
+
+    int32 RemainingDamage = damage - *resist;
+
+    // Reflect damage spells (not cast any damage spell in aura lookup)
+    uint32 reflectSpell = 0;
+    int32  reflectDamage = 0;
+    Aura*  reflectTriggeredBy = nullptr;                       // expected as not expired at reflect as in current cases
+    // Death Prevention Aura
+    SpellEntry const*  preventDeathSpell = nullptr;
+
+    // full absorb cases (by chance)
+    /* none cases, but preserve for better backporting conflict resolve
+    AuraList const& vAbsorb = GetAurasByType(SPELL_AURA_SCHOOL_ABSORB);
+    for(AuraList::const_iterator i = vAbsorb.begin(); i != vAbsorb.end() && RemainingDamage > 0; ++i)
+    {
+        // only work with proper school mask damage
+        Modifier* i_mod = (*i)->GetModifier();
+        if (!(i_mod->m_miscvalue & schoolMask))
+            continue;
+
+        SpellEntry const* i_spellProto = (*i)->GetSpellProto();
+    }
+    */
+
+    // Need remove expired auras after
+    bool existExpired = false;
+
+    // absorb without mana cost
+    AuraList const& vSchoolAbsorb = GetAurasByType(SPELL_AURA_SCHOOL_ABSORB);
+    for (AuraList::const_iterator i = vSchoolAbsorb.begin(); i != vSchoolAbsorb.end() && RemainingDamage > 0; ++i)
+    {
+        Modifier* mod = (*i)->GetModifier();
+        if (!(mod->m_miscvalue & schoolMask))
+            continue;
+
+        SpellEntry const* spellProto = (*i)->GetSpellProto();
+
+        // Max Amount can be absorbed by this aura
+        int32  currentAbsorb = mod->m_amount;
+
+        // Found empty aura (impossible but..)
+        if (currentAbsorb <= 0)
+        {
+            existExpired = true;
+            continue;
+        }
+
+        // Handle custom absorb auras
+        // TODO: try find better way
+
+        switch (spellProto->SpellFamilyName)
+        {
+            case SPELLFAMILY_GENERIC:
+            {
+                // Reflective Shield (Lady Malande boss)
+                if (spellProto->Id == 41475 && canReflect)
+                {
+                    if (RemainingDamage < currentAbsorb)
+                        reflectDamage = RemainingDamage / 2;
+                    else
+                        reflectDamage = currentAbsorb / 2;
+                    reflectSpell = 33619;
+                    reflectTriggeredBy = *i;
+                    reflectTriggeredBy->SetInUse(true);     // lock aura from final deletion until processing
+                    break;
+                }
+                if (spellProto->Id == 39228)                // Argussian Compass
+                {
+                    // Max absorb stored in 1 dummy effect
+                    int32 max_absorb = spellProto->CalculateSimpleValue(EFFECT_INDEX_1);
+                    if (max_absorb < currentAbsorb)
+                        currentAbsorb = max_absorb;
+                    break;
+                }
+                break;
+            }
+            case SPELLFAMILY_ROGUE:
+            {
+                // Cheat Death
+                if (spellProto->SpellIconID == 2109)
+                {
+                    if (!preventDeathSpell &&
+                            GetTypeId() == TYPEID_PLAYER && // Only players
+                            !((Player*)this)->HasSpellCooldown(31231) &&
+                            // Only if no cooldown
+                            roll_chance_i((*i)->GetModifier()->m_amount))
+                        // Only if roll
+                    {
+                        preventDeathSpell = (*i)->GetSpellProto();
+                    }
+                    // always skip this spell in charge dropping, absorb amount calculation since it has chance as m_amount and doesn't need to absorb any damage
+                    continue;
+                }
+                break;
+            }
+            case SPELLFAMILY_PRIEST:
+            {
+                // Reflective Shield
+                if (spellProto->IsFitToFamilyMask(uint64(0x0000000000000001)) && canReflect)
+                {
+                    if (pCaster == this)
+                        break;
+                    Unit* caster = (*i)->GetCaster();
+                    if (!caster)
+                        break;
+                    AuraList const& vOverRideCS = caster->GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
+                    for (AuraList::const_iterator k = vOverRideCS.begin(); k != vOverRideCS.end(); ++k)
+                    {
+                        switch ((*k)->GetModifier()->m_miscvalue)
+                        {
+                            case 5065:                      // Rank 1
+                            case 5064:                      // Rank 2
+                            case 5063:                      // Rank 3
+                            case 5062:                      // Rank 4
+                            case 5061:                      // Rank 5
+                            {
+                                if (RemainingDamage >= currentAbsorb)
+                                    reflectDamage = (*k)->GetModifier()->m_amount * currentAbsorb / 100;
+                                else
+                                    reflectDamage = (*k)->GetModifier()->m_amount * RemainingDamage / 100;
+                                reflectSpell = 33619;
+                                reflectTriggeredBy = *i;
+                                reflectTriggeredBy->SetInUse(true);// lock aura from final deletion until processing
+                            } break;
+                            default: break;
+                        }
+                    }
+                    break;
+                }
+                break;
+            }
+            default:
+                break;
+        }
+
+        // currentAbsorb - damage can be absorbed by shield
+        // If need absorb less damage
+        if (RemainingDamage < currentAbsorb)
+            currentAbsorb = RemainingDamage;
+
+        RemainingDamage -= currentAbsorb;
+
+        // Reduce shield amount
+        mod->m_amount -= currentAbsorb;
+        if ((*i)->GetHolder()->DropAuraCharge())
+            mod->m_amount = 0;
+        // Need remove it later
+        if (mod->m_amount <= 0)
+            existExpired = true;
+    }
+
+    // Remove all expired absorb auras
+    if (existExpired)
+    {
+        for (AuraList::const_iterator i = vSchoolAbsorb.begin(); i != vSchoolAbsorb.end();)
+        {
+            if ((*i)->GetModifier()->m_amount <= 0)
+            {
+                RemoveAurasDueToSpell((*i)->GetId(), nullptr, AURA_REMOVE_BY_SHIELD_BREAK);
+                i = vSchoolAbsorb.begin();
+            }
+            else
+                ++i;
+        }
+    }
+
+    // Cast back reflect damage spell
+    if (canReflect && reflectSpell)
+    {
+        CastCustomSpell(pCaster, reflectSpell, &reflectDamage, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, nullptr, reflectTriggeredBy);
+        reflectTriggeredBy->SetInUse(false);                // free lock from deletion
+    }
+
+    // absorb by mana cost
+    AuraList const& vManaShield = GetAurasByType(SPELL_AURA_MANA_SHIELD);
+    for (AuraList::const_iterator i = vManaShield.begin(), next; i != vManaShield.end() && RemainingDamage > 0; i = next)
+    {
+        next = i; ++next;
+
+        // check damage school mask
+        if (((*i)->GetModifier()->m_miscvalue & schoolMask) == 0)
+            continue;
+
+        int32 currentAbsorb;
+        if (RemainingDamage >= (*i)->GetModifier()->m_amount)
+            currentAbsorb = (*i)->GetModifier()->m_amount;
+        else
+            currentAbsorb = RemainingDamage;
+
+        if (float manaMultiplier = (*i)->GetSpellProto()->EffectMultipleValue[(*i)->GetEffIndex()])
+        {
+            if (Player* modOwner = GetSpellModOwner())
+                modOwner->ApplySpellMod((*i)->GetId(), SPELLMOD_MULTIPLE_VALUE, manaMultiplier);
+
+            int32 maxAbsorb = int32(GetPower(POWER_MANA) / manaMultiplier);
+            if (currentAbsorb > maxAbsorb)
+                currentAbsorb = maxAbsorb;
+
+            int32 manaReduction = int32(currentAbsorb * manaMultiplier);
+            ApplyPowerMod(POWER_MANA, manaReduction, false);
+        }
+
+        (*i)->GetModifier()->m_amount -= currentAbsorb;
+        if ((*i)->GetModifier()->m_amount <= 0)
+        {
+            RemoveAurasDueToSpell((*i)->GetId());
+            next = vManaShield.begin();
+        }
+
+        RemainingDamage -= currentAbsorb;
+    }
+
+    // only split damage if not damaging yourself
+    if (pCaster != this)
+    {
+        AuraList const& vSplitDamageFlat = GetAurasByType(SPELL_AURA_SPLIT_DAMAGE_FLAT);
+        for (AuraList::const_iterator i = vSplitDamageFlat.begin(), next; i != vSplitDamageFlat.end() && RemainingDamage >= 0; i = next)
+        {
+            next = i; ++next;
+
+            // check damage school mask
+            if (((*i)->GetModifier()->m_miscvalue & schoolMask) == 0)
+                continue;
+
+            // Damage can be splitted only if aura has an alive caster
+            Unit* caster = (*i)->GetCaster();
+            if (!caster || caster == this || !caster->IsInWorld() || !caster->isAlive())
+                continue;
+
+            int32 currentAbsorb;
+            if (RemainingDamage >= (*i)->GetModifier()->m_amount)
+                currentAbsorb = (*i)->GetModifier()->m_amount;
+            else
+                currentAbsorb = RemainingDamage;
+
+            RemainingDamage -= currentAbsorb;
+
+            if (caster->IsImmuneToDamage(schoolMask))
+            {
+                SendSpellMiss(caster, (*i)->GetSpellProto()->Id, SPELL_MISS_IMMUNE);
+                return;
+            }
+
+            uint32 splitted = currentAbsorb;
+            uint32 splitted_absorb = 0;
+            pCaster->DealDamageMods(caster, splitted, &splitted_absorb, DIRECT_DAMAGE, (*i)->GetSpellProto());
+
+            pCaster->SendSpellNonMeleeDamageLog(caster, (*i)->GetSpellProto()->Id, splitted, schoolMask, splitted_absorb, 0, false, 0, false);
+
+            CleanDamage cleanDamage = CleanDamage(splitted, BASE_ATTACK, MELEE_HIT_NORMAL);
+            pCaster->DealDamage(caster, splitted, &cleanDamage, DIRECT_DAMAGE, schoolMask, (*i)->GetSpellProto(), false);
+        }
+
+        AuraList const& vSplitDamagePct = GetAurasByType(SPELL_AURA_SPLIT_DAMAGE_PCT);
+        for (AuraList::const_iterator i = vSplitDamagePct.begin(), next; i != vSplitDamagePct.end() && RemainingDamage >= 0; i = next)
+        {
+            next = i; ++next;
+
+            // check damage school mask
+            if (((*i)->GetModifier()->m_miscvalue & schoolMask) == 0)
+                continue;
+
+            // Damage can be splitted only if aura has an alive caster
+            Unit* caster = (*i)->GetCaster();
+            if (!caster || caster == this || !caster->IsInWorld() || !caster->isAlive())
+                continue;
+
+            uint32 splitted = uint32(RemainingDamage * (*i)->GetModifier()->m_amount / 100.0f);
+
+            RemainingDamage -=  int32(splitted);
+
+            if (caster->IsImmuneToDamage(schoolMask))
+            {
+                SendSpellMiss(caster, (*i)->GetSpellProto()->Id, SPELL_MISS_IMMUNE);
+                return;
+            }
+
+            uint32 split_absorb = 0;
+            pCaster->DealDamageMods(caster, splitted, &split_absorb, DIRECT_DAMAGE, (*i)->GetSpellProto());
+
+            pCaster->SendSpellNonMeleeDamageLog(caster, (*i)->GetSpellProto()->Id, splitted, schoolMask, split_absorb, 0, false, 0, false);
+
+            CleanDamage cleanDamage = CleanDamage(splitted, BASE_ATTACK, MELEE_HIT_NORMAL);
+            pCaster->DealDamage(caster, splitted, &cleanDamage, DIRECT_DAMAGE, schoolMask, (*i)->GetSpellProto(), false);
+        }
+    }
+
+    // Apply death prevention spells effects
+    if (preventDeathSpell && RemainingDamage >= (int32)GetHealth())
+    {
+        switch (preventDeathSpell->SpellFamilyName)
+        {
+            // Cheat Death
+            case SPELLFAMILY_ROGUE:
+            {
+                // Cheat Death
+                if (preventDeathSpell->SpellIconID == 2109)
+                {
+                    CastSpell(this, 31231, TRIGGERED_OLD_TRIGGERED);
+                    ((Player*)this)->AddSpellCooldown(31231, 0, time(nullptr) + 60);
+                    // with health > 10% lost health until health==10%, in other case no losses
+                    uint32 health10 = GetMaxHealth() / 10;
+                    RemainingDamage = GetHealth() > health10 ? GetHealth() - health10 : 0;
+                }
+                break;
+            }
+        }
+    }
+
+    *absorb = damage - RemainingDamage - *resist;
+}
+
+void Unit::CalculateAbsorbResistBlock(Unit* pCaster, SpellNonMeleeDamage* damageInfo, SpellEntry const* spellProto, WeaponAttackType attType)
+{
+    if (CanBlockAbility(pCaster, spellProto) && roll_chance_f(CalculateEffectiveBlockChance(pCaster, attType, spellProto)))
+    {
+        damageInfo->blocked = GetShieldBlockValue();
+        if (damageInfo->damage < damageInfo->blocked)
+            damageInfo->blocked = damageInfo->damage;
+        damageInfo->damage -= damageInfo->blocked;
+    }
+
+    CalculateDamageAbsorbAndResist(pCaster, GetSpellSchoolMask(spellProto), SPELL_DIRECT_DAMAGE, damageInfo->damage, &damageInfo->absorb, &damageInfo->resist, IsReflectableSpell(spellProto), spellProto->HasAttribute(SPELL_ATTR_EX4_IGNORE_RESISTANCES), IsBinarySpell(spellProto));
+    damageInfo->damage -= damageInfo->absorb + damageInfo->resist;
+}
+
+void Unit::AttackerStateUpdate(Unit* pVictim, WeaponAttackType attType, bool extra)
+{
+    if (hasUnitState(UNIT_STAT_CAN_NOT_REACT) || HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED))
+        return;
+
+    if (!pVictim->isAlive())
+        return;
+
+    if (IsNonMeleeSpellCasted(false))
+        return;
+
+    if (attType == RANGED_ATTACK)
+        return;                                             // ignore ranged case
+
+    uint32 extraAttacks = m_extraAttacks;
+
+    // melee attack spell casted at main hand attack only
+    if (attType == BASE_ATTACK && m_currentSpells[CURRENT_MELEE_SPELL])
+    {
+        m_currentSpells[CURRENT_MELEE_SPELL]->cast();
+        return;
+    }
+
+    RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_MELEE_ATTACK);
+
+    // attack can be redirected to another target
+    if (Unit* magnetTarget = SelectMagnetTarget(pVictim))
+         pVictim = magnetTarget;
+
+    CalcDamageInfo damageInfo;
+    CalculateMeleeDamage(pVictim, &damageInfo, attType);
+    // Send log damage message to client
+    DealDamageMods(pVictim, damageInfo.damage, &damageInfo.absorb, DIRECT_DAMAGE);
+    SendAttackStateUpdate(&damageInfo);
+    ProcDamageAndSpell(damageInfo.target, damageInfo.procAttacker, damageInfo.procVictim, damageInfo.procEx, damageInfo.damage, damageInfo.attackType);
+    DealMeleeDamage(&damageInfo, true);
+
+    if (GetTypeId() == TYPEID_PLAYER)
+        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "AttackerStateUpdate: (Player) %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",
+                         GetGUIDLow(), pVictim->GetGUIDLow(), pVictim->GetTypeId(), damageInfo.damage, damageInfo.absorb, damageInfo.blocked_amount, damageInfo.resist);
+    else
+        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "AttackerStateUpdate: (NPC)    %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",
+                         GetGUIDLow(), pVictim->GetGUIDLow(), pVictim->GetTypeId(), damageInfo.damage, damageInfo.absorb, damageInfo.blocked_amount, damageInfo.resist);
+
+    if (Unit* owner = GetOwner())
+        if (owner->GetTypeId() == TYPEID_UNIT)
+        {
+            owner->SetInCombatWith(pVictim);
+            owner->AddThreat(pVictim);
+            pVictim->SetInCombatWith(owner);
+        }
+
+    for (GuidSet::const_iterator itr = m_guardianPets.begin(); itr != m_guardianPets.end(); ++itr)
+        if (Unit* pet = (Unit*)GetMap()->GetPet(*itr))
+        {
+            pet->SetInCombatWith(pVictim);
+            pet->AddThreat(pVictim);
+            pVictim->SetInCombatWith(pet);
+        }
+
+    // if damage pVictim call AI reaction
+    pVictim->AttackedBy(this);
+}
+
+void Unit::DoExtraAttacks(Unit* pVictim)
+{
+    while (m_extraAttacks)
+    {
+        AttackerStateUpdate(pVictim, BASE_ATTACK, true);
+        if (m_extraAttacks > 0)
+            --m_extraAttacks;
+    }
+}
+
+MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackType attType, SpellSchoolMask schoolMask) const
+{
+    if (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode())
+        return MELEE_HIT_EVADE;
+
+    Die<UnitCombatDieSide, UNIT_COMBAT_DIE_HIT, NUM_UNIT_COMBAT_DIE_SIDES> die;
+    die.chance[UNIT_COMBAT_DIE_MISS] = uint32(CalculateEffectiveMissChance(pVictim, attType) * 100);
+    if (pVictim->GetTypeId() == TYPEID_PLAYER && !pVictim->IsStandState() && CanCrit(attType))
+    {
+        die.chance[UNIT_COMBAT_DIE_CRIT] = 10000;
+        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: New attack die: [MISS:%u, CRIT:%u] (target is sitting)",
+                         die.chance[UNIT_COMBAT_DIE_MISS], die.chance[UNIT_COMBAT_DIE_CRIT]);
+    }
+    else
+    {
+        if (pVictim->CanReactInCombat())
+        {
+            if (pVictim->CanDodgeInCombat(this))
+                die.chance[UNIT_COMBAT_DIE_DODGE] = uint32(pVictim->CalculateEffectiveDodgeChance(this, attType) * 100);
+            if (pVictim->CanParryInCombat(this))
+                die.chance[UNIT_COMBAT_DIE_PARRY] = uint32(pVictim->CalculateEffectiveParryChance(this, attType) * 100);
+            if (pVictim->CanBlockInCombat(this, schoolMask))
+                die.chance[UNIT_COMBAT_DIE_BLOCK] = uint32(pVictim->CalculateEffectiveBlockChance(this, attType) * 100);
+        }
+        if (CanGlanceInCombat(pVictim))
+            die.chance[UNIT_COMBAT_DIE_GLANCE] = uint32(CalculateEffectiveGlanceChance(pVictim, attType) * 100);
+        die.chance[UNIT_COMBAT_DIE_CRIT] = uint32(CalculateEffectiveCritChance(pVictim, attType) * 100);
+        if (CanCrushInCombat(pVictim))
+            die.chance[UNIT_COMBAT_DIE_CRUSH] = uint32(CalculateEffectiveCrushChance(pVictim, attType) * 100);
+        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: New attack die: [MISS:%u, DODGE:%u, PARRY:%u, BLOCK:%u, GLANCE:%u, CRIT:%u, CRUSH:%u]",
+                         die.chance[UNIT_COMBAT_DIE_MISS], die.chance[UNIT_COMBAT_DIE_DODGE], die.chance[UNIT_COMBAT_DIE_PARRY], die.chance[UNIT_COMBAT_DIE_BLOCK],
+                         die.chance[UNIT_COMBAT_DIE_GLANCE], die.chance[UNIT_COMBAT_DIE_CRIT], die.chance[UNIT_COMBAT_DIE_CRUSH]);
+    }
+
+    const uint32 random = urand(1, 10000);
+    const UnitCombatDieSide side = die.roll(random);
+    if (side != UNIT_COMBAT_DIE_HIT)
+        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: Rolled %u, result: %s (chance %u)", random, UnitCombatDieSideText(side), die.chance[side]);
+    switch (uint32(side))
+    {
+        case UNIT_COMBAT_DIE_MISS:   return MELEE_HIT_MISS;
+        case UNIT_COMBAT_DIE_DODGE:  return MELEE_HIT_DODGE;
+        case UNIT_COMBAT_DIE_PARRY:  return MELEE_HIT_PARRY;
+        case UNIT_COMBAT_DIE_BLOCK:  return MELEE_HIT_BLOCK;
+        case UNIT_COMBAT_DIE_GLANCE: return MELEE_HIT_GLANCING;
+        case UNIT_COMBAT_DIE_CRIT:   return MELEE_HIT_CRIT;
+        case UNIT_COMBAT_DIE_CRUSH:  return MELEE_HIT_CRUSHING;
+    }
+    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: Rolled %u, result: HIT", random);
+    return MELEE_HIT_NORMAL;
+}
+
+uint32 Unit::CalculateDamage(WeaponAttackType attType, bool normalized)
+{
+    float min_damage, max_damage;
+
+    if (normalized && GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->CalculateMinMaxDamage(attType, normalized, min_damage, max_damage);
+    else
+    {
+        switch (attType)
+        {
+            case RANGED_ATTACK:
+                min_damage = GetFloatValue(UNIT_FIELD_MINRANGEDDAMAGE);
+                max_damage = GetFloatValue(UNIT_FIELD_MAXRANGEDDAMAGE);
+                break;
+            case BASE_ATTACK:
+                min_damage = GetFloatValue(UNIT_FIELD_MINDAMAGE);
+                max_damage = GetFloatValue(UNIT_FIELD_MAXDAMAGE);
+                break;
+            case OFF_ATTACK:
+                min_damage = GetFloatValue(UNIT_FIELD_MINOFFHANDDAMAGE);
+                max_damage = GetFloatValue(UNIT_FIELD_MAXOFFHANDDAMAGE);
+                break;
+            // Just for good manner
+            default:
+                min_damage = 0.0f;
+                max_damage = 0.0f;
+                break;
+        }
+    }
+
+    if (min_damage > max_damage)
+    {
+        std::swap(min_damage, max_damage);
+    }
+
+    if (max_damage == 0.0f)
+        max_damage = 5.0f;
+
+    return urand((uint32)min_damage, (uint32)max_damage);
+}
+
+float Unit::CalculateLevelPenalty(SpellEntry const* spellProto) const
+{
+    uint32 spellLevel = spellProto->spellLevel;
+    if (spellLevel <= 0)
+        return 1.0f;
+
+    float LvlPenalty = 0.0f;
+
+    if (spellLevel < 20)
+        LvlPenalty = (20.0f - spellLevel) * 3.75f;
+    float LvlFactor = (float(spellLevel) + 6.0f) / float(getLevel());
+    if (LvlFactor > 1.0f)
+        LvlFactor = 1.0f;
+
+    return (100.0f - LvlPenalty) * LvlFactor / 100.0f;
+}
+
+void Unit::SendMeleeAttackStart(Unit* pVictim) const
+{
+    WorldPacket data(SMSG_ATTACKSTART, 8 + 8);
+    data << GetObjectGuid();
+    data << pVictim->GetObjectGuid();
+
+    SendMessageToSet(data, true);
+    DEBUG_LOG("WORLD: Sent SMSG_ATTACKSTART");
+}
+
+void Unit::SendMeleeAttackStop(Unit* victim) const
+{
+    if (!victim)
+        return;
+
+    WorldPacket data(SMSG_ATTACKSTOP, (4 + 16));            // we guess size
+    data << GetPackGUID();
+    data << victim->GetPackGUID();                          // can be 0x00...
+    data << uint32(0);                                      // can be 0x1
+    SendMessageToSet(data, true);
+    DETAIL_FILTER_LOG(LOG_FILTER_COMBAT, "%s %u stopped attacking %s %u", (GetTypeId() == TYPEID_PLAYER ? "player" : "creature"), GetGUIDLow(), (victim->GetTypeId() == TYPEID_PLAYER ? "player" : "creature"), victim->GetGUIDLow());
+
+    /*if(victim->GetTypeId() == TYPEID_UNIT)
+    ((Creature*)victim)->AI().EnterEvadeMode(this);*/
+}
+
+// Melee based spells hit result calculations
+SpellMissInfo Unit::MeleeSpellHitResult(Unit* pVictim, SpellEntry const* spell)
+{
+    Die<UnitCombatDieSide, UNIT_COMBAT_DIE_HIT, NUM_UNIT_COMBAT_DIE_SIDES> die;
+    die.chance[UNIT_COMBAT_DIE_MISS] = uint32(CalculateSpellMissChance(pVictim, SPELL_SCHOOL_MASK_NORMAL, spell) * 100);
+    die.chance[UNIT_COMBAT_DIE_RESIST] = uint32(CalculateSpellResistChance(pVictim, SPELL_SCHOOL_MASK_NORMAL, spell) * 100);
+    if (pVictim->CanReactOnAbility(spell))
+    {
+        const WeaponAttackType attackType = GetWeaponAttackType(spell);
+        if (pVictim->CanDodgeAbility(this, spell))
+           die.chance[UNIT_COMBAT_DIE_DODGE] = uint32(pVictim->CalculateEffectiveDodgeChance(this, attackType, spell) * 100);
+        if (pVictim->CanParryAbility(this, spell))
+           die.chance[UNIT_COMBAT_DIE_PARRY] = uint32(pVictim->CalculateEffectiveParryChance(this, attackType, spell) * 100);
+        if (pVictim->CanDeflectAbility(this, spell))
+           die.chance[UNIT_COMBAT_DIE_DEFLECT] = uint32(pVictim->CalculateAbilityDeflectChance(this, spell) * 100);
+        if (pVictim->CanBlockAbility(this, spell, true))
+           die.chance[UNIT_COMBAT_DIE_BLOCK] = uint32(pVictim->CalculateEffectiveBlockChance(this, attackType, spell) * 100);
+    }
+    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MeleeSpellHitResult: New ability hit die: %u [MISS:%u, RESIST:%u, DODGE:%u, PARRY:%u, DEFLECT:%u, BLOCK:%u]", spell->Id,
+                     die.chance[UNIT_COMBAT_DIE_MISS], die.chance[UNIT_COMBAT_DIE_RESIST], die.chance[UNIT_COMBAT_DIE_DODGE],
+                     die.chance[UNIT_COMBAT_DIE_PARRY], die.chance[UNIT_COMBAT_DIE_DEFLECT], die.chance[UNIT_COMBAT_DIE_BLOCK]);
+    const uint32 random = urand(1, 10000);
+    const UnitCombatDieSide side = die.roll(random);
+    if (side != UNIT_COMBAT_DIE_HIT)
+        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MeleeSpellHitResult: Rolled %u, result: %s (chance %u)", random, UnitCombatDieSideText(side), die.chance[side]);
+    switch (uint32(side))
+    {
+        case UNIT_COMBAT_DIE_MISS:      return SPELL_MISS_MISS;
+        case UNIT_COMBAT_DIE_RESIST:    return SPELL_MISS_RESIST;
+        case UNIT_COMBAT_DIE_DODGE:     return SPELL_MISS_DODGE;
+        case UNIT_COMBAT_DIE_PARRY:     return SPELL_MISS_PARRY;
+        case UNIT_COMBAT_DIE_DEFLECT:   return SPELL_MISS_DEFLECT;
+        case UNIT_COMBAT_DIE_BLOCK:     return SPELL_MISS_BLOCK;
+    }
+    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MeleeSpellHitResult: Rolled %u, result: HIT", random);
+    return SPELL_MISS_NONE;
+}
+
+SpellMissInfo Unit::MagicSpellHitResult(Unit* pVictim, SpellEntry const* spell)
+{
+    // Can`t miss on dead target (on skinning for example)
+    if (!pVictim->isAlive())
+        return SPELL_MISS_NONE;
+
+    const SpellSchoolMask schoolMask = GetSpellSchoolMask(spell);
+
+    Die<UnitCombatDieSide, UNIT_COMBAT_DIE_HIT, NUM_UNIT_COMBAT_DIE_SIDES> die;
+    die.chance[UNIT_COMBAT_DIE_MISS] = uint32(CalculateSpellMissChance(pVictim, schoolMask, spell) * 100);
+    die.chance[UNIT_COMBAT_DIE_RESIST] = uint32(CalculateSpellResistChance(pVictim, schoolMask, spell) * 100);
+    /* Deflect for spells is currently unused up until WotLK, commented out for performance
+    if (pVictim->CanDeflectAbility(this, spell))
+       die.chance[UNIT_COMBAT_DIE_DEFLECT] = uint32(pVictim->CalculateAbilityDeflectChance(this, spell) * 100);
+    */
+    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MagicSpellHitResult: New spell hit die: %u [MISS:%u, RESIST:%u, DEFLECT:%u]", spell->Id,
+                     die.chance[UNIT_COMBAT_DIE_MISS], die.chance[UNIT_COMBAT_DIE_RESIST], die.chance[UNIT_COMBAT_DIE_DEFLECT]);
+    const uint32 random = urand(1, 10000);
+    const UnitCombatDieSide side = die.roll(random);
+    if (side != UNIT_COMBAT_DIE_HIT)
+        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MagicSpellHitResult: Rolled %u, result: %s (chance %u)", random, UnitCombatDieSideText(side), die.chance[side]);
+    switch (uint32(side))
+    {
+        case UNIT_COMBAT_DIE_MISS:      // Shows up as "Resist" up until WotLK
+        case UNIT_COMBAT_DIE_RESIST:    return SPELL_MISS_RESIST;
+        case UNIT_COMBAT_DIE_DEFLECT:   return SPELL_MISS_DEFLECT;
+    }
+    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MagicSpellHitResult: Rolled %u, result: HIT", random);
+    return SPELL_MISS_NONE;
+}
+
+// Calculate spell hit result can be:
+// Every spell can: Evade/Immune/Reflect/Sucesful hit
+// For melee based spells:
+//   Miss
+//   Dodge
+//   Parry
+// For spells
+//   Resist
+SpellMissInfo Unit::SpellHitResult(Unit* pVictim, SpellEntry const* spell, bool CanReflect)
+{
+    // Return evade for units in evade mode
+    if (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode())
+        return SPELL_MISS_EVADE;
+
+    // All positive spells can`t miss
+    // TODO: client not show miss log for this spells - so need find info for this in dbc and use it!
+    if (IsPositiveSpell(spell->Id, this, pVictim))
+        return SPELL_MISS_NONE;
+
+    // Try victim reflect spell
+    if (CanReflect)
+    {
+        int32 reflectchance = pVictim->GetTotalAuraModifier(SPELL_AURA_REFLECT_SPELLS);
+        Unit::AuraList const& mReflectSpellsSchool = pVictim->GetAurasByType(SPELL_AURA_REFLECT_SPELLS_SCHOOL);
+        for (Unit::AuraList::const_iterator i = mReflectSpellsSchool.begin(); i != mReflectSpellsSchool.end(); ++i)
+            if ((*i)->GetModifier()->m_miscvalue & GetSpellSchoolMask(spell))
+                reflectchance += (*i)->GetModifier()->m_amount;
+        if (reflectchance > 0 && roll_chance_i(reflectchance))
+        {
+            // Start triggers for remove charges if need (trigger only for victim, and mark as active spell)
+            ProcDamageAndSpell(pVictim, PROC_FLAG_NONE, PROC_FLAG_TAKEN_SPELL_MAGIC_DMG_CLASS_NEG, PROC_EX_REFLECT, 1, BASE_ATTACK, spell);
+            return SPELL_MISS_REFLECT;
+        }
+    }
+
+    if (!spell->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY))
+    {
+        // Check for immune
+        if (pVictim->IsImmuneToSpell(spell, this == pVictim))
+            return SPELL_MISS_IMMUNE;
+
+        // Check for immune (use charges)
+        if (pVictim->IsImmuneToDamage(GetSpellSchoolMask(spell)))
+            return SPELL_MISS_IMMUNE;
+    }
+
+    switch (spell->DmgClass)
+    {
+        case SPELL_DAMAGE_CLASS_NONE:
+            return SPELL_MISS_NONE;
+        case SPELL_DAMAGE_CLASS_MAGIC:
+            return MagicSpellHitResult(pVictim, spell);
+        case SPELL_DAMAGE_CLASS_MELEE:
+        case SPELL_DAMAGE_CLASS_RANGED:
+            return MeleeSpellHitResult(pVictim, spell);
+    }
+    return SPELL_MISS_NONE;
+}
+
+uint32 Unit::GetDefenseSkillValue(Unit const* target) const
+{
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        // in PvP always use full skill (and bonuses on top of it if present)
+        uint32 value = (target && target->GetTypeId() == TYPEID_PLAYER)
+                       ? std::max(((Player*)this)->GetMaxSkillValue(SKILL_DEFENSE), ((Player*)this)->GetSkillValue(SKILL_DEFENSE))
+                       : ((Player*)this)->GetSkillValue(SKILL_DEFENSE);
+        value += uint32(((Player*)this)->GetRatingBonusValue(CR_DEFENSE_SKILL));
+        return value;
+    }
+    else
+        return GetUnitMeleeSkill(target);
+}
+
+void Unit::SetCanDodge(const bool flag)
+{
+    if (m_canDodge == flag)
+        return;
+
+    m_canDodge = flag;
+    if (GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->UpdateDodgePercentage();
+}
+
+void Unit::SetCanParry(const bool flag)
+{
+    if (m_canParry == flag)
+        return;
+
+    m_canParry = flag;
+    if (GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->UpdateParryPercentage();
+}
+
+void Unit::SetCanBlock(const bool flag)
+{
+    if (m_canBlock == flag)
+        return;
+
+    m_canBlock = flag;
+    if (GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->UpdateBlockPercentage();
+}
+
+bool Unit::CanDodgeInCombat() const
+{
+    if (!CanDodge() || !CanReactInCombat())
+        return false;
+    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): unit is incapable
+    if (GetDodgeChance() < 0.01f)
+        return false;
+     return true;
+}
+
+bool Unit::CanDodgeInCombat(const Unit *attacker) const
+{
+    if (!attacker || !CanDodgeInCombat())
+        return false;
+    // Players can't dodge attacks from behind
+    if (GetTypeId() == TYPEID_PLAYER)
+        return attacker->IsFacingTargetsFront(this);
+    return true;
+}
+
+bool Unit::CanParryInCombat() const
+{
+    if (!CanParry() || !CanReactInCombat() || HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_DISARMED) || IsNonMeleeSpellCasted(false))
+        return false;
+    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): unit is incapable
+    if (GetParryChance() < 0.01f)
+        return false;
+    // Players need a melee weapon they can use to parry an attack
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        const Player* player = (const Player*)this;
+        return (player->GetWeaponForAttack(BASE_ATTACK, true, true) || player->GetWeaponForAttack(OFF_ATTACK, true, true));
+    }
+    return true;
+}
+
+bool Unit::CanParryInCombat(const Unit *attacker) const
+{
+    return (attacker && CanParryInCombat() && attacker->IsFacingTargetsFront(this));
+}
+
+bool Unit::CanBlockInCombat(SpellSchoolMask weaponSchoolMask) const
+{
+    // Pre-WotLK: cannot block elemental and magic melee auto-attacks
+    if (weaponSchoolMask & SPELL_SCHOOL_MASK_MAGIC)
+        return false;
+    if (!CanBlock() || !CanReactInCombat() || IsNonMeleeSpellCasted(false))
+        return false;
+    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): unit is incapable
+    if (GetBlockChance() < 0.01f)
+        return false;
+    // Players need a shield equipped to block an attack
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        const Player* player = (const Player*)this;
+        if (player->CanUseEquippedWeapon(OFF_ATTACK))
+        {
+            const Item* offhand = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
+            return (offhand && !offhand->IsBroken() && offhand->GetProto()->Block);
+        }
+        return false;
+    }
+    return true;
+}
+
+bool Unit::CanBlockInCombat(const Unit *attacker, SpellSchoolMask weaponSchoolMask) const
+{
+    return (attacker && CanBlockInCombat(weaponSchoolMask) && attacker->IsFacingTargetsFront(this));
+}
+
+bool Unit::CanCrushInCombat() const
+{
+    if (!CanCrush())
+        return false;
+    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_NO_CRUSH)
+        return false;
+    return true;
+}
+
+bool Unit::CanCrushInCombat(const Unit *victim) const
+{
+    return (victim && CanCrushInCombat() && victim->GetCharmerOrOwnerOrOwnGuid().IsPlayer());
+}
+
+bool Unit::CanGlanceInCombat(const Unit *victim) const
+{
+    return (victim && CanGlanceInCombat() && victim->GetCharmerOrOwnerOrOwnGuid().IsCreature() && victim->GetLevelForTarget(this) > 10);
+}
+
+bool Unit::CanDazeInCombat(const Unit *victim) const
+{
+    return (victim && CanDazeInCombat() && (victim->GetTypeId() == TYPEID_PLAYER) && IsFacingTargetsBack(victim));
+}
+
+bool Unit::CanReactOnAbility(const SpellEntry *ability) const
+{
+    return (ability && !ability->HasAttribute(SPELL_ATTR_IMPOSSIBLE_DODGE_PARRY_BLOCK));
+}
+
+bool Unit::CanDodgeAbility(const Unit *attacker, const SpellEntry *ability) const
+{
+    // Can't dodge unavoidable and ranged attacks
+    if (!CanReactOnAbility(ability) || ability->DmgClass != SPELL_DAMAGE_CLASS_MELEE)
+        return false;
+    // Check if attacker can be dodged at the moment
+    if (!CanDodgeInCombat(attacker))
+        return false;
+    // Check if attacker cuts through dodge with this ability
+    const AuraList &ignore = attacker->GetAurasByType(SPELL_AURA_IGNORE_COMBAT_RESULT);
+    for (AuraList::const_iterator i = ignore.begin(); i != ignore.end(); ++i)
+    {
+        if ((*i)->isAffectedOnSpell(ability) && (*i)->GetModifier()->m_miscvalue == MELEE_HIT_DODGE)
+            return false;
+    }
+    return true;
+}
+
+bool Unit::CanParryAbility(const Unit *attacker, const SpellEntry *ability) const
+{
+    // Can't parry unavoidable attacks
+    if (!CanReactOnAbility(ability))
+        return false;
+    // Only physical melee attacks can be parried, deflect for magical and ranged
+    if (ability->DmgClass != SPELL_DAMAGE_CLASS_MELEE || (GetSpellSchoolMask(ability) & SPELL_SCHOOL_MASK_MAGIC))
+        return false;
+    // Only close range melee attacks can be parried, longer range abilities use deflect
+    if (ability->rangeIndex != SPELL_RANGE_IDX_COMBAT && ability->rangeIndex != SPELL_RANGE_IDX_SELF_ONLY)
+        return false;
+    // Check if attacker can be parried at the moment
+    if (!CanParryInCombat(attacker))
+        return false;
+    // Check if attacker cuts through parry with this ability
+    const AuraList &ignore = attacker->GetAurasByType(SPELL_AURA_IGNORE_COMBAT_RESULT);
+    for (AuraList::const_iterator i = ignore.begin(); i != ignore.end(); ++i)
+    {
+        if ((*i)->isAffectedOnSpell(ability) && (*i)->GetModifier()->m_miscvalue == MELEE_HIT_PARRY)
+            return false;
+    }
+    return true;
+}
+
+bool Unit::CanBlockAbility(const Unit *attacker, const SpellEntry *ability, bool miss) const
+{
+    // Can't block unavoidable attacks
+    if (!CanReactOnAbility(ability))
+        return false;
+    // Melee and ranged spells only
+    switch (ability->DmgClass)
+    {
+        case SPELL_DAMAGE_CLASS_MELEE:
+        case SPELL_DAMAGE_CLASS_RANGED:
+            break;
+        default:
+            return false;
+    }
+    // There are 2 types of ability blocks: partial and full
+    // Fully blockable spells have a specific attribute, which generates a miss instead of a partial block
+    // Spells with an attribute must be rolled for block once on spell hit die
+    // Spells without an attribute must be rolled for partial block only inside damage calculation
+    // This function can query both scenarios via an argument flag
+    if (miss != ability->HasAttribute(SPELL_ATTR_EX3_BLOCKABLE_SPELL))
+        return false;
+    // Check if attacker can be blocked at the moment
+    if (!CanBlockInCombat(attacker))
+        return false;
+    // Check if attacker cuts through block with this ability
+    const AuraList &ignore = attacker->GetAurasByType(SPELL_AURA_IGNORE_COMBAT_RESULT);
+    for (AuraList::const_iterator i = ignore.begin(); i != ignore.end(); ++i)
+    {
+        if ((*i)->isAffectedOnSpell(ability) && (*i)->GetModifier()->m_miscvalue == MELEE_HIT_BLOCK)
+            return false;
+    }
+    return true;
+}
+
+bool Unit::CanDeflectAbility(const Unit *attacker, const SpellEntry *ability) const
+{
+    // Can't deflect unavoidable attacks
+    if (!CanReactOnAbility(ability))
+        return false;
+    // Only magical melee attacks, ranged attacks and spells can be deflected, parry for the rest
+    switch (ability->DmgClass)
+    {
+        case SPELL_DAMAGE_CLASS_RANGED:
+        case SPELL_DAMAGE_CLASS_MAGIC:
+            break;
+        case SPELL_DAMAGE_CLASS_MELEE:
+            if (!(GetSpellSchoolMask(ability) & SPELL_SCHOOL_MASK_MAGIC))
+                return false;
+            if (ability->rangeIndex == SPELL_RANGE_IDX_COMBAT || ability->rangeIndex == SPELL_RANGE_IDX_SELF_ONLY)
+                return false;
+            break;
+        default:
+            return false;
+    }
+    // Check if attacker can be parried/deflected at the moment
+    if (!CanParryInCombat(attacker))
+        return false;
+    // Check if attacker cuts through parry/deflect with this ability
+    const AuraList &ignore = attacker->GetAurasByType(SPELL_AURA_IGNORE_COMBAT_RESULT);
+    for (AuraList::const_iterator i = ignore.begin(); i != ignore.end(); ++i)
+    {
+        if ((*i)->isAffectedOnSpell(ability) && (*i)->GetModifier()->m_miscvalue == MELEE_HIT_PARRY)
+            return false;
+    }
+    return true;
+}
+
+float Unit::CalculateEffectiveDodgeChance(const Unit *attacker, WeaponAttackType attType, const SpellEntry *ability) const
+{
+    float chance = 0.0f;
+
+    chance += GetDodgeChance();
+    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit is incapable
+    if (chance < 0.01f)
+        return 0.0f;
+    const bool weapon = (!ability || ability->EquippedItemClass == ITEM_CLASS_WEAPON);
+    // Skill difference can be negative (and reduce our chance to mitigate an attack), which means:
+    // a) Attacker's level is higher
+    // b) Attacker has +skill bonuses
+    const bool isPlayerOrPet = (GetTypeId() == TYPEID_PLAYER || GetOwnerGuid().IsPlayer());
+    const uint32 skill = (weapon ? attacker->GetWeaponSkillValue(attType, this) : attacker->GetMaxSkillValueForLevel(this));
+    int32 difference = int32(GetDefenseSkillValue(attacker) - skill);
+    // Defense/weapon skill factor: for players and NPCs
+    float factor = 0.04f;
+    // NPCs gain additional bonus dodge chance based on positive skill difference
+    if (!isPlayerOrPet && difference > 0)
+        factor = 0.1f;
+    chance += (difference * factor);
+    // Attacker's SPELL_AURA_MOD_COMBAT_RESULT_CHANCE contribution (or reduction)
+    chance += attacker->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_COMBAT_RESULT_CHANCE, VICTIMSTATE_DODGE);
+    // Attacker's expertise reduction
+    chance -= attacker->GetExpertisePercent(attType);
+    return std::max(0.0f, std::min(chance, 100.0f));
+}
+
+float Unit::CalculateEffectiveParryChance(const Unit *attacker, WeaponAttackType attType, const SpellEntry *ability) const
+{
+    float chance = 0.0f;
+
+    if (attType == RANGED_ATTACK)
+        return 0.0f;
+
+    chance += GetParryChance();
+    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit is incapable
+    if (chance < 0.01f)
+        return 0.0f;
+    const bool weapon = (!ability || ability->EquippedItemClass == ITEM_CLASS_WEAPON);
+    // Skill difference can be negative (and reduce our chance to mitigate an attack), which means:
+    // a) Attacker's level is higher
+    // b) Attacker has +skill bonuses
+    const bool isPlayerOrPet = (GetTypeId() == TYPEID_PLAYER || GetOwnerGuid().IsPlayer());
+    const uint32 skill = (weapon ? attacker->GetWeaponSkillValue(attType, this) : attacker->GetMaxSkillValueForLevel(this));
+    int32 difference = int32(GetDefenseSkillValue(attacker) - skill);
+    // Defense/weapon skill factor: for players and NPCs
+    float factor = 0.04f;
+    // NPCs gain additional bonus parry chance based on positive skill difference (same value as bonus miss rate)
+    if (!isPlayerOrPet && difference > 0)
+    {
+        if (difference > 10)
+        {
+            // First 10 points of difference (2 levels): usual decrease
+            chance += (10 * 0.1f);
+            difference -= 10;
+            // Each additional point of difference:
+            factor = 0.4f;
+            chance += (difference * 0.2f); // Pre-WotLK: Additional 1% miss chance for each level above 2 (total @ 3% per level)
         }
         else
+            factor = 0.1f;
+    }
+    chance += (difference * factor);
+    // Attacker's SPELL_AURA_MOD_COMBAT_RESULT_CHANCE contribution (or reduction)
+    chance += attacker->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_COMBAT_RESULT_CHANCE, VICTIMSTATE_PARRY);
+    // Attacker's expertise reduction
+    chance -= attacker->GetExpertisePercent(attType);
+    return std::max(0.0f, std::min(chance, 100.0f));
+}
+
+float Unit::CalculateEffectiveBlockChance(const Unit *attacker, WeaponAttackType attType, const SpellEntry *ability) const
+{
+    float chance = 0.0f;
+
+    chance += GetBlockChance();
+    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit is incapable
+    if (chance < 0.01f)
+        return 0.0f;
+    const bool weapon = (!ability || ability->EquippedItemClass == ITEM_CLASS_WEAPON);
+    // Skill difference can be negative (and reduce our chance to mitigate an attack), which means:
+    // a) Attacker's level is higher
+    // b) Attacker has +skill bonuses
+    const bool isPlayerOrPet = (GetTypeId() == TYPEID_PLAYER || GetOwnerGuid().IsPlayer());
+    const uint32 skill = (weapon ? attacker->GetWeaponSkillValue(attType, this) : attacker->GetMaxSkillValueForLevel(this));
+    const int32 difference = int32(GetDefenseSkillValue(attacker) - skill);
+    // Defense/weapon skill factor: for players and NPCs
+    float factor = 0.04f;
+    // NPCs cannot gain bonus block chance based on positive skill difference
+    if (!isPlayerOrPet && difference > 0)
+        factor = 0.0f;
+    chance += (difference * factor);
+    // Attacker's SPELL_AURA_MOD_COMBAT_RESULT_CHANCE contribution (or reduction)
+    chance += attacker->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_COMBAT_RESULT_CHANCE, VICTIMSTATE_BLOCKS);
+    return std::max(0.0f, std::min(chance, 100.0f));
+}
+
+float Unit::CalculateEffectiveCrushChance(const Unit *victim, WeaponAttackType attType) const
+{
+    float chance = 0.0f;
+
+    // Crushing blow chance is present when attacker's weapon skill is >= 15 over victim's own capped defense skill
+    // The chance starts at 15% and increased by 2% per each additional skill point of defense deficit
+    const uint32 cap = victim->GetMaxSkillValueForLevel();
+    const uint32 defense = std::min(victim->GetDefenseSkillValue(this), cap);
+    const int32 deficit = (int32(GetWeaponSkillValue(attType, victim)) - int32(defense));
+    if (deficit >= 15)
+        chance += ((2 * deficit) - 15);
+    return std::max(0.0f, std::min(chance, 100.0f));
+}
+
+float Unit::CalculateEffectiveGlanceChance(const Unit *victim, WeaponAttackType attType) const
+{
+    float chance = 0.0f;
+
+    // Glancing blow chance starts at 1% when victim's defense skill is > 10 lower than attacker's own capped weapon skill
+    // The chance is increased for each point of skill diffrernce
+    const uint32 cap = GetMaxSkillValueForLevel();
+    const uint32 skill = std::min(GetWeaponSkillValue(attType, victim), cap);
+    const int32 level = int32(GetLevelForTarget(victim));
+    const uint32 defense = victim->GetDefenseSkillValue(this);
+    // Penalty for caster classes lower than level 30 in TBC
+    if (GetTypeId() == TYPEID_PLAYER && (getClassMask() & CLASSMASK_WAND_USERS) && level < 30)
+        chance += (level + int32(defense - skill));
+    else
+        chance += (10 + int32(defense - skill));
+    return std::max(0.0f, std::min(chance, 100.0f));
+}
+
+float Unit::CalculateEffectiveDazeChance(const Unit *victim, WeaponAttackType attType) const
+{
+    float chance = 0.0f;
+
+    // Base chance starts at 20% and is modified by difference between victim's defense skill and attacker's weapon skill
+    const uint32 level = victim->GetLevelForTarget(this);
+    // Base chance is reduced for lower levels
+    if (level < 30)
+        chance += (0.65f * level) + 0.5f;
+    else
+        chance += 20.0f;
+    // Same mechanics as miss chance, but premultiplied by 4 (20% base instead of 5% base)
+    chance += (int32(GetWeaponSkillValue(attType, victim)) - int32(victim->GetDefenseSkillValue(this))) * 0.04f * 4;
+    // Chance is capped at 40%
+    return std::max(0.0f, std::min(chance, 40.0f));
+}
+
+float Unit::CalculateAbilityDeflectChance(const Unit *attacker, const SpellEntry *ability) const
+{
+    switch (ability->DmgClass)
+    {
+        case SPELL_DAMAGE_CLASS_MELEE:
+        case SPELL_DAMAGE_CLASS_RANGED: return CalculateEffectiveParryChance(attacker, GetWeaponAttackType(ability), ability);
+        case SPELL_DAMAGE_CLASS_MAGIC:  return CalculateEffectiveParryChance(attacker, RANGED_ATTACK, ability);
+    }
+    return 0.0f;
+}
+
+float Unit::GetDodgeChance() const
+{
+    float chance = 0.0f;
+    if (GetTypeId() == TYPEID_UNIT)
+        chance += 5.0f;
+    chance += m_modDodgeChance;
+    return chance;
+}
+
+float Unit::GetParryChance() const
+{
+    float chance = 0.0f;
+    // FIXME: Verify which creatures are eligible for parry together with DB team and implement in a more clean way
+    if (GetTypeId() == TYPEID_UNIT)
+        chance += 5.0f;
+    chance += m_modParryChance;
+    return chance;
+}
+
+float Unit::GetBlockChance() const
+{
+    float chance = 0.0f;
+    // FIXME: Verify which creatures are eligible for block together with DB team and implement in a more clean way
+    if (GetTypeId() == TYPEID_UNIT)
+        chance += 5.0f;
+    chance += m_modBlockChance;
+    return chance;
+}
+
+bool Unit::CanCrit(const SpellEntry *entry, SpellSchoolMask schoolMask, WeaponAttackType attType) const
+{
+    if (!IsSpellAbleToCrit(entry))
+        return false;
+    // Creatures do not crit with their spells or abilities, unless it is owned by a player (pet, totem, etc)
+    if (GetTypeId() == TYPEID_UNIT && !GetOwnerGuid().IsPlayer())
+        return false;
+    switch (entry->DmgClass)
+    {
+        case SPELL_DAMAGE_CLASS_MELEE:
+        case SPELL_DAMAGE_CLASS_RANGED: return CanCrit(attType);
+        case SPELL_DAMAGE_CLASS_NONE:
+        case SPELL_DAMAGE_CLASS_MAGIC:  return CanCrit(schoolMask);
+    }
+    return false;
+}
+
+float Unit::GetCritChance(WeaponAttackType attType) const
+{
+    float chance = 0.0f;
+    if (GetTypeId() == TYPEID_UNIT)
+        // Base crit chance (needed for units only, already included for players)
+        chance += 5.0f;
+    chance += m_modCritChance[attType];
+    return chance;
+}
+
+float Unit::GetCritChance(SpellSchoolMask schoolMask) const
+{
+    float chance = 0.0f;
+
+    uint32 mask = uint32(schoolMask);
+    if (!mask)
+        return 0.0f;
+
+    if (GetTypeId() == TYPEID_UNIT)
+        // Base crit chance (needed for units only, already included for players)
+        chance += 5.0f;
+    // Pick highest spell crit available for given school mask
+    for (uint8 school = 0; mask; ++school)
+    {
+        if (mask & 1)
         {
-            // Do chosen ability
-            switch (m_uiChosenAbility)
+            const float crit = m_modSpellCritChance[school];
+            if (crit > chance)
+                chance = crit;
+        }
+        mask >>= 1;
+    }
+    return chance;
+}
+
+float Unit::GetCritChance(const SpellEntry *entry, SpellSchoolMask schoolMask) const
+{
+    float chance = 0.0f;
+
+    if (!entry)
+        return 0.0f;
+
+    // Add own hit chance
+    switch (entry->DmgClass)
+    {
+        case SPELL_DAMAGE_CLASS_MAGIC:
+            chance += GetCritChance(schoolMask);
+            break;
+        case SPELL_DAMAGE_CLASS_MELEE:
+        case SPELL_DAMAGE_CLASS_RANGED:
+            chance += GetCritChance(GetWeaponAttackType(entry));
+            break;
+    }
+    // Add mod
+    if (Player* modOwner = GetSpellModOwner())
+        modOwner->ApplySpellMod(entry->Id, SPELLMOD_CRITICAL_CHANCE, chance);
+    return chance;
+}
+
+float Unit::GetCritTakenChance(SpellSchoolMask dmgSchoolMask, SpellDmgClass dmgClass, bool heal) const
+{
+    float chance = 0.0f;
+    // Resilience and resilience-like auras:
+    if (!heal)
+    {
+        // Resilience percent decreases chance to be crit 1:1
+        switch (uint32(dmgClass))
+        {
+            case SPELL_DAMAGE_CLASS_MELEE:
+                chance += GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_CHANCE);
+                chance -= GetCombatRatingReduction(CR_CRIT_TAKEN_MELEE);
+                break;
+            case SPELL_DAMAGE_CLASS_RANGED:
+                chance += GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_RANGED_CRIT_CHANCE);
+                chance -= GetCombatRatingReduction(CR_CRIT_TAKEN_RANGED);
+                break;
+            case SPELL_DAMAGE_CLASS_MAGIC:
+                chance += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_ATTACKER_SPELL_CRIT_CHANCE, dmgSchoolMask);
+                chance -= GetCombatRatingReduction(CR_CRIT_TAKEN_SPELL);
+                break;
+        }
+        chance += GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_SPELL_AND_WEAPON_CRIT_CHANCE);
+    }
+    return chance;
+}
+
+float Unit::GetCritMultiplier(SpellSchoolMask dmgSchoolMask, uint32 creatureTypeMask, const SpellEntry *spell, bool heal) const
+{
+    // Default crit multiplier (attacks): 2x
+    float multiplier = 2.0f;
+    // Default crit multiplier for spells: 1.5x
+    if (spell)
+    {
+        switch (spell->DmgClass)
+        {
+            case SPELL_DAMAGE_CLASS_NONE:
+            case SPELL_DAMAGE_CLASS_MAGIC:
+                multiplier = 1.5f;
+                break;
+        }
+    }
+    // Multiplier bonus coefficient for damage
+    if (!heal)
+    {
+        float bonus = 0;
+        if (dmgSchoolMask)
+            bonus += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_CRIT_DAMAGE_BONUS, dmgSchoolMask); // Gems, talents
+        if (creatureTypeMask)
+            bonus += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_CRIT_PERCENT_VERSUS, creatureTypeMask); // Creature slaying
+        multiplier *= (1.0f + (bonus / 100.0f));
+    }
+    // Apply spell mods
+    if (spell)
+    {
+        if (Player* modOwner = GetSpellModOwner())
+        {
+            // Extract crit bonus part only from multiplier (exclude base of 1) and modify it
+            float bonus = (multiplier - 1.0f);
+            modOwner->ApplySpellMod(spell->Id, SPELLMOD_CRIT_DAMAGE_BONUS, bonus);
+            // Reconstruct final multiplier now with increased bonus part
+            multiplier = (1.0f + bonus);
+        }
+    }
+    return std::max(0.0f, multiplier);
+}
+
+float Unit::GetCritTakenMultiplier(SpellSchoolMask dmgSchoolMask, SpellDmgClass dmgClass, float ignorePct, bool heal) const
+{
+    // Default incoming crit multiplier: 1x (receive full damage)
+    float multiplier = 1.0f;
+    // Resilience and resilience-like auras:
+    if (!heal)
+    {
+        const float pct = 0.01f;
+        // Resilience cap and factor: % of incoming crit dmg reduction per % of resilience
+        const float factor = 2.0f * pct; // TBC
+        const float cap = 25.0f * pct; // TBC
+        const float ratio = (100.0f - ignorePct) * pct;
+        switch (uint32(dmgClass))
+        {
+            case SPELL_DAMAGE_CLASS_MELEE:
+                multiplier += (GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_DAMAGE) * pct);
+                multiplier -= std::min(cap, (GetCombatRatingReduction(CR_CRIT_TAKEN_MELEE) * factor)) * ratio;
+                break;
+            case SPELL_DAMAGE_CLASS_RANGED:
+                multiplier += (GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_RANGED_CRIT_DAMAGE) * pct);
+                multiplier -= std::min(cap, (GetCombatRatingReduction(CR_CRIT_TAKEN_RANGED) * factor)) * ratio;
+                break;
+            case SPELL_DAMAGE_CLASS_MAGIC:
+                multiplier += (GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_ATTACKER_SPELL_CRIT_DAMAGE, dmgSchoolMask) * pct);
+                multiplier -= std::min(cap, (GetCombatRatingReduction(CR_CRIT_TAKEN_SPELL) * factor)) * ratio;
+                break;
+        }
+    }
+    return std::max(0.0f, multiplier);
+}
+
+uint32 Unit::CalculateCritAmount(const Unit *victim, uint32 amount, const SpellEntry *entry, bool heal) const
+{
+    if (!entry)
+        return 0;
+    const SpellSchoolMask schoolMask = GetSpellSchoolMask(entry);
+    const uint32 creatureTypeMask = (victim ? victim->GetCreatureTypeMask() : 0);
+    const float multiplier = GetCritMultiplier(schoolMask, creatureTypeMask, entry, heal);
+    const SpellDmgClass dmgClass = SpellDmgClass(entry->DmgClass);
+    const float ignoreReduction = 0.0f;
+    const float taken = (victim ? victim->GetCritTakenMultiplier(schoolMask, dmgClass, ignoreReduction, heal) : 1.0f);
+    const uint32 outgoing = uint32(amount * multiplier);
+    // Crit amount can't be less than normal hit
+    const uint32 result = std::max(amount, uint32(outgoing * taken));
+    return result;
+}
+
+uint32 Unit::CalculateCritAmount(CalcDamageInfo *meleeInfo) const
+{
+    if (!meleeInfo)
+        return 0;
+    const Unit* victim = meleeInfo->target;
+    const uint32 amount = meleeInfo->damage;
+    const SpellSchoolMask schoolMask = meleeInfo->damageSchoolMask;
+    const uint32 creatureTypeMask = (victim ? victim->GetCreatureTypeMask() : 0);
+    const float multiplier = GetCritMultiplier(schoolMask, creatureTypeMask);
+    const SpellDmgClass dmgClass = ((meleeInfo->attackType == RANGED_ATTACK) ? SPELL_DAMAGE_CLASS_RANGED : SPELL_DAMAGE_CLASS_MELEE);
+    const float ignoreReduction = 0.0f;
+    const float taken = (victim ? victim->GetCritTakenMultiplier(schoolMask, dmgClass, ignoreReduction) : 1.0f);
+    const uint32 outgoing = uint32(amount * multiplier);
+    // Crit amount can't be less than normal hit
+    const uint32 result = std::max(amount, uint32(outgoing * taken));
+    meleeInfo->damage = result;
+    meleeInfo->cleanDamage = std::max(result, outgoing);
+    return result;
+}
+
+float Unit::GetHitChance(WeaponAttackType attackType) const
+{
+    if (attackType == RANGED_ATTACK)
+        return m_modRangedHitChance;
+    return m_modMeleeHitChance;
+}
+
+float Unit::GetHitChance(SpellSchoolMask schoolMask) const
+{
+    float chance = 0.0f;
+
+    if (!uint32(schoolMask))
+        return 0.0f;
+
+    chance += m_modSpellHitChance;
+    // Pick highest spell hit available for given school mask
+    chance += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_INCREASES_SPELL_PCT_TO_HIT, schoolMask);
+    return chance;
+}
+
+float Unit::GetHitChance(const SpellEntry *entry, SpellSchoolMask schoolMask) const
+{
+    float chance = 0.0f;
+
+    if (!entry)
+        return 0.0f;
+
+    // Add own hit chance
+    switch (entry->DmgClass)
+    {
+        case SPELL_DAMAGE_CLASS_MAGIC:
+            chance += GetHitChance(schoolMask);
+            break;
+        case SPELL_DAMAGE_CLASS_MELEE:
+        case SPELL_DAMAGE_CLASS_RANGED:
+            chance += GetHitChance(GetWeaponAttackType(entry));
+            break;
+    }
+    // Add mod
+    if (Player* modOwner = GetSpellModOwner())
+        modOwner->ApplySpellMod(entry->Id, SPELLMOD_RESIST_MISS_CHANCE, chance);
+    return chance;
+}
+
+float Unit::GetMissChance(WeaponAttackType attackType) const
+{
+    // Totems have no inherit miss chance
+    if (GetTypeId() == TYPEID_UNIT && ((const Creature*)this)->IsTotem())
+        return 0.0f;
+    // Default base chance to be missed for all acting units: 5%
+    float chance = 5.0f;
+    // Rating contribution
+    if (GetTypeId() == TYPEID_PLAYER)
+        chance += ((const Player*)this)->GetRatingBonusValue((attackType == RANGED_ATTACK) ? CR_HIT_TAKEN_RANGED : CR_HIT_TAKEN_MELEE);
+    return chance;
+}
+
+float Unit::GetMissChance(SpellSchoolMask /*schoolMask*/) const
+{
+    // Totems have no inherit miss chance
+    if (GetTypeId() == TYPEID_UNIT && ((const Creature*)this)->IsTotem())
+        return 0.0f;
+    // Default base chance to be missed by a spell for all acting units: 4%
+    float chance = 4.0f;
+    // Rating contribution
+    if (GetTypeId() == TYPEID_PLAYER)
+        chance += ((const Player*)this)->GetRatingBonusValue(CR_HIT_TAKEN_SPELL);
+    return chance;
+}
+
+float Unit::GetMissChance(const SpellEntry *entry, SpellSchoolMask schoolMask) const
+{
+    float chance = 0.0f;
+
+    if (!entry)
+        return 0.0f;
+
+    // Add own miss chance
+    switch (entry->DmgClass)
+    {
+        case SPELL_DAMAGE_CLASS_MELEE:
+        case SPELL_DAMAGE_CLASS_RANGED:
+            chance += GetMissChance(GetWeaponAttackType(entry));
+            break;
+        // By default, we use spell miss chance even for spells without dmgclass
+        default:
+            chance += GetMissChance(schoolMask);
+            break;
+    }
+    // AoE avoidance
+    if (IsAreaOfEffectSpell(entry))
+        chance += GetTotalAuraModifier(SPELL_AURA_MOD_AOE_AVOIDANCE);
+    return chance;
+}
+
+float Unit::CalculateEffectiveCritChance(const Unit* victim, WeaponAttackType attType, const SpellEntry *ability) const
+{
+    float chance = 0.0f;
+
+    chance += (ability ? GetCritChance(ability, SPELL_SCHOOL_MASK_NORMAL) : GetCritChance(attType));
+    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit is incapable
+    if (chance < 0.01f)
+        return 0.0f;
+    // Skip victim calculation if positive ability
+    if (ability && IsPositiveSpell(ability, this, victim))
+        return std::max(0.0f, std::min(chance, 100.0f));
+    const bool weapon = (!ability || ability->EquippedItemClass == ITEM_CLASS_WEAPON);
+    // Skill difference can be both negative and positive.
+    // a) Positive means that attacker's level is higher or additional weapon +skill bonuses
+    // b) Negative means that victim's level is higher or additional +defense bonuses
+    const bool ranged = (attType == RANGED_ATTACK);
+    const uint32 skill = (weapon ? GetWeaponSkillValue(attType, victim) : GetMaxSkillValueForLevel(victim));
+    const int32 difference = int32(skill - victim->GetDefenseSkillValue(this));
+    // Weapon skill factor: for players and NPCs
+    float factor = 0.04f;
+    chance += (difference * factor);
+    // Victim's crit taken chance
+    const SpellDmgClass dmgClass = (ranged ? SPELL_DAMAGE_CLASS_RANGED : SPELL_DAMAGE_CLASS_MELEE);
+    chance += victim->GetCritTakenChance(SPELL_SCHOOL_MASK_NORMAL, dmgClass);
+    return std::max(0.0f, std::min(chance, 100.0f));
+}
+
+float Unit::CalculateEffectiveMissChance(const Unit *victim, WeaponAttackType attType, const SpellEntry *ability) const
+{
+    float chance = 0.0f;
+
+    chance += (ability ? victim->GetMissChance(ability, SPELL_SCHOOL_MASK_NORMAL) : victim->GetMissChance(attType));
+    // Victim's own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit can't be missed
+    if (chance < 0.01f)
+        return 0.0f;
+    const bool ranged = (attType == RANGED_ATTACK);
+    const bool weapon = (!ability || ability->EquippedItemClass == ITEM_CLASS_WEAPON);
+    // Check if dual wielding, add additional miss penalty
+    if (!ability && !ranged && haveOffhandWeapon())
+        chance += 19.0f;
+    // Skill difference can be both negative and positive. Positive difference means that:
+    // a) Victim's level is higher
+    // b) Victim has additional defense skill bonuses
+    const bool vsPlayerOrPet = (victim->GetTypeId() == TYPEID_PLAYER || victim->GetOwnerGuid().IsPlayer());
+    const uint32 skill = (weapon ? GetWeaponSkillValue(attType, victim) : GetMaxSkillValueForLevel(victim));
+    int32 difference = int32(victim->GetDefenseSkillValue(this) - skill);
+    // Defense/weapon skill factor: for players and NPCs
+    float factor = 0.04f;
+    // NPCs gain additional bonus to incoming hit chance reduction based on positive skill difference (same value as bonus parry rate)
+    if (!vsPlayerOrPet && difference > 0)
+    {
+        if (difference > 10)
+        {
+            // First 10 points of difference (2 levels): usual decrease
+            chance += (10 * 0.1f);
+            difference -= 10;
+            // Each additional point of difference:
+            factor = 0.4f;
+            chance += (difference * 0.2f); // Pre-WotLK: Additional 1% miss chance for each level (final @ 3% per level)
+        }
+        else
+            factor = 0.1f;
+    }
+    chance += (difference * factor);
+    // Victim's auras affecting attacker's hit contribution:
+    chance -= victim->GetTotalAuraModifier(ranged ? SPELL_AURA_MOD_ATTACKER_RANGED_HIT_CHANCE: SPELL_AURA_MOD_ATTACKER_MELEE_HIT_CHANCE);
+    // Finally, take hit chance
+    chance -= (ability ? GetHitChance(ability, SPELL_SCHOOL_MASK_NORMAL) : GetHitChance(attType));
+    return std::max(0.0f, std::min(chance, 100.0f));
+}
+
+float Unit::CalculateSpellCritChance(const Unit *victim, SpellSchoolMask schoolMask, const SpellEntry *spell) const
+{
+    if (!spell || spell->HasAttribute(SPELL_ATTR_EX2_CANT_CRIT))
+        return 0.0f;
+
+    float chance = 0.0f;
+
+    switch (spell->DmgClass)
+    {
+        case SPELL_DAMAGE_CLASS_MELEE:
+        case SPELL_DAMAGE_CLASS_RANGED:
+            return CalculateEffectiveCritChance(victim, GetWeaponAttackType(spell), spell);
+    }
+    chance += GetCritChance(spell, schoolMask);
+    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit is incapable
+    if (chance < 0.01f)
+        return 0.0f;
+    // Modify by victim in case of hostile hit
+    if (!IsPositiveSpell(spell, this, victim))
+        chance += victim->GetCritTakenChance(schoolMask, SpellDmgClass(spell->DmgClass));
+    // TODO: Scripted crit chance auras: class script auras need to be orgnaized and re-implemented in the future as a part of scripting system
+    const AuraList &scripts = GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
+    for (AuraList::const_iterator i = scripts.begin(); i != scripts.end(); ++i)
+    {
+        if (!((*i)->isAffectedOnSpell(spell)))
+            continue;
+        switch ((*i)->GetModifier()->m_miscvalue)
+        {
+            // Shatter
+            case 849: if (victim->isFrozen()) chance += 10.0f; break;
+            case 910: if (victim->isFrozen()) chance += 20.0f; break;
+            case 911: if (victim->isFrozen()) chance += 30.0f; break;
+            case 912: if (victim->isFrozen()) chance += 40.0f; break;
+            case 913: if (victim->isFrozen()) chance += 50.0f; break;
+            default:
+                break;
+        }
+    }
+    return std::max(0.0f, std::min(chance, 100.0f));
+}
+
+float Unit::CalculateSpellMissChance(const Unit *victim, SpellSchoolMask schoolMask, const SpellEntry *spell) const
+{
+    if (!spell || spell->HasAttribute(SPELL_ATTR_EX3_CANT_MISS))
+        return 0.0f;
+
+    float chance = 0.0f;
+    const float minimum = 1.0f; // Pre-WotLK: unavoidable spell miss is at least 1%
+
+    switch (spell->DmgClass)
+    {
+        case SPELL_DAMAGE_CLASS_MELEE:
+        case SPELL_DAMAGE_CLASS_RANGED:
+            return CalculateEffectiveMissChance(victim, GetWeaponAttackType(spell), spell);
+    }
+    if (spell->HasAttribute(SPELL_ATTR_EX5_USE_PHYSICAL_HIT_CHANCE))
+    {
+        // How it works:
+        // - First introduced in patch 2.3 for Taunt, Growl, Righteous Defense, Challenging Shout and Challenging Roar
+        // - Switches spell to use ability miss chance calculation, but leaves standard unavoidable miss percent
+        // In WotLK+:
+        // - Removed for Taunt, Growl and Righteous Defense, so these spells have 17% miss against bosses
+        // - Added glyphs for Taunt and Growl to negate remaining 8% of spell miss difference
+        // - AoE taunts on cooldowns still use ability miss calculation
+        return std::max(minimum, CalculateEffectiveMissChance(victim, GetWeaponAttackType(spell), spell));
+    }
+    chance += victim->GetMissChance(spell, schoolMask);
+    // Victim's own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit can't be missed
+    if (chance < 0.01f)
+        return 0.0f;
+    // Level difference: positive adds to miss chance, negative substracts
+    const bool vsPlayerOrPet = (victim->GetTypeId() == TYPEID_PLAYER || victim->GetOwnerGuid().IsPlayer());
+    int32 difference = int32(victim->GetLevelForTarget(this) - GetLevelForTarget(victim));
+    // Level difference factor: 1% per level
+    uint8 factor = 1;
+    // NPCs and players gain additional bonus to incoming spell hit chance reduction based on positive level difference
+    if (difference > 2)
+    {
+        chance += (2 * factor);
+        // Miss bonus for each additional level of difference above 2
+        factor = (vsPlayerOrPet ? 7 : 11);
+        chance += ((difference - 2) * factor);
+    }
+    else
+        chance += (difference * factor);
+    // Reduce by caster's spell hit chance
+    chance -= GetHitChance(spell, schoolMask);
+    // Reduce (or increase) by victim SPELL_AURA_MOD_ATTACKER_SPELL_HIT_CHANCE auras
+    chance -= victim->GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_ATTACKER_SPELL_HIT_CHANCE, schoolMask);
+    return std::max(minimum, std::min(chance, 100.0f));
+}
+
+float Unit::GetExpertisePercent(WeaponAttackType attType) const
+{
+    int32 expertise = 0;
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        switch (uint32(attType))
+        {
+            case BASE_ATTACK:
+                expertise += int32(GetUInt32Value(PLAYER_EXPERTISE));
+                break;
+            case OFF_ATTACK:
+                expertise += int32(GetUInt32Value(PLAYER_OFFHAND_EXPERTISE));
+                break;
+        }
+    }
+    else if (attType != RANGED_ATTACK)
+        expertise += GetTotalAuraModifier(SPELL_AURA_MOD_EXPERTISE);
+    return (expertise * 0.25f); // (expertise / 4)
+}
+
+int32 Unit::GetResistancePenetration(SpellSchools school) const
+{
+    // Technically, it is target resistance mod, but it's used as penetration (negative sign) 99.9% of the time
+    // So, let's logically reverse the sign and use it as such
+    return -(GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_TARGET_RESISTANCE, (1 << school)));
+}
+
+float Unit::CalculateEffectiveMagicResistancePercent(const Unit *attacker, SpellSchoolMask schoolMask, bool binary) const
+{
+    // Non-magical or contains Physical as a component (such as Chaos) - ignores resistances completely
+    if (schoolMask & SPELL_SCHOOL_MASK_NORMAL)
+        return 0.0f;
+    // Completely ignore holy resistance value (since beta stages)
+    uint32 schools = uint32(schoolMask & ~uint32(SPELL_SCHOOL_MASK_HOLY));
+    // Select a resistance value matching given school mask, prefer mininal for multischool spells
+    int32 resistance = 0;
+    for (uint32 school = 0; schools; ++school)
+    {
+        if (schools & 1)
+        {
+            // Base victim resistance
+            int32 amount = int32(GetResistance(SpellSchools(school)));
+            // Modify by penetration
+            amount -= attacker->GetResistancePenetration(SpellSchools(school));
+            // If unit has no resistance for this school: use it!
+            if (amount < 1)
             {
-                case SPELL_SHADOWFURY:
-                    if (m_uiAbilityTimer < uiDiff)
+                resistance = 0; // Resistance can't be negative since early stages of development
+                break;
+            }
+            // Else if first school encountered or more vulnerable: memorize and continue
+            else if (!resistance || amount < resistance)
+                resistance = amount;
+        }
+        schools >>= 1;
+    }
+    // Attacker's level based skill, penalize when calculating for low levels (< 20):
+    const uint32 skill = std::max(attacker->GetMaxSkillValueForLevel(this), uint16(100));
+    float percent = float(float(resistance) / float(skill)) * 100 * 0.75f;
+    // Bonus resistance by level difference when calculating damage hit for NPCs only
+    if (!binary && GetTypeId() == TYPEID_UNIT && GetCharmerOrOwnerOrOwnGuid().IsCreature())
+        percent += (0.4f * std::max(int32(GetMaxSkillValueForLevel(attacker) - skill), 0));
+    // Magic resistance percentage cap
+    const float cap = 75.0f; // Pre-WotLK: 75%
+    return std::max(0.0f, std::min(percent, cap));
+}
+
+float Unit::CalculateSpellResistChance(const Unit *victim, SpellSchoolMask schoolMask, const SpellEntry *spell) const
+{
+    float chance = 0.0f;
+
+    // Chance to fully resist a spell by magic resistance
+    if (spell->DmgClass == SPELL_DAMAGE_CLASS_MAGIC && !spell->HasAttribute(SPELL_ATTR_EX4_IGNORE_RESISTANCES))
+    {
+        const bool binary = IsBinarySpell(spell);
+        const float percent = victim->CalculateEffectiveMagicResistancePercent(this, schoolMask, binary);
+        if (binary)
+            chance += percent;
+        else
+            chance += float(SPELL_PARTIAL_RESIST_DISTRIBUTION.at(uint32(percent * 100)).at(SPELL_PARTIAL_RESIST_PCT_100)) * 0.01f;
+    }
+    // Chance to fully resist entire spell by it's dispel type
+    if (const int32 type = int32(spell->Dispel))
+        chance += victim->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_DEBUFF_RESISTANCE, type);
+    // Chance to fully resist entire spell by it's mechanic
+    if (const int32 mechanic = int32(spell->Mechanic))
+        chance += victim->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_MECHANIC_RESISTANCE, mechanic);
+
+    // TODO: Move it in the future, effect mechanic resist must be processed differently
+    float effects = 0.0f;
+    for (uint32 i = EFFECT_INDEX_0; i < MAX_EFFECT_INDEX; ++i)
+    {
+        if (!spell->Effect[i])
+            continue;
+        if (const int32 mechanic = int32(spell->EffectMechanic[i]))
+        {
+            const float resist = victim->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_MECHANIC_RESISTANCE, mechanic);
+            if (resist > effects)
+                effects = resist;
+        }
+    }
+    chance += effects;
+    //
+    return std::max(0.0f, std::min(chance, 100.0f));
+}
+
+uint32 Unit::GetWeaponSkillValue(WeaponAttackType attType, Unit const* target) const
+{
+    uint32 value;
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        Item* item = ((Player*)this)->GetWeaponForAttack(attType, true, true);
+
+        // feral or unarmed skill only for base attack
+        if (attType != BASE_ATTACK && !item)
+            return 0;
+
+        if (IsInFeralForm())
+            return GetMaxSkillValueForLevel();              // always maximized SKILL_FERAL_COMBAT in fact
+
+        // weapon skill or (unarmed for base attack)
+        uint32 skill = item ? item->GetSkill() : uint32(SKILL_UNARMED);
+
+        // in PvP always use full skill (and bonuses on top of it if present)
+        value = (target && target->GetTypeId() == TYPEID_PLAYER)
+                ? std::max(((Player*)this)->GetMaxSkillValue(skill), ((Player*)this)->GetSkillValue(skill))
+                : ((Player*)this)->GetSkillValue(skill);
+        // Modify value from ratings
+        value += uint32(((Player*)this)->GetRatingBonusValue(CR_WEAPON_SKILL));
+        switch (attType)
+        {
+            case BASE_ATTACK:   value += uint32(((Player*)this)->GetRatingBonusValue(CR_WEAPON_SKILL_MAINHAND)); break;
+            case OFF_ATTACK:    value += uint32(((Player*)this)->GetRatingBonusValue(CR_WEAPON_SKILL_OFFHAND)); break;
+            case RANGED_ATTACK: value += uint32(((Player*)this)->GetRatingBonusValue(CR_WEAPON_SKILL_RANGED)); break;
+        }
+    }
+    else
+        value = GetUnitMeleeSkill(target);
+    return value;
+}
+
+void Unit::_UpdateSpells(uint32 time)
+{
+    if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL])
+        _UpdateAutoRepeatSpell();
+
+    // remove finished spells from current pointers
+    for (uint32 i = 0; i < CURRENT_MAX_SPELL; ++i)
+    {
+        if (m_currentSpells[i] && m_currentSpells[i]->getState() == SPELL_STATE_FINISHED)
+        {
+            m_currentSpells[i]->SetReferencedFromCurrent(false);
+            m_currentSpells[i] = nullptr;                      // remove pointer
+        }
+    }
+
+    // update auras
+    // m_AurasUpdateIterator can be updated in inderect called code at aura remove to skip next planned to update but removed auras
+    for (m_spellAuraHoldersUpdateIterator = m_spellAuraHolders.begin(); m_spellAuraHoldersUpdateIterator != m_spellAuraHolders.end();)
+    {
+        SpellAuraHolder* i_holder = m_spellAuraHoldersUpdateIterator->second;
+        ++m_spellAuraHoldersUpdateIterator;                 // need shift to next for allow update if need into aura update
+        i_holder->UpdateHolder(time);
+    }
+
+    // remove expired auras
+    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
+    {
+        SpellAuraHolder* holder = iter->second;
+
+        if (!(holder->IsPermanent() || holder->IsPassive()) && holder->GetAuraDuration() == 0)
+        {
+            RemoveSpellAuraHolder(holder, AURA_REMOVE_BY_EXPIRE);
+            iter = m_spellAuraHolders.begin();
+        }
+        else
+            ++iter;
+    }
+
+    if (!m_gameObj.empty())
+    {
+        GameObjectList::iterator ite1, dnext1;
+        for (ite1 = m_gameObj.begin(); ite1 != m_gameObj.end(); ite1 = dnext1)
+        {
+            dnext1 = ite1;
+            //(*i)->Update( difftime );
+            if (!(*ite1)->isSpawned())
+            {
+                (*ite1)->SetOwnerGuid(ObjectGuid());
+                (*ite1)->SetRespawnTime(0);
+                (*ite1)->Delete();
+                dnext1 = m_gameObj.erase(ite1);
+            }
+            else
+                ++dnext1;
+        }
+    }
+}
+
+void Unit::_UpdateAutoRepeatSpell()
+{
+    // check "realtime" interrupts
+    if ((GetTypeId() == TYPEID_PLAYER && ((Player*)this)->isMoving()) || IsNonMeleeSpellCasted(false, false, true))
+    {
+        // cancel wand shoot
+        if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Category == 351)
+            InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+        m_AutoRepeatFirstCast = true;
+        return;
+    }
+
+    // apply delay
+    if (m_AutoRepeatFirstCast && getAttackTimer(RANGED_ATTACK) < 500)
+        setAttackTimer(RANGED_ATTACK, 500);
+    m_AutoRepeatFirstCast = false;
+
+    // castroutine
+    if (isAttackReady(RANGED_ATTACK))
+    {
+        // Check if able to cast
+        if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->CheckCast(true) != SPELL_CAST_OK)
+        {
+            InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+            return;
+        }
+
+        // we want to shoot
+        Spell* spell = new Spell(this, m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo, true);
+        spell->SpellStart(&(m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_targets));
+
+        // all went good, reset attack
+        resetAttackTimer(RANGED_ATTACK);
+    }
+}
+
+void Unit::SetCurrentCastedSpell(Spell* pSpell)
+{
+    MANGOS_ASSERT(pSpell);                                  // nullptr may be never passed here, use InterruptSpell or InterruptNonMeleeSpells
+
+    CurrentSpellTypes CSpellType = pSpell->GetCurrentContainer();
+
+    if (pSpell == m_currentSpells[CSpellType]) return;      // avoid breaking self
+
+    // break same type spell if it is not delayed
+    InterruptSpell(CSpellType, false);
+
+    // special breakage effects:
+    switch (CSpellType)
+    {
+        case CURRENT_GENERIC_SPELL:
+        {
+            // generic spells always break channeled not delayed spells
+            InterruptSpell(CURRENT_CHANNELED_SPELL, false);
+
+            // autorepeat breaking
+            if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL])
+            {
+                // break autorepeat if not Auto Shot
+                if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Category == 351)
+                    InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+                m_AutoRepeatFirstCast = true;
+            }
+        } break;
+
+        case CURRENT_CHANNELED_SPELL:
+        {
+            // channel spells always break generic non-delayed and any channeled spells
+            InterruptSpell(CURRENT_GENERIC_SPELL, false);
+            InterruptSpell(CURRENT_CHANNELED_SPELL);
+
+            // it also does break autorepeat if not Auto Shot
+            if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL] &&
+                    m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Category == 351)
+                InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+        } break;
+
+        case CURRENT_AUTOREPEAT_SPELL:
+        {
+            // only Auto Shoot does not break anything
+            if (pSpell->m_spellInfo->Category == 351)
+            {
+                // generic autorepeats break generic non-delayed and channeled non-delayed spells
+                InterruptSpell(CURRENT_GENERIC_SPELL, false);
+                InterruptSpell(CURRENT_CHANNELED_SPELL, false);
+            }
+            // special action: set first cast flag
+            m_AutoRepeatFirstCast = true;
+        } break;
+
+        default:
+        {
+            // other spell types don't break anything now
+        } break;
+    }
+
+    // current spell (if it is still here) may be safely deleted now
+    if (m_currentSpells[CSpellType])
+        m_currentSpells[CSpellType]->SetReferencedFromCurrent(false);
+
+    // set new current spell
+    m_currentSpells[CSpellType] = pSpell;
+    pSpell->SetReferencedFromCurrent(true);
+}
+
+void Unit::InterruptSpell(CurrentSpellTypes spellType, bool withDelayed)
+{
+    if (m_currentSpells[spellType] && (withDelayed || m_currentSpells[spellType]->getState() != SPELL_STATE_DELAYED))
+    {
+        // send autorepeat cancel message for autorepeat spells
+        if (spellType == CURRENT_AUTOREPEAT_SPELL)
+        {
+            if (GetTypeId() == TYPEID_PLAYER)
+                ((Player*)this)->SendAutoRepeatCancel();
+        }
+
+        if (m_currentSpells[spellType]->getState() != SPELL_STATE_FINISHED)
+            m_currentSpells[spellType]->cancel();
+
+        // cancel can interrupt spell already (caster cancel ->target aura remove -> caster iterrupt)
+        if (m_currentSpells[spellType])
+        {
+            m_currentSpells[spellType]->SetReferencedFromCurrent(false);
+            m_currentSpells[spellType] = nullptr;
+        }
+    }
+}
+
+void Unit::FinishSpell(CurrentSpellTypes spellType, bool ok /*= true*/)
+{
+    Spell* spell = m_currentSpells[spellType];
+    if (!spell)
+        return;
+
+    if (spellType == CURRENT_CHANNELED_SPELL)
+        spell->SendChannelUpdate(0);
+
+    spell->finish(ok);
+}
+
+bool Unit::IsNonMeleeSpellCasted(bool withDelayed, bool skipChanneled, bool skipAutorepeat) const
+{
+    // We don't do loop here to explicitly show that melee spell is excluded.
+    // Maybe later some special spells will be excluded too.
+
+    // generic spells are casted when they are not finished and not delayed
+    if (m_currentSpells[CURRENT_GENERIC_SPELL] &&
+            (m_currentSpells[CURRENT_GENERIC_SPELL]->getState() != SPELL_STATE_FINISHED) &&
+            (withDelayed || m_currentSpells[CURRENT_GENERIC_SPELL]->getState() != SPELL_STATE_DELAYED))
+        return true;
+
+    // channeled spells may be delayed, but they are still considered casted
+    else if (!skipChanneled && m_currentSpells[CURRENT_CHANNELED_SPELL] &&
+             (m_currentSpells[CURRENT_CHANNELED_SPELL]->getState() != SPELL_STATE_FINISHED))
+        return true;
+
+    // autorepeat spells may be finished or delayed, but they are still considered casted
+    else if (!skipAutorepeat && m_currentSpells[CURRENT_AUTOREPEAT_SPELL])
+        return true;
+
+    return false;
+}
+
+void Unit::InterruptNonMeleeSpells(bool withDelayed, uint32 spell_id)
+{
+    // generic spells are interrupted if they are not finished or delayed
+    if (m_currentSpells[CURRENT_GENERIC_SPELL] && (!spell_id || m_currentSpells[CURRENT_GENERIC_SPELL]->m_spellInfo->Id == spell_id))
+        InterruptSpell(CURRENT_GENERIC_SPELL, withDelayed);
+
+    // autorepeat spells are interrupted if they are not finished or delayed
+    if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL] && (!spell_id || m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Id == spell_id))
+        InterruptSpell(CURRENT_AUTOREPEAT_SPELL, withDelayed);
+
+    // channeled spells are interrupted if they are not finished, even if they are delayed
+    if (m_currentSpells[CURRENT_CHANNELED_SPELL] && (!spell_id || m_currentSpells[CURRENT_CHANNELED_SPELL]->m_spellInfo->Id == spell_id))
+        InterruptSpell(CURRENT_CHANNELED_SPELL, true);
+}
+
+Spell* Unit::FindCurrentSpellBySpellId(uint32 spell_id) const
+{
+    for (uint32 i = 0; i < CURRENT_MAX_SPELL; ++i)
+        if (m_currentSpells[i] && m_currentSpells[i]->m_spellInfo->Id == spell_id)
+            return m_currentSpells[i];
+    return nullptr;
+}
+
+void Unit::SetInFront(Unit const* target)
+{
+    SetOrientation(GetAngle(target));
+}
+
+void Unit::SetFacingTo(float ori)
+{
+    Movement::MoveSplineInit init(*this);
+    init.SetFacing(ori);
+    init.Launch();
+}
+
+void Unit::SetFacingToObject(WorldObject* pObject)
+{
+    // never face when already moving
+    if (!IsStopped())
+        return;
+
+    // TODO: figure out under what conditions creature will move towards object instead of facing it where it currently is.
+    SetFacingTo(GetAngle(pObject));
+}
+
+bool Unit::isInAccessablePlaceFor(Unit const* unit) const
+{
+    if (IsInWater())
+        return unit->CanSwim();
+    else
+        return unit->CanWalk() || unit->CanFly();
+}
+
+bool Unit::IsInWater() const
+{
+    return GetTerrain()->IsInWater(GetPositionX(), GetPositionY(), GetPositionZ());
+}
+
+bool Unit::IsUnderWater() const
+{
+    return GetTerrain()->IsUnderWater(GetPositionX(), GetPositionY(), GetPositionZ());
+}
+
+void Unit::DeMorph()
+{
+    SetDisplayId(GetNativeDisplayId());
+}
+
+int32 Unit::GetTotalAuraModifier(AuraType auratype) const
+{
+    int32 modifier = 0;
+
+    AuraList const& mTotalAuraList = GetAurasByType(auratype);
+    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
+        modifier += (*i)->GetModifier()->m_amount;
+
+    return modifier;
+}
+
+float Unit::GetTotalAuraMultiplier(AuraType auratype) const
+{
+    float multiplier = 1.0f;
+
+    AuraList const& mTotalAuraList = GetAurasByType(auratype);
+    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
+        multiplier *= (100.0f + (*i)->GetModifier()->m_amount) / 100.0f;
+
+    return multiplier;
+}
+
+int32 Unit::GetMaxPositiveAuraModifier(AuraType auratype) const
+{
+    int32 modifier = 0;
+
+    AuraList const& mTotalAuraList = GetAurasByType(auratype);
+    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
+        if ((*i)->GetModifier()->m_amount > modifier)
+            modifier = (*i)->GetModifier()->m_amount;
+
+    return modifier;
+}
+
+int32 Unit::GetMaxNegativeAuraModifier(AuraType auratype) const
+{
+    int32 modifier = 0;
+
+    AuraList const& mTotalAuraList = GetAurasByType(auratype);
+    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
+        if ((*i)->GetModifier()->m_amount < modifier)
+            modifier = (*i)->GetModifier()->m_amount;
+
+    return modifier;
+}
+
+int32 Unit::GetTotalAuraModifierByMiscMask(AuraType auratype, uint32 misc_mask) const
+{
+    if (!misc_mask)
+        return 0;
+
+    int32 modifier = 0;
+
+    AuraList const& mTotalAuraList = GetAurasByType(auratype);
+    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
+    {
+        Modifier* mod = (*i)->GetModifier();
+        if (mod->m_miscvalue & misc_mask)
+            modifier += mod->m_amount;
+    }
+    return modifier;
+}
+
+float Unit::GetTotalAuraMultiplierByMiscMask(AuraType auratype, uint32 misc_mask) const
+{
+    if (!misc_mask)
+        return 1.0f;
+
+    float multiplier = 1.0f;
+
+    AuraList const& mTotalAuraList = GetAurasByType(auratype);
+    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
+    {
+        Modifier* mod = (*i)->GetModifier();
+        if (mod->m_miscvalue & misc_mask)
+            multiplier *= (100.0f + mod->m_amount) / 100.0f;
+    }
+    return multiplier;
+}
+
+int32 Unit::GetMaxPositiveAuraModifierByMiscMask(AuraType auratype, uint32 misc_mask) const
+{
+    if (!misc_mask)
+        return 0;
+
+    int32 modifier = 0;
+
+    AuraList const& mTotalAuraList = GetAurasByType(auratype);
+    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
+    {
+        Modifier* mod = (*i)->GetModifier();
+        if (mod->m_miscvalue & misc_mask && mod->m_amount > modifier)
+            modifier = mod->m_amount;
+    }
+
+    return modifier;
+}
+
+int32 Unit::GetMaxNegativeAuraModifierByMiscMask(AuraType auratype, uint32 misc_mask) const
+{
+    if (!misc_mask)
+        return 0;
+
+    int32 modifier = 0;
+
+    AuraList const& mTotalAuraList = GetAurasByType(auratype);
+    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
+    {
+        Modifier* mod = (*i)->GetModifier();
+        if (mod->m_miscvalue & misc_mask && mod->m_amount < modifier)
+            modifier = mod->m_amount;
+    }
+
+    return modifier;
+}
+
+int32 Unit::GetTotalAuraModifierByMiscValue(AuraType auratype, int32 misc_value) const
+{
+    int32 modifier = 0;
+
+    AuraList const& mTotalAuraList = GetAurasByType(auratype);
+    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
+    {
+        Modifier* mod = (*i)->GetModifier();
+        if (mod->m_miscvalue == misc_value)
+            modifier += mod->m_amount;
+    }
+    return modifier;
+}
+
+float Unit::GetTotalAuraMultiplierByMiscValue(AuraType auratype, int32 misc_value) const
+{
+    float multiplier = 1.0f;
+
+    AuraList const& mTotalAuraList = GetAurasByType(auratype);
+    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
+    {
+        Modifier* mod = (*i)->GetModifier();
+        if (mod->m_miscvalue == misc_value)
+            multiplier *= (100.0f + mod->m_amount) / 100.0f;
+    }
+    return multiplier;
+}
+
+int32 Unit::GetMaxPositiveAuraModifierByMiscValue(AuraType auratype, int32 misc_value) const
+{
+    int32 modifier = 0;
+
+    AuraList const& mTotalAuraList = GetAurasByType(auratype);
+    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
+    {
+        Modifier* mod = (*i)->GetModifier();
+        if (mod->m_miscvalue == misc_value && mod->m_amount > modifier)
+            modifier = mod->m_amount;
+    }
+
+    return modifier;
+}
+
+int32 Unit::GetMaxNegativeAuraModifierByMiscValue(AuraType auratype, int32 misc_value) const
+{
+    int32 modifier = 0;
+
+    AuraList const& mTotalAuraList = GetAurasByType(auratype);
+    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
+    {
+        Modifier* mod = (*i)->GetModifier();
+        if (mod->m_miscvalue == misc_value && mod->m_amount < modifier)
+            modifier = mod->m_amount;
+    }
+
+    return modifier;
+}
+
+bool Unit::AddSpellAuraHolder(SpellAuraHolder* holder)
+{
+    SpellEntry const* aurSpellInfo = holder->GetSpellProto();
+
+    // ghost spell check, allow apply any auras at player loading in ghost mode (will be cleanup after load)
+    if (!isAlive() && !IsDeathPersistentSpell(aurSpellInfo) &&
+        !IsDeathOnlySpell(aurSpellInfo) && !aurSpellInfo->HasAttribute(SPELL_ATTR_EX2_CAN_TARGET_DEAD) &&
+        (GetTypeId() != TYPEID_PLAYER || !((Player*)this)->GetSession()->PlayerLoading()))
+    {
+        delete holder;
+        return false;
+    }
+
+    if (holder->GetTarget() != this)
+    {
+        sLog.outError("Holder (spell %u) add to spell aura holder list of %s (lowguid: %u) but spell aura holder target is %s (lowguid: %u)",
+                      holder->GetId(), (GetTypeId() == TYPEID_PLAYER ? "player" : "creature"), GetGUIDLow(),
+                      (holder->GetTarget()->GetTypeId() == TYPEID_PLAYER ? "player" : "creature"), holder->GetTarget()->GetGUIDLow());
+        delete holder;
+        return false;
+    }
+
+    // passive and persistent auras can stack with themselves any number of times
+    if ((!holder->IsPassive() && !holder->IsPersistent()) || holder->IsAreaAura())
+    {
+        SpellAuraHolderBounds spair = GetSpellAuraHolderBounds(aurSpellInfo->Id);
+
+        // take out same spell
+        for (SpellAuraHolderMap::iterator iter = spair.first; iter != spair.second; ++iter)
+        {
+            SpellAuraHolder* foundHolder = iter->second;
+            if (foundHolder->GetCasterGuid() == holder->GetCasterGuid())
+            {
+                // Aura can stack on self -> Stack it;
+                if (aurSpellInfo->StackAmount)
+                {
+                    // can be created with >1 stack by some spell mods
+                    foundHolder->ModStackAmount(holder->GetStackAmount());
+                    delete holder;
+                    return false;
+                }
+
+                // Check for coexisting Weapon-proced Auras
+                if (holder->IsWeaponBuffCoexistableWith(foundHolder))
+                    continue;
+
+                // Carry over removed Aura's remaining damage if Aura still has ticks remaining
+                if (foundHolder->GetSpellProto()->HasAttribute(SPELL_ATTR_EX4_STACK_DOT_MODIFIER))
+                {
+                    for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
                     {
-                        if (m_creature->IsWithinDistInMap(m_creature->getVictim(), INTERACTION_DISTANCE))
+                        if (Aura* aur = holder->GetAuraByEffectIndex(SpellEffectIndex(i)))
                         {
-                            if (DoCastSpellIfCan(m_creature, SPELL_SHADOWFURY) == CAST_OK)
-                                m_uiSuicideTimer = 1000;
+                            // m_auraname can be modified to SPELL_AURA_NONE for area auras, use original
+                            AuraType aurNameReal = AuraType(aurSpellInfo->EffectApplyAuraName[i]);
+
+                            if (aurNameReal == SPELL_AURA_PERIODIC_DAMAGE && aur->GetAuraDuration() > 0)
+                            {
+                                if (Aura* existing = foundHolder->GetAuraByEffectIndex(SpellEffectIndex(i)))
+                                {
+                                    int32 remainingTicks = existing->GetAuraMaxTicks() - existing->GetAuraTicks();
+                                    int32 remainingDamage = existing->GetModifier()->m_amount * remainingTicks;
+
+                                    aur->GetModifier()->m_amount += int32(remainingDamage / aur->GetAuraMaxTicks());
+                                }
+                                else
+                                    DEBUG_LOG("Holder (spell %u) on target (lowguid: %u) doesn't have aura on effect index %u. skipping.", aurSpellInfo->Id, holder->GetTarget()->GetGUIDLow(), i);
+                            }
                         }
                     }
-                    else
-                        m_uiAbilityTimer -= uiDiff;
+                }
+
+                // can be only single
+                RemoveSpellAuraHolder(foundHolder, AURA_REMOVE_BY_STACK);
+                break;
+            }
+            else
+            {
+                //any stackable case with amount should mod existing stack amount
+                if (aurSpellInfo->StackAmount && aurSpellInfo->rangeIndex != SPELL_RANGE_IDX_SELF_ONLY && !aurSpellInfo->HasAttribute(SPELL_ATTR_EX3_STACK_FOR_DIFF_CASTERS))
+                {
+                    foundHolder->ModStackAmount(holder->GetStackAmount());
+                    delete holder;
+                    return false;
+                }
+                else
+                {
+                    if (!IsStackableSpell(holder->GetSpellProto(), foundHolder->GetSpellProto(), holder->GetTarget()))
+                    {
+                        RemoveSpellAuraHolder(foundHolder, AURA_REMOVE_BY_STACK);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // normal spell or passive auras not stackable with other ranks
+    if (!IsPassiveSpell(aurSpellInfo) || !IsPassiveSpellStackableWithRanks(aurSpellInfo))
+    {
+        if (!RemoveNoStackAurasDueToAuraHolder(holder))
+        {
+            delete holder;
+            return false;                                   // couldn't remove conflicting aura with higher rank
+        }
+    }
+
+    // update tracked aura targets list (before aura add to aura list, to prevent unexpected remove recently added aura)
+    if (TrackedAuraType trackedType = holder->GetTrackedAuraType())
+    {
+        if (Unit* caster = holder->GetCaster())             // caster not in world
+        {
+            // Only compare TrackedAuras of same tracking type
+            TrackedAuraTargetMap& scTargets = caster->GetTrackedAuraTargets(trackedType);
+            for (TrackedAuraTargetMap::iterator itr = scTargets.begin(); itr != scTargets.end();)
+            {
+                SpellEntry const* itr_spellEntry = itr->first;
+                ObjectGuid itr_targetGuid = itr->second;    // Target on whom the tracked aura is
+
+                if (itr_targetGuid == GetObjectGuid())      // Note: I don't understand this check (based on old aura concepts, kept when adding holders)
+                {
+                    ++itr;
+                    continue;
+                }
+
+                bool removed = false;
+                switch (trackedType)
+                {
+                    case TRACK_AURA_TYPE_SINGLE_TARGET:
+                        if (IsSingleTargetSpells(itr_spellEntry, aurSpellInfo))
+                        {
+                            removed = true;
+                            // remove from target if target found
+                            if (Unit* itr_target = GetMap()->GetUnit(itr_targetGuid))
+                                itr_target->RemoveAurasDueToSpell(itr_spellEntry->Id); // TODO AURA_REMOVE_BY_TRACKING (might require additional work elsewhere)
+                            else                            // Normally the tracking will be removed by the AuraRemoval
+                                scTargets.erase(itr);
+                        }
+                        break;
+                    case TRACK_AURA_TYPE_NOT_TRACKED:       // These two can never happen
+                    case MAX_TRACKED_AURA_TYPES:
+                        MANGOS_ASSERT(false);
+                        break;
+                }
+
+                if (removed)
+                {
+                    itr = scTargets.begin();                // list can be chnaged at remove aura
+                    continue;
+                }
+
+                ++itr;
+            }
+
+            // TODO remove this switch after confirming that we dont need other cases
+            switch (trackedType)
+            {
+                case TRACK_AURA_TYPE_SINGLE_TARGET:         // Register spell holder single target
+                    scTargets[aurSpellInfo] = GetObjectGuid();
                     break;
-                case SPELL_DARK_STRIKE:
-                    if (m_uiAbilityTimer < uiDiff)
-                    {
-                        if (DoCastSpellIfCan(m_creature->getVictim(), SPELL_DARK_STRIKE) == CAST_OK)
-                        {
-                            ++m_uiDarkStrikes;
-                            // kill itself after 2 strikes
-                            if (m_uiDarkStrikes == 2)
-                                m_uiSuicideTimer = 1000;
-                            else
-                                m_uiAbilityTimer = 1000;
-                        }
-                    }
-                    else
-                        m_uiAbilityTimer -= uiDiff;
+                default:
                     break;
             }
         }
     }
+
+    // add aura, register in lists and arrays
+    holder->_AddSpellAuraHolder();
+    m_spellAuraHolders.insert(SpellAuraHolderMap::value_type(holder->GetId(), holder));
+
+    for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+        if (Aura* aur = holder->GetAuraByEffectIndex(SpellEffectIndex(i)))
+            AddAuraToModList(aur);
+
+    holder->ApplyAuraModifiers(true, true);                 // This is the place where auras are actually applied onto the target
+    DEBUG_LOG("Holder of spell %u now is in use", holder->GetId());
+
+    // if aura deleted before boosts apply ignore
+    // this can be possible it it removed indirectly by triggered spell effect at ApplyModifier
+    if (holder->IsDeleted())
+        return false;
+
+    holder->HandleSpellSpecificBoosts(true);
+
+    return true;
+}
+
+void Unit::AddAuraToModList(Aura* aura)
+{
+    if (aura->GetModifier()->m_auraname < TOTAL_AURAS)
+        m_modAuras[aura->GetModifier()->m_auraname].push_back(aura);
+}
+
+void Unit::RemoveRankAurasDueToSpell(uint32 spellId)
+{
+    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
+    if (!spellInfo)
+        return;
+    SpellAuraHolderMap::const_iterator i, next;
+    for (i = m_spellAuraHolders.begin(); i != m_spellAuraHolders.end(); i = next)
+    {
+        next = i;
+        ++next;
+        uint32 i_spellId = (*i).second->GetId();
+        if ((*i).second && i_spellId && i_spellId != spellId)
+        {
+            if (sSpellMgr.IsRankSpellDueToSpell(spellInfo, i_spellId))
+            {
+                RemoveAurasDueToSpell(i_spellId);
+
+                if (m_spellAuraHolders.empty())
+                    break;
+                else
+                    next =  m_spellAuraHolders.begin();
+            }
+        }
+    }
+}
+
+bool Unit::RemoveNoStackAurasDueToAuraHolder(SpellAuraHolder* holder)
+{
+    if (!holder)
+        return false;
+
+    SpellEntry const* spellProto = holder->GetSpellProto();
+    if (!spellProto)
+        return false;
+
+    // passive spell special case (only non stackable with ranks)
+    if (IsPassiveSpell(spellProto))
+    {
+        if (IsPassiveSpellStackableWithRanks(spellProto))
+            return true;
+    }
+
+    const uint32 spellId = holder->GetId();
+    const SpellSpecific specific = GetSpellSpecific(spellId);
+    SpellEntry const* triggeredBy = holder->GetTriggeredBy();
+
+    SpellAuraHolderMap::iterator i, next;
+    for (i = m_spellAuraHolders.begin(); i != m_spellAuraHolders.end(); i = next)
+    {
+        next = i;
+        ++next;
+        if (!(*i).second) continue;
+
+        SpellAuraHolder* existing = (*i).second;
+        SpellEntry const* existingSpellProto = existing->GetSpellProto();
+
+        if (!existingSpellProto)
+            continue;
+
+        const uint32 existingSpellId = existingSpellProto->Id;
+        const SpellSpecific existingSpecific = GetSpellSpecific(existingSpellId);
+        const bool own = (holder->GetCasterGuid() == existing->GetCasterGuid());
+
+        // early checks that spellId is passive non stackable spell
+        if (IsPassiveSpell(existingSpellProto))
+        {
+            // passive non-stackable spells not stackable only for same caster
+            if (!own)
+                continue;
+
+            // passive non-stackable spells not stackable only with another rank of same spell
+            if (!sSpellMgr.IsRankSpellDueToSpell(spellProto, existingSpellId))
+                continue;
+        }
+
+        // prevent triggering aura of removing aura that triggered it
+        if ((existing->GetTriggeredBy() && existing->GetTriggeredBy()->Id == spellId)
+            || (holder->GetTriggeredBy() && holder->GetTriggeredBy()->Id == existingSpellId))
+            continue;
+
+        bool unique = false;
+        bool personal = false;
+        if (specific && existingSpecific && IsSpellSpecificIdentical(specific, existingSpecific))
+        {
+            personal = IsSpellSpecificUniquePerCaster(specific);
+            unique = (personal || IsSpellSpecificUniquePerTarget(specific));
+        }
+
+        const bool stackable = !sSpellMgr.IsNoStackSpellDueToSpell(spellProto, existingSpellProto);
+        if (unique || !stackable)
+        {
+            // check if this spell can be triggered by any talent aura
+            if (!unique && triggeredBy && sSpellMgr.IsSpellCanAffectSpell(triggeredBy, existingSpellProto))
+                continue;
+
+            if (!own)
+            {
+                if (personal && stackable)
+                    continue;
+                // holder cannot remove higher rank if it isn't from the same caster
+                if (IsSimilarExistingAuraStronger(holder, existing) || (sSpellMgr.IsRankSpellDueToSpell(spellProto, existingSpellId) && sSpellMgr.IsHighRankOfSpell(existingSpellId, spellId)))
+                    return false;
+            }
+
+            // Its a parent aura (create this aura in ApplyModifier)
+            if (existing->IsInUse())
+            {
+                sLog.outError("SpellAuraHolder (Spell %u) is in process but attempt removed at SpellAuraHolder (Spell %u) adding, need add stack rule for Unit::RemoveNoStackAurasDueToAuraHolder", i->second->GetId(), holder->GetId());
+                continue;
+            }
+
+            if (personal && stackable)
+                RemoveAurasByCasterSpell(existingSpellId, holder->GetCasterGuid());
+            else
+                RemoveAurasDueToSpell(existingSpellId);
+
+            if (m_spellAuraHolders.empty())
+                break;
+            else
+                next = m_spellAuraHolders.begin();
+        }
+    }
+    return true;
+}
+
+void Unit::RemoveAura(uint32 spellId, SpellEffectIndex effindex, Aura* except)
+{
+    SpellAuraHolderBounds spair = GetSpellAuraHolderBounds(spellId);
+    for (SpellAuraHolderMap::iterator iter = spair.first; iter != spair.second;)
+    {
+        Aura* aur = iter->second->m_auras[effindex];
+        if (aur && aur != except)
+        {
+            RemoveSingleAuraFromSpellAuraHolder(iter->second, effindex);
+            // may remove holder
+            spair = GetSpellAuraHolderBounds(spellId);
+            iter = spair.first;
+        }
+        else
+            ++iter;
+    }
+}
+void Unit::RemoveAurasByCasterSpell(uint32 spellId, ObjectGuid casterGuid)
+{
+    SpellAuraHolderBounds spair = GetSpellAuraHolderBounds(spellId);
+    for (SpellAuraHolderMap::iterator iter = spair.first; iter != spair.second;)
+    {
+        if (iter->second->GetCasterGuid() == casterGuid)
+        {
+            RemoveSpellAuraHolder(iter->second);
+            spair = GetSpellAuraHolderBounds(spellId);
+            iter = spair.first;
+        }
+        else
+            ++iter;
+    }
+}
+
+void Unit::RemoveSingleAuraFromSpellAuraHolder(uint32 spellId, SpellEffectIndex effindex, ObjectGuid casterGuid, AuraRemoveMode mode)
+{
+    SpellAuraHolderBounds spair = GetSpellAuraHolderBounds(spellId);
+    for (SpellAuraHolderMap::iterator iter = spair.first; iter != spair.second;)
+    {
+        Aura* aur = iter->second->m_auras[effindex];
+        if (aur && aur->GetCasterGuid() == casterGuid)
+        {
+            RemoveSingleAuraFromSpellAuraHolder(iter->second, effindex, mode);
+            spair = GetSpellAuraHolderBounds(spellId);
+            iter = spair.first;
+        }
+        else
+            ++iter;
+    }
+}
+
+void Unit::RemoveAuraHolderDueToSpellByDispel(uint32 spellId, uint32 stackAmount, ObjectGuid casterGuid, Unit* dispeller)
+{
+    SpellEntry const* spellEntry = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
+
+    // Custom dispel case
+    // Unstable Affliction
+    if (spellEntry->SpellFamilyName == SPELLFAMILY_WARLOCK && (spellEntry->SpellFamilyFlags & uint64(0x010000000000)))
+    {
+        if (Aura* dotAura = GetAura(SPELL_AURA_PERIODIC_DAMAGE, SPELLFAMILY_WARLOCK, uint64(0x010000000000), casterGuid))
+        {
+            // use clean value for initial damage
+            int32 damage = dotAura->GetSpellProto()->CalculateSimpleValue(EFFECT_INDEX_0);
+            damage *= 9;
+
+            // Remove spell auras from stack
+            RemoveAuraHolderFromStack(spellId, stackAmount, casterGuid, AURA_REMOVE_BY_DISPEL);
+
+            // backfire damage and silence
+            dispeller->CastCustomSpell(dispeller, 31117, &damage, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, nullptr, nullptr, casterGuid);
+            return;
+        }
+    }
+    // Lifebloom
+    else if (spellEntry->SpellFamilyName == SPELLFAMILY_DRUID && (spellEntry->SpellFamilyFlags & uint64(0x0000001000000000)))
+    {
+        if (Aura* dotAura = GetAura(SPELL_AURA_DUMMY, SPELLFAMILY_DRUID, uint64(0x0000001000000000), casterGuid))
+        {
+            if (dotAura->GetStackAmount() <= stackAmount)
+            {
+                // Lifebloom dummy store single stack amount always
+                int32 amount = dotAura->GetModifier()->m_amount;
+                CastCustomSpell(this, 33778, &amount, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, nullptr, dotAura, casterGuid);
+            }
+        }
+    }
+
+    RemoveAuraHolderFromStack(spellId, stackAmount, casterGuid, AURA_REMOVE_BY_DISPEL);
+}
+
+void Unit::RemoveAurasDueToSpellBySteal(uint32 spellId, ObjectGuid casterGuid, Unit* stealer)
+{
+    SpellAuraHolder* holder = GetSpellAuraHolder(spellId, casterGuid);
+    SpellEntry const* spellProto = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
+    SpellAuraHolder* new_holder = CreateSpellAuraHolder(spellProto, stealer, this);
+
+    // set its duration and maximum duration
+    // max duration 2 minutes (in msecs)
+    int32 dur = holder->GetAuraDuration();
+    int32 max_dur = 2 * MINUTE * IN_MILLISECONDS;
+    int32 new_max_dur = max_dur > dur ? dur : max_dur;
+    new_holder->SetAuraMaxDuration(new_max_dur);
+    new_holder->SetAuraDuration(new_max_dur);
+
+    for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+    {
+        Aura* aur = holder->GetAuraByEffectIndex(SpellEffectIndex(i));
+
+        if (!aur)
+            continue;
+
+        int32 basePoints = aur->GetBasePoints();
+        // construct the new aura for the attacker - will never return nullptr, it's just a wrapper for
+        // some different constructors
+        Aura* new_aur = CreateAura(aur->GetSpellProto(), aur->GetEffIndex(), &basePoints, new_holder, stealer, this);
+
+        // set periodic to do at least one tick (for case when original aura has been at last tick preparing)
+        int32 periodic = aur->GetModifier()->periodictime;
+        new_aur->GetModifier()->periodictime = periodic < new_max_dur ? periodic : new_max_dur;
+
+        // add the new aura to stealer
+        new_holder->AddAura(new_aur, new_aur->GetEffIndex());
+    }
+
+    if (holder->ModStackAmount(-1))
+        // Remove aura as dispel
+        RemoveSpellAuraHolder(holder, AURA_REMOVE_BY_DISPEL);
+
+    // strange but intended behaviour: Stolen single target auras won't be treated as single targeted
+    new_holder->SetTrackedAuraType(TRACK_AURA_TYPE_NOT_TRACKED);
+
+    stealer->AddSpellAuraHolder(new_holder);
+}
+
+void Unit::RemoveAurasDueToSpellByCancel(uint32 spellId)
+{
+    SpellAuraHolderBounds spair = GetSpellAuraHolderBounds(spellId);
+    for (SpellAuraHolderMap::iterator iter = spair.first; iter != spair.second;)
+    {
+        RemoveSpellAuraHolder(iter->second, AURA_REMOVE_BY_CANCEL);
+        spair = GetSpellAuraHolderBounds(spellId);
+        iter = spair.first;
+    }
+}
+
+void Unit::RemoveAurasTriggeredBySpell(uint32 spellId, ObjectGuid casterGuid /*= ObjectGuid()*/)
+{
+    if (!spellId)
+        return;
+
+    SpellAuraHolderMap& auras = GetSpellAuraHolderMap();
+    for (SpellAuraHolderMap::iterator itr = auras.begin(); itr != auras.end();)
+    {
+        const SpellEntry* entry = itr->second->GetTriggeredBy();
+        if ((entry && entry->Id == spellId) && (casterGuid.IsEmpty() || casterGuid == itr->second->GetCasterGuid()))
+        {
+            RemoveSpellAuraHolder(itr->second);
+            itr = auras.begin();
+        }
+        else
+            ++itr;
+    }
+}
+
+void Unit::RemoveAurasWithDispelType(DispelType type, ObjectGuid casterGuid)
+{
+    // Create dispel mask by dispel type
+    uint32 dispelMask = GetDispellMask(type);
+    // Dispel all existing auras vs current dispel type
+    SpellAuraHolderMap& auras = GetSpellAuraHolderMap();
+    for (SpellAuraHolderMap::iterator itr = auras.begin(); itr != auras.end();)
+    {
+        SpellEntry const* spell = itr->second->GetSpellProto();
+        if (((1 << spell->Dispel) & dispelMask) && (!casterGuid || casterGuid == itr->second->GetCasterGuid()))
+        {
+            // Dispel aura
+            RemoveAurasDueToSpell(spell->Id);
+            itr = auras.begin();
+        }
+        else
+            ++itr;
+    }
+}
+
+void Unit::RemoveAuraHolderFromStack(uint32 spellId, uint32 stackAmount, ObjectGuid casterGuid, AuraRemoveMode mode)
+{
+    SpellAuraHolderBounds spair = GetSpellAuraHolderBounds(spellId);
+    for (SpellAuraHolderMap::iterator iter = spair.first; iter != spair.second; ++iter)
+    {
+        if (!casterGuid || iter->second->GetCasterGuid() == casterGuid)
+        {
+            if (iter->second->ModStackAmount(-int32(stackAmount)))
+            {
+                RemoveSpellAuraHolder(iter->second, mode);
+                break;
+            }
+        }
+    }
+}
+
+void Unit::RemoveAurasDueToSpell(uint32 spellId, SpellAuraHolder* except, AuraRemoveMode mode)
+{
+    SpellAuraHolderBounds bounds = GetSpellAuraHolderBounds(spellId);
+    for (SpellAuraHolderMap::iterator iter = bounds.first; iter != bounds.second;)
+    {
+        if (iter->second != except)
+        {
+            RemoveSpellAuraHolder(iter->second, mode);
+            bounds = GetSpellAuraHolderBounds(spellId);
+            iter = bounds.first;
+        }
+        else
+            ++iter;
+    }
+}
+
+void Unit::RemoveAurasDueToItemSpell(Item* castItem, uint32 spellId)
+{
+    SpellAuraHolderBounds bounds = GetSpellAuraHolderBounds(spellId);
+    for (SpellAuraHolderMap::iterator iter = bounds.first; iter != bounds.second;)
+    {
+        if (iter->second->GetCastItemGuid() == castItem->GetObjectGuid())
+        {
+            RemoveSpellAuraHolder(iter->second);
+            bounds = GetSpellAuraHolderBounds(spellId);
+            iter = bounds.first;
+        }
+        else
+            ++iter;
+    }
+}
+
+void Unit::RemoveAurasWithInterruptFlags(uint32 flags)
+{
+    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
+    {
+        if (iter->second->GetSpellProto()->AuraInterruptFlags & flags)
+        {
+            RemoveSpellAuraHolder(iter->second);
+            iter = m_spellAuraHolders.begin();
+        }
+        else
+            ++iter;
+    }
+}
+
+void Unit::RemoveAurasWithAttribute(uint32 flags)
+{
+    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
+    {
+        if (iter->second->GetSpellProto()->HasAttribute((SpellAttributes)flags))
+        {
+            RemoveSpellAuraHolder(iter->second);
+            iter = m_spellAuraHolders.begin();
+        }
+        else
+            ++iter;
+    }
+}
+
+void Unit::RemoveAurasOnCast(SpellEntry const* castedSpellEntry)
+{
+    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
+    {
+        SpellAuraHolder* holder = iter->second;
+        SpellEntry const* spellEntry = holder->GetSpellProto();
+        bool removeThisHolder = false;
+
+        if (spellEntry->AuraInterruptFlags & AURA_INTERRUPT_FLAG_UNK2)
+        {
+            if (castedSpellEntry->HasAttribute(SPELL_ATTR_EX_NOT_BREAK_STEALTH))
+            {
+                bool foundStealth = false;
+                for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+                {
+                    if (Aura* aura = holder->m_auras[i])
+                    {
+                        if (aura->GetModifier()->m_auraname == SPELL_AURA_MOD_STEALTH)
+                        {
+                            foundStealth = true;
+                            break;
+                        }
+                    }
+                }
+                removeThisHolder = !foundStealth;
+            }
+            else
+                removeThisHolder = true;
+        }
+
+        if (removeThisHolder)
+        {
+            RemoveSpellAuraHolder(iter->second);
+            iter = m_spellAuraHolders.begin();
+        }
+        else
+            ++iter;
+    }
+}
+
+void Unit::RemoveNotOwnTrackedTargetAuras()
+{
+    // tracked aura targets from other casters are removed if the phase does no more fit
+    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
+    {
+        TrackedAuraType trackedType = iter->second->GetTrackedAuraType();
+        if (!trackedType)
+        {
+            ++iter;
+            continue;
+        }
+
+        if (iter->second->GetCasterGuid() != GetObjectGuid())
+        {
+            RemoveSpellAuraHolder(iter->second);
+            iter = m_spellAuraHolders.begin();
+            continue;
+        }
+
+        ++iter;
+    }
+
+    // tracked aura targets at other targets
+    for (uint8 type = TRACK_AURA_TYPE_SINGLE_TARGET; type < MAX_TRACKED_AURA_TYPES; ++type)
+    {
+        TrackedAuraTargetMap& scTargets = GetTrackedAuraTargets(TrackedAuraType(type));
+        for (TrackedAuraTargetMap::iterator itr = scTargets.begin(); itr != scTargets.end();)
+        {
+            SpellEntry const* itr_spellEntry = itr->first;
+            ObjectGuid itr_targetGuid = itr->second;
+
+            if (itr_targetGuid != GetObjectGuid())
+            {
+                scTargets.erase(itr);                           // remove for caster in any case
+
+                // remove from target if target found
+                if (Unit* itr_target = GetMap()->GetUnit(itr_targetGuid))
+                    itr_target->RemoveAurasByCasterSpell(itr_spellEntry->Id, GetObjectGuid());
+
+                itr = scTargets.begin();                        // list can be changed at remove aura
+                continue;
+            }
+
+            ++itr;
+        }
+    }
+}
+
+void Unit::RemoveSpellAuraHolder(SpellAuraHolder* holder, AuraRemoveMode mode)
+{
+    // Statue unsummoned at holder remove
+    SpellEntry const* AurSpellInfo = holder->GetSpellProto();
+    Totem* statue = nullptr;
+    Unit* caster = holder->GetCaster();
+    if (IsChanneledSpell(AurSpellInfo) && caster)
+        if (caster->GetTypeId() == TYPEID_UNIT && ((Creature*)caster)->IsTotem() && ((Totem*)caster)->GetTotemType() == TOTEM_STATUE)
+            statue = ((Totem*)caster);
+
+    if (m_spellAuraHoldersUpdateIterator != m_spellAuraHolders.end() && m_spellAuraHoldersUpdateIterator->second == holder)
+        ++m_spellAuraHoldersUpdateIterator;
+
+    SpellAuraHolderBounds bounds = GetSpellAuraHolderBounds(holder->GetId());
+    for (SpellAuraHolderMap::iterator itr = bounds.first; itr != bounds.second; ++itr)
+    {
+        if (itr->second == holder)
+        {
+            m_spellAuraHolders.erase(itr);
+            break;
+        }
+    }
+
+    holder->SetRemoveMode(mode);
+    holder->UnregisterAndCleanupTrackedAuras();
+
+    for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+    {
+        if (Aura* aura = holder->m_auras[i])
+            RemoveAura(aura, mode);
+    }
+
+    holder->_RemoveSpellAuraHolder();
+
+    if (mode != AURA_REMOVE_BY_DELETE)
+        holder->HandleSpellSpecificBoosts(false);
+
+    if (statue)
+        statue->UnSummon();
+
+    // If holder in use (removed from code that plan access to it data after return)
+    // store it in holder list with delayed deletion
+    if (holder->IsInUse())
+    {
+        holder->SetDeleted();
+        m_deletedHolders.push_back(holder);
+    }
+    else
+        delete holder;
+
+    if (mode != AURA_REMOVE_BY_EXPIRE && IsChanneledSpell(AurSpellInfo) && !IsAreaOfEffectSpell(AurSpellInfo) &&
+            caster && caster->GetObjectGuid() != GetObjectGuid())
+    {
+        caster->InterruptSpell(CURRENT_CHANNELED_SPELL);
+    }
+}
+
+void Unit::RemoveSingleAuraFromSpellAuraHolder(SpellAuraHolder* holder, SpellEffectIndex index, AuraRemoveMode mode)
+{
+    Aura* aura = holder->GetAuraByEffectIndex(index);
+    if (!aura)
+        return;
+
+    if (aura->IsLastAuraOnHolder())
+        RemoveSpellAuraHolder(holder, mode);
+    else
+        RemoveAura(aura, mode);
+}
+
+void Unit::RemoveAura(Aura* Aur, AuraRemoveMode mode)
+{
+    // remove from list before mods removing (prevent cyclic calls, mods added before including to aura list - use reverse order)
+    if (Aur->GetModifier()->m_auraname < TOTAL_AURAS)
+    {
+        m_modAuras[Aur->GetModifier()->m_auraname].remove(Aur);
+    }
+
+    // Set remove mode
+    Aur->SetRemoveMode(mode);
+
+    // some ShapeshiftBoosts at remove trigger removing other auras including parent Shapeshift aura
+    // remove aura from list before to prevent deleting it before
+    /// m_Auras.erase(i);
+
+    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Aura %u now is remove mode %d", Aur->GetModifier()->m_auraname, mode);
+
+    // aura _MUST_ be remove from holder before unapply.
+    // un-apply code expected that aura not find by diff searches
+    // in another case it can be double removed for example, if target die/etc in un-apply process.
+    Aur->GetHolder()->RemoveAura(Aur->GetEffIndex());
+
+    // some auras also need to apply modifier (on caster) on remove
+    if (mode == AURA_REMOVE_BY_DELETE)
+    {
+        switch (Aur->GetModifier()->m_auraname)
+        {
+            // need properly undo any auras with player-caster mover set (or will crash at next caster move packet)
+            case SPELL_AURA_MOD_POSSESS:
+            case SPELL_AURA_MOD_POSSESS_PET:
+                Aur->ApplyModifier(false, true);
+                break;
+            default: break;
+        }
+    }
+    else
+        Aur->ApplyModifier(false, true);
+
+    // If aura in use (removed from code that plan access to it data after return)
+    // store it in aura list with delayed deletion
+    if (Aur->IsInUse())
+        m_deletedAuras.push_back(Aur);
+    else
+        delete Aur;
+}
+
+void Unit::RemoveAllAuras(AuraRemoveMode mode /*= AURA_REMOVE_BY_DEFAULT*/)
+{
+    while (!m_spellAuraHolders.empty())
+    {
+        SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin();
+        RemoveSpellAuraHolder(iter->second, mode);
+    }
+}
+
+void Unit::RemoveArenaAuras(bool onleave)
+{
+    // in join, remove positive buffs, on end, remove negative
+    // used to remove positive visible auras in arenas
+    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
+    {
+        if (!iter->second->GetSpellProto()->HasAttribute(SPELL_ATTR_EX4_UNK21) &&
+                // don't remove stances, shadowform, pally/hunter auras
+                !iter->second->IsPassive() &&               // don't remove passive auras
+                (!iter->second->GetSpellProto()->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY) ||
+                 !iter->second->GetSpellProto()->HasAttribute(SPELL_ATTR_HIDE_IN_COMBAT_LOG)) &&
+                // not unaffected by invulnerability auras or not having that unknown flag (that seemed the most probable)
+                (iter->second->IsPositive() != onleave))    // remove positive buffs on enter, negative buffs on leave
+        {
+            RemoveSpellAuraHolder(iter->second);
+            iter = m_spellAuraHolders.begin();
+        }
+        else
+            ++iter;
+    }
+}
+
+void Unit::RemoveAllAurasOnDeath()
+{
+    // used just after dieing to remove all visible auras
+    // and disable the mods for the passive ones
+    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
+    {
+        if (!iter->second->IsPassive() && !iter->second->IsDeathPersistent())
+        {
+            RemoveSpellAuraHolder(iter->second, AURA_REMOVE_BY_DEATH);
+            iter = m_spellAuraHolders.begin();
+        }
+        else
+            ++iter;
+    }
+}
+
+void Unit::RemoveAllAurasOnEvade()
+{
+    // used when evading to remove all auras except some special auras
+    // Fly should not be removed on evade - neither should linked auras
+    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
+    {
+        SpellEntry const* proto = iter->second->GetSpellProto();
+        if (!IsSpellHaveAura(proto, SPELL_AURA_FLY))
+        {
+            RemoveSpellAuraHolder(iter->second, AURA_REMOVE_BY_DEFAULT);
+            iter = m_spellAuraHolders.begin();
+        }
+        else
+            ++iter;
+    }
+}
+
+void Unit::DelaySpellAuraHolder(uint32 spellId, int32 delaytime, ObjectGuid casterGuid)
+{
+    SpellAuraHolderBounds bounds = GetSpellAuraHolderBounds(spellId);
+    for (SpellAuraHolderMap::iterator iter = bounds.first; iter != bounds.second; ++iter)
+    {
+        SpellAuraHolder* holder = iter->second;
+
+        if (casterGuid != holder->GetCasterGuid())
+            continue;
+
+        if (holder->GetAuraDuration() < delaytime)
+            holder->SetAuraDuration(0);
+        else
+            holder->SetAuraDuration(holder->GetAuraDuration() - delaytime);
+
+        holder->UpdateAuraDuration();
+
+        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell %u partially interrupted on %s, new duration: %u ms", spellId, GetGuidStr().c_str(), holder->GetAuraDuration());
+    }
+}
+
+void Unit::_RemoveAllAuraMods()
+{
+    for (SpellAuraHolderMap::const_iterator i = m_spellAuraHolders.begin(); i != m_spellAuraHolders.end(); ++i)
+    {
+        (*i).second->ApplyAuraModifiers(false);
+    }
+}
+
+void Unit::_ApplyAllAuraMods()
+{
+    for (SpellAuraHolderMap::const_iterator i = m_spellAuraHolders.begin(); i != m_spellAuraHolders.end(); ++i)
+    {
+        (*i).second->ApplyAuraModifiers(true);
+    }
+}
+
+bool Unit::HasAuraType(AuraType auraType) const
+{
+    return !GetAurasByType(auraType).empty();
+}
+
+bool Unit::HasAffectedAura(AuraType auraType, SpellEntry const* spellProto) const
+{
+    Unit::AuraList const& auras = GetAurasByType(auraType);
+
+    for (Unit::AuraList::const_iterator itr = auras.begin(); itr != auras.end(); ++itr)
+    {
+        if ((*itr)->isAffectedOnSpell(spellProto))
+            return true;
+    }
+
+    return false;
+}
+
+Aura* Unit::GetAura(uint32 spellId, SpellEffectIndex effindex)
+{
+    SpellAuraHolderBounds bounds = GetSpellAuraHolderBounds(spellId);
+    if (bounds.first != bounds.second)
+        return bounds.first->second->GetAuraByEffectIndex(effindex);
+    return nullptr;
+}
+
+Aura* Unit::GetAura(AuraType type, SpellFamily family, uint64 familyFlag, ObjectGuid casterGuid)
+{
+    AuraList const& auras = GetAurasByType(type);
+    for (AuraList::const_iterator i = auras.begin(); i != auras.end(); ++i)
+        if ((*i)->GetSpellProto()->IsFitToFamily(family, familyFlag) &&
+                (!casterGuid || (*i)->GetCasterGuid() == casterGuid))
+            return *i;
+
+    return nullptr;
+}
+
+bool Unit::HasAura(uint32 spellId, SpellEffectIndex effIndex) const
+{
+    SpellAuraHolderConstBounds spair = GetSpellAuraHolderBounds(spellId);
+    for (SpellAuraHolderMap::const_iterator i_holder = spair.first; i_holder != spair.second; ++i_holder)
+        if (i_holder->second->GetAuraByEffectIndex(effIndex))
+            return true;
+
+    return false;
+}
+
+void Unit::AddDynObject(DynamicObject* dynObj)
+{
+    m_dynObjGUIDs.push_back(dynObj->GetObjectGuid());
+}
+
+void Unit::RemoveDynObject(uint32 spellid)
+{
+    if (m_dynObjGUIDs.empty())
+        return;
+    for (GuidList::iterator i = m_dynObjGUIDs.begin(); i != m_dynObjGUIDs.end();)
+    {
+        DynamicObject* dynObj = GetMap()->GetDynamicObject(*i);
+        if (!dynObj)
+        {
+            i = m_dynObjGUIDs.erase(i);
+        }
+        else if (spellid == 0 || dynObj->GetSpellId() == spellid)
+        {
+            dynObj->Delete();
+            i = m_dynObjGUIDs.erase(i);
+        }
+        else
+            ++i;
+    }
+}
+
+void Unit::RemoveAllDynObjects()
+{
+    while (!m_dynObjGUIDs.empty())
+    {
+        if (DynamicObject* dynObj = GetMap()->GetDynamicObject(*m_dynObjGUIDs.begin()))
+            dynObj->Delete();
+        m_dynObjGUIDs.erase(m_dynObjGUIDs.begin());
+    }
+}
+
+DynamicObject* Unit::GetDynObject(uint32 spellId, SpellEffectIndex effIndex)
+{
+    for (GuidList::iterator i = m_dynObjGUIDs.begin(); i != m_dynObjGUIDs.end();)
+    {
+        DynamicObject* dynObj = GetMap()->GetDynamicObject(*i);
+        if (!dynObj)
+        {
+            i = m_dynObjGUIDs.erase(i);
+            continue;
+        }
+
+        if (dynObj->GetSpellId() == spellId && dynObj->GetEffIndex() == effIndex)
+            return dynObj;
+        ++i;
+    }
+    return nullptr;
+}
+
+DynamicObject* Unit::GetDynObject(uint32 spellId)
+{
+    for (GuidList::iterator i = m_dynObjGUIDs.begin(); i != m_dynObjGUIDs.end();)
+    {
+        DynamicObject* dynObj = GetMap()->GetDynamicObject(*i);
+        if (!dynObj)
+        {
+            i = m_dynObjGUIDs.erase(i);
+            continue;
+        }
+
+        if (dynObj->GetSpellId() == spellId)
+            return dynObj;
+        ++i;
+    }
+    return nullptr;
+}
+
+GameObject* Unit::GetGameObject(uint32 spellId) const
+{
+    for (GameObjectList::const_iterator i = m_gameObj.begin(); i != m_gameObj.end(); ++i)
+        if ((*i)->GetSpellId() == spellId)
+            return *i;
+
+    WildGameObjectMap::const_iterator find = m_wildGameObjs.find(spellId);
+    if (find != m_wildGameObjs.end())
+        return GetMap()->GetGameObject(find->second);       // Can be nullptr
+
+    return nullptr;
+}
+
+void Unit::AddGameObject(GameObject* gameObj)
+{
+    MANGOS_ASSERT(gameObj && !gameObj->GetOwnerGuid());
+    m_gameObj.push_back(gameObj);
+    gameObj->SetOwnerGuid(GetObjectGuid());
+
+    if (GetTypeId() == TYPEID_PLAYER && gameObj->GetSpellId())
+    {
+        SpellEntry const* createBySpell = sSpellTemplate.LookupEntry<SpellEntry>(gameObj->GetSpellId());
+        // Need disable spell use for owner
+        if (createBySpell && createBySpell->HasAttribute(SPELL_ATTR_DISABLED_WHILE_ACTIVE))
+            // note: item based cooldowns and cooldown spell mods with charges ignored (unknown existing cases)
+            ((Player*)this)->AddSpellAndCategoryCooldowns(createBySpell, 0, nullptr, true);
+    }
+}
+
+void Unit::AddWildGameObject(GameObject* gameObj)
+{
+    MANGOS_ASSERT(gameObj && gameObj->GetOwnerGuid().IsEmpty());
+    m_wildGameObjs[gameObj->GetSpellId()] = gameObj->GetObjectGuid();
+
+    // As of 335 there are no wild-summon spells with SPELL_ATTR_DISABLED_WHILE_ACTIVE
+
+    // Remove outdated wild summoned GOs
+    for (WildGameObjectMap::iterator itr = m_wildGameObjs.begin(); itr != m_wildGameObjs.end();)
+    {
+        GameObject* pGo = GetMap()->GetGameObject(itr->second);
+        if (pGo)
+            ++itr;
+        else
+            m_wildGameObjs.erase(itr++);
+    }
+}
+
+void Unit::RemoveGameObject(GameObject* gameObj, bool del)
+{
+    MANGOS_ASSERT(gameObj && gameObj->GetOwnerGuid() == GetObjectGuid());
+
+    gameObj->SetOwnerGuid(ObjectGuid());
+
+    // GO created by some spell
+    if (uint32 spellid = gameObj->GetSpellId())
+    {
+        RemoveAurasDueToSpell(spellid);
+
+        if (GetTypeId() == TYPEID_PLAYER)
+        {
+            SpellEntry const* createBySpell = sSpellTemplate.LookupEntry<SpellEntry>(spellid);
+            // Need activate spell use for owner
+            if (createBySpell && createBySpell->HasAttribute(SPELL_ATTR_DISABLED_WHILE_ACTIVE))
+                // note: item based cooldowns and cooldown spell mods with charges ignored (unknown existing cases)
+                ((Player*)this)->SendCooldownEvent(createBySpell);
+        }
+    }
+
+    m_gameObj.remove(gameObj);
+
+    if (del)
+    {
+        gameObj->SetRespawnTime(0);
+        gameObj->Delete();
+    }
+}
+
+void Unit::RemoveGameObject(uint32 spellid, bool del)
+{
+    if (m_gameObj.empty())
+        return;
+
+    GameObjectList::iterator i, next;
+    for (i = m_gameObj.begin(); i != m_gameObj.end(); i = next)
+    {
+        next = i;
+        if (spellid == 0 || (*i)->GetSpellId() == spellid)
+        {
+            (*i)->SetOwnerGuid(ObjectGuid());
+            if (del)
+            {
+                (*i)->SetRespawnTime(0);
+                (*i)->Delete();
+            }
+
+            next = m_gameObj.erase(i);
+        }
+        else
+            ++next;
+    }
+}
+
+void Unit::RemoveAllGameObjects()
+{
+    // remove references to unit
+    for (GameObjectList::iterator i = m_gameObj.begin(); i != m_gameObj.end();)
+    {
+        (*i)->SetOwnerGuid(ObjectGuid());
+        (*i)->SetRespawnTime(0);
+        (*i)->Delete();
+        i = m_gameObj.erase(i);
+    }
+
+    // wild summoned GOs - only remove references, do not remove GOs
+    m_wildGameObjs.clear();
+}
+
+void Unit::SendSpellNonMeleeDamageLog(SpellNonMeleeDamage* log) const
+{
+    WorldPacket data(SMSG_SPELLNONMELEEDAMAGELOG, (16 + 4 + 4 + 1 + 4 + 4 + 1 + 1 + 4 + 4 + 1)); // we guess size
+    data << log->target->GetPackGUID();
+    data << log->attacker->GetPackGUID();
+    data << uint32(log->SpellID);
+    data << uint32(log->damage);                            // damage amount
+    data << uint8(log->schoolMask);                         // damage school
+    data << uint32(log->absorb);                            // AbsorbedDamage
+    data << uint32(log->resist);                            // resist
+    data << uint8(log->physicalLog);                        // if 1, then client show spell name (example: %s's ranged shot hit %s for %u school or %s suffers %u school damage from %s's spell_name
+    data << uint8(log->unused);                             // unused
+    data << uint32(log->blocked);                           // blocked
+    data << uint32(log->HitInfo);
+    data << uint8(0);                                       // flag to use extend data
+    SendMessageToSet(data, true);
+}
+
+void Unit::SendSpellNonMeleeDamageLog(Unit* target, uint32 SpellID, uint32 Damage, SpellSchoolMask damageSchoolMask, uint32 AbsorbedDamage, uint32 Resist, bool PhysicalDamage, uint32 Blocked, bool CriticalHit)
+{
+    SpellNonMeleeDamage log(this, target, SpellID, damageSchoolMask);
+    log.damage = Damage - AbsorbedDamage - Resist - Blocked;
+    log.absorb = AbsorbedDamage;
+    log.resist = Resist;
+    log.physicalLog = PhysicalDamage;
+    log.blocked = Blocked;
+    log.HitInfo = SPELL_HIT_TYPE_UNK1 | SPELL_HIT_TYPE_UNK3 | SPELL_HIT_TYPE_UNK6;
+    if (CriticalHit)
+        log.HitInfo |= SPELL_HIT_TYPE_CRIT;
+    SendSpellNonMeleeDamageLog(&log);
+}
+
+void Unit::SendPeriodicAuraLog(SpellPeriodicAuraLogInfo* pInfo) const
+{
+    Aura* aura = pInfo->aura;
+    Modifier* mod = aura->GetModifier();
+
+    WorldPacket data(SMSG_PERIODICAURALOG, 30);
+    data << aura->GetTarget()->GetPackGUID();
+    data << aura->GetCasterGuid().WriteAsPacked();
+    data << uint32(aura->GetId());                          // spellId
+    data << uint32(1);                                      // count
+    data << uint32(mod->m_auraname);                        // auraId
+    switch (mod->m_auraname)
+    {
+        case SPELL_AURA_PERIODIC_DAMAGE:
+        case SPELL_AURA_PERIODIC_DAMAGE_PERCENT:
+            data << uint32(pInfo->damage);                  // damage
+            data << uint32(GetSpellSchoolMask(aura->GetSpellProto()));
+            data << uint32(pInfo->absorb);                  // absorb
+            data << uint32(pInfo->resist);                  // resist
+            break;
+        case SPELL_AURA_PERIODIC_HEAL:
+        case SPELL_AURA_OBS_MOD_HEALTH:
+            data << uint32(pInfo->damage);                  // damage
+            break;
+        case SPELL_AURA_OBS_MOD_MANA:
+        case SPELL_AURA_PERIODIC_ENERGIZE:
+            data << uint32(mod->m_miscvalue);               // power type
+            data << uint32(pInfo->damage);                  // damage
+            break;
+        case SPELL_AURA_PERIODIC_MANA_LEECH:
+            data << uint32(mod->m_miscvalue);               // power type
+            data << uint32(pInfo->damage);                  // amount
+            data << float(pInfo->multiplier);               // gain multiplier
+            break;
+        default:
+            sLog.outError("Unit::SendPeriodicAuraLog: unknown aura %u", uint32(mod->m_auraname));
+            return;
+    }
+
+    aura->GetTarget()->SendMessageToSet(data, true);
+}
+
+void Unit::ProcDamageAndSpell(Unit* pVictim, uint32 procAttacker, uint32 procVictim, uint32 procExtra, uint32 amount, WeaponAttackType attType, SpellEntry const* procSpell)
+{
+    // Not much to do if no flags are set.
+    if (procAttacker)
+        ProcDamageAndSpellFor(false, pVictim, procAttacker, procExtra, attType, procSpell, amount);
+    // Now go on with a victim's events'n'auras
+    // Not much to do if no flags are set or there is no victim
+    if (pVictim && pVictim->isAlive() && procVictim)
+        pVictim->ProcDamageAndSpellFor(true, this, procVictim, procExtra, attType, procSpell, amount);
+}
+
+void Unit::SendSpellMiss(Unit* target, uint32 spellID, SpellMissInfo missInfo) const
+{
+    WorldPacket data(SMSG_SPELLLOGMISS, (4 + 8 + 1 + 4 + 8 + 1));
+    data << uint32(spellID);
+    data << GetObjectGuid();
+    data << uint8(0);                                       // can be 0 or 1
+    data << uint32(1);                                      // target count
+    // for(i = 0; i < target count; ++i)
+    data << target->GetObjectGuid();                        // target GUID
+    data << uint8(missInfo);
+    // end loop
+    SendMessageToSet(data, true);
+}
+
+void Unit::SendAttackStateUpdate(CalcDamageInfo* damageInfo) const
+{
+    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "WORLD: Sending SMSG_ATTACKERSTATEUPDATE");
+
+    WorldPacket data(SMSG_ATTACKERSTATEUPDATE, (16 + 84));  // we guess size
+    data << (uint32)damageInfo->HitInfo;
+    data << GetPackGUID();
+    data << damageInfo->target->GetPackGUID();
+    data << uint32(damageInfo->damage);                     // Full damage
+
+    data << uint8(1);                                       // Sub damage count
+    //===  Sub damage description
+    data << uint32(damageInfo->damageSchoolMask);           // School of sub damage
+    data << float(damageInfo->damage);                      // sub damage
+    data << uint32(damageInfo->damage);                     // Sub Damage
+    data << uint32(damageInfo->absorb);                     // Absorb
+    data << uint32(damageInfo->resist);                     // Resist
+    //=================================================
+    data << uint32(damageInfo->TargetState);
+    data << uint32(0);                                      // unknown, usually seen with -1, 0 and 1000
+    data << uint32(0);                                      // spell id, seen with heroic strike and disarm as examples.
+    // HITINFO_NOACTION normally set if spell
+    data << uint32(damageInfo->blocked_amount);
+    SendMessageToSet(data, true);  /**/
+}
+
+void Unit::SendAttackStateUpdate(uint32 HitInfo, Unit* target, SpellSchoolMask damageSchoolMask, uint32 Damage, uint32 AbsorbDamage, uint32 Resist, VictimState TargetState, uint32 BlockedAmount)
+{
+    CalcDamageInfo dmgInfo;
+    dmgInfo.HitInfo = HitInfo;
+    dmgInfo.attacker = this;
+    dmgInfo.target = target;
+    dmgInfo.damage = Damage - AbsorbDamage - Resist - BlockedAmount;
+    dmgInfo.damageSchoolMask = damageSchoolMask;
+    dmgInfo.absorb = AbsorbDamage;
+    dmgInfo.resist = Resist;
+    dmgInfo.TargetState = TargetState;
+    dmgInfo.blocked_amount = BlockedAmount;
+    SendAttackStateUpdate(&dmgInfo);
+}
+
+void Unit::SetPowerType(Powers new_powertype)
+{
+    // set power type
+    SetByteValue(UNIT_FIELD_BYTES_0, 3, new_powertype);
+
+    // group updates
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        if (((Player*)this)->GetGroup())
+            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_POWER_TYPE);
+    }
+    else if (((Creature*)this)->IsPet())
+    {
+        Pet* pet = ((Pet*)this);
+        if (pet->isControlled())
+        {
+            Unit* owner = GetOwner();
+            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
+                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_POWER_TYPE);
+        }
+    }
+
+    // special cases for power type switching (druid and pets only)
+    if (GetTypeId() == TYPEID_PLAYER || (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsPet()))
+    {
+        uint32 maxValue = GetCreatePowers(new_powertype);
+        uint32 curValue = maxValue;
+
+        // special cases with current power = 0
+        if (new_powertype == POWER_RAGE)
+            curValue = 0;
+
+        // set power (except for mana)
+        if (new_powertype != POWER_MANA)
+        {
+            SetMaxPower(new_powertype, maxValue);
+            SetPower(new_powertype, curValue);
+        }
+    }
+}
+
+FactionTemplateEntry const* Unit::getFactionTemplateEntry() const
+{
+    FactionTemplateEntry const* entry = sFactionTemplateStore.LookupEntry(getFaction());
+    if (!entry)
+    {
+        static ObjectGuid guid;                             // prevent repeating spam same faction problem
+
+        if (GetObjectGuid() != guid)
+        {
+            guid = GetObjectGuid();
+
+            if (guid.GetHigh() == HIGHGUID_PET)
+                sLog.outError("%s (base creature entry %u) have invalid faction template id %u, owner %s", GetGuidStr().c_str(), GetEntry(), getFaction(), ((Pet*)this)->GetOwnerGuid().GetString().c_str());
+            else
+                sLog.outError("%s have invalid faction template id %u", GetGuidStr().c_str(), getFaction());
+        }
+    }
+    return entry;
+}
+
+bool Unit::IsHostileTo(Unit const* unit) const
+{
+    // always non-hostile to self
+    if (unit == this)
+        return false;
+
+    // always non-hostile to GM in GM mode
+    if (unit->GetTypeId() == TYPEID_PLAYER && ((Player const*)unit)->isGameMaster())
+        return false;
+
+    // always hostile to enemy
+    if (getVictim() == unit || unit->getVictim() == this)
+        return true;
+
+    // test pet/charm masters instead pers/charmeds
+    Unit const* testerOwner = GetCharmerOrOwner();
+    Unit const* targetOwner = unit->GetCharmerOrOwner();
+
+    // always hostile to owner's enemy
+    if (testerOwner && (testerOwner->getVictim() == unit || unit->getVictim() == testerOwner))
+        return true;
+
+    // always hostile to enemy owner
+    if (targetOwner && (getVictim() == targetOwner || targetOwner->getVictim() == this))
+        return true;
+
+    // always hostile to owner of owner's enemy
+    if (testerOwner && targetOwner && (testerOwner->getVictim() == targetOwner || targetOwner->getVictim() == testerOwner))
+        return true;
+
+    Unit const* tester = testerOwner ? testerOwner : this;
+    Unit const* target = targetOwner ? targetOwner : unit;
+
+    // always non-hostile to target with common owner, or to owner/pet
+    if (tester == target)
+        return false;
+
+    // special cases (Duel, etc)
+    if (tester->GetTypeId() == TYPEID_PLAYER && target->GetTypeId() == TYPEID_PLAYER)
+    {
+        Player const* pTester = (Player const*)tester;
+        Player const* pTarget = (Player const*)target;
+
+        // Duel
+        if (pTester->IsInDuelWith(pTarget))
+            return true;
+
+        // Group
+        if (pTester->GetGroup() && pTester->GetGroup() == pTarget->GetGroup())
+            return false;
+
+        // Sanctuary
+        if (pTarget->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_SANCTUARY) && pTester->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_SANCTUARY))
+            return false;
+
+        // PvP FFA state
+        if (pTester->IsFFAPvP() && pTarget->IsFFAPvP())
+            return true;
+
+        //= PvP states
+        // Green/Blue (can't attack)
+        if (pTester->GetTeam() == pTarget->GetTeam())
+            return false;
+
+        // Red (can attack) if true, Blue/Yellow (can't attack) in another case
+        return pTester->IsPvP() && pTarget->IsPvP();
+    }
+
+    // faction base cases
+    FactionTemplateEntry const* tester_faction = tester->getFactionTemplateEntry();
+    FactionTemplateEntry const* target_faction = target->getFactionTemplateEntry();
+    if (!tester_faction || !target_faction)
+        return false;
+
+    if (target->isAttackingPlayer() && tester->IsContestedGuard())
+        return true;
+
+    // PvC forced reaction and reputation case
+    if (tester->GetTypeId() == TYPEID_PLAYER)
+    {
+        if (target_faction->faction)
+        {
+            // forced reaction
+            if (ReputationRank const* force = ((Player*)tester)->GetReputationMgr().GetForcedRankIfAny(target_faction))
+                return *force <= REP_HOSTILE;
+
+            // if faction have reputation then hostile state for tester at 100% dependent from at_war state
+            if (FactionEntry const* raw_target_faction = sFactionStore.LookupEntry(target_faction->faction))
+                if (FactionState const* factionState = ((Player*)tester)->GetReputationMgr().GetState(raw_target_faction))
+                    return !!(factionState->Flags & FACTION_FLAG_AT_WAR);
+        }
+    }
+    // CvP forced reaction and reputation case
+    else if (target->GetTypeId() == TYPEID_PLAYER)
+    {
+        if (tester_faction->faction)
+        {
+            // forced reaction
+            if (ReputationRank const* force = ((Player*)target)->GetReputationMgr().GetForcedRankIfAny(tester_faction))
+                return *force <= REP_HOSTILE;
+
+            // apply reputation state
+            FactionEntry const* raw_tester_faction = sFactionStore.LookupEntry(tester_faction->faction);
+            if (raw_tester_faction && raw_tester_faction->reputationListID >= 0)
+                return ((Player const*)target)->GetReputationMgr().GetRank(raw_tester_faction) <= REP_HOSTILE;
+        }
+    }
+
+    // common faction based case (CvC,PvC,CvP)
+    return tester_faction->IsHostileTo(*target_faction);
+}
+
+bool Unit::IsFriendlyTo(Unit const* unit) const
+{
+    // always friendly to self
+    if (unit == this)
+        return true;
+
+    // always friendly to GM in GM mode
+    if (unit->GetTypeId() == TYPEID_PLAYER && ((Player const*)unit)->isGameMaster())
+        return true;
+
+    // always non-friendly to enemy
+    if (getVictim() == unit || unit->getVictim() == this)
+        return false;
+
+    // test pet/charm masters instead pers/charmeds
+    Unit const* testerOwner = GetCharmerOrOwner();
+    Unit const* targetOwner = unit->GetCharmerOrOwner();
+
+    // always non-friendly to owner's enemy
+    if (testerOwner && (testerOwner->getVictim() == unit || unit->getVictim() == testerOwner))
+        return false;
+
+    // always non-friendly to enemy owner
+    if (targetOwner && (getVictim() == targetOwner || targetOwner->getVictim() == this))
+        return false;
+
+    // always non-friendly to owner of owner's enemy
+    if (testerOwner && targetOwner && (testerOwner->getVictim() == targetOwner || targetOwner->getVictim() == testerOwner))
+        return false;
+
+    Unit const* tester = testerOwner ? testerOwner : this;
+    Unit const* target = targetOwner ? targetOwner : unit;
+
+    // always friendly to target with common owner, or to owner/pet
+    if (tester == target)
+        return true;
+
+    // special cases (Duel)
+    if (tester->GetTypeId() == TYPEID_PLAYER && target->GetTypeId() == TYPEID_PLAYER)
+    {
+        Player const* pTester = (Player const*)tester;
+        Player const* pTarget = (Player const*)target;
+
+        // Duel
+        if (pTester->IsInDuelWith(pTarget))
+            return false;
+
+        // Group
+        if (pTester->GetGroup() && pTester->GetGroup() == pTarget->GetGroup())
+            return true;
+
+        // Sanctuary
+        if (pTarget->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_SANCTUARY) && pTester->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_SANCTUARY))
+            return true;
+
+        // PvP FFA state
+        if (pTester->IsFFAPvP() && pTarget->IsFFAPvP())
+            return false;
+
+        //= PvP states
+        // Green/Blue (non-attackable)
+        if (pTester->GetTeam() == pTarget->GetTeam())
+            return true;
+
+        // Blue (friendly/non-attackable) if not PVP, or Yellow/Red in another case (attackable)
+        return !pTarget->IsPvP();
+    }
+
+    // faction base cases
+    FactionTemplateEntry const* tester_faction = tester->getFactionTemplateEntry();
+    FactionTemplateEntry const* target_faction = target->getFactionTemplateEntry();
+    if (!tester_faction || !target_faction)
+        return false;
+
+    if (target->isAttackingPlayer() && tester->IsContestedGuard())
+        return false;
+
+    // PvC forced reaction and reputation case
+    if (tester->GetTypeId() == TYPEID_PLAYER)
+    {
+        if (target_faction->faction)
+        {
+            // forced reaction
+            if (ReputationRank const* force = ((Player*)tester)->GetReputationMgr().GetForcedRankIfAny(target_faction))
+                return *force >= REP_FRIENDLY;
+
+            // if faction have reputation then friendly state for tester at 100% dependent from at_war state
+            if (FactionEntry const* raw_target_faction = sFactionStore.LookupEntry(target_faction->faction))
+                if (FactionState const* factionState = ((Player*)tester)->GetReputationMgr().GetState(raw_target_faction))
+                    return !(factionState->Flags & FACTION_FLAG_AT_WAR);
+        }
+    }
+    // CvP forced reaction and reputation case
+    else if (target->GetTypeId() == TYPEID_PLAYER)
+    {
+        if (tester_faction->faction)
+        {
+            // forced reaction
+            if (ReputationRank const* force = ((Player*)target)->GetReputationMgr().GetForcedRankIfAny(tester_faction))
+                return *force >= REP_FRIENDLY;
+
+            // apply reputation state
+            if (FactionEntry const* raw_tester_faction = sFactionStore.LookupEntry(tester_faction->faction))
+                if (raw_tester_faction->reputationListID >= 0)
+                    return ((Player const*)target)->GetReputationMgr().GetRank(raw_tester_faction) >= REP_FRIENDLY;
+        }
+    }
+
+    // common faction based case (CvC,PvC,CvP)
+    return tester_faction->IsFriendlyTo(*target_faction);
+}
+
+bool Unit::IsHostileToPlayers() const
+{
+    FactionTemplateEntry const* my_faction = getFactionTemplateEntry();
+    if (!my_faction || !my_faction->faction)
+        return false;
+
+    FactionEntry const* raw_faction = sFactionStore.LookupEntry(my_faction->faction);
+    if (raw_faction && raw_faction->reputationListID >= 0)
+        return false;
+
+    return my_faction->IsHostileToPlayers();
+}
+
+bool Unit::IsNeutralToAll() const
+{
+    FactionTemplateEntry const* my_faction = getFactionTemplateEntry();
+    if (!my_faction || !my_faction->faction)
+        return true;
+
+    FactionEntry const* raw_faction = sFactionStore.LookupEntry(my_faction->faction);
+    if (raw_faction && raw_faction->reputationListID >= 0)
+        return false;
+
+    return my_faction->IsNeutralToAll();
+}
+
+bool Unit::Attack(Unit* victim, bool meleeAttack)
+{
+    if (!victim || victim == this)
+        return false;
+
+    // dead units can neither attack nor be attacked
+    if (!isAlive() || !victim->IsInWorld() || !victim->isAlive())
+        return false;
+
+    // player cannot attack in mount state
+    if (GetTypeId() == TYPEID_PLAYER && IsMounted())
+        return false;
+
+    // nobody can attack GM in GM-mode
+    if (victim->GetTypeId() == TYPEID_PLAYER)
+    {
+        if (((Player*)victim)->isGameMaster())
+            return false;
+    }
+    else
+    {
+        if (((Creature*)victim)->IsInEvadeMode())
+            return false;
+    }
+
+    // remove SPELL_AURA_MOD_UNATTACKABLE at attack (in case non-interruptible spells stun aura applied also that not let attack)
+    if (HasAuraType(SPELL_AURA_MOD_UNATTACKABLE))
+        RemoveSpellsCausingAura(SPELL_AURA_MOD_UNATTACKABLE);
+
+    // in fighting already
+    if (m_attacking)
+    {
+        if (m_attacking == victim)
+        {
+            // switch to melee attack from ranged/magic
+            if (meleeAttack)
+            {
+                if (!hasUnitState(UNIT_STAT_MELEE_ATTACKING))
+                {
+                    addUnitState(UNIT_STAT_MELEE_ATTACKING);
+                    SendMeleeAttackStart(victim);
+                }
+                return true;
+            }
+            return false;
+        }
+
+        // remove old target data
+        AttackStop(true);
+    }
+    // new battle
+    else
+    {
+        // set position before any AI calls/assistance
+        if (GetTypeId() == TYPEID_UNIT)
+            ((Creature*)this)->SetCombatStartPosition(GetPositionX(), GetPositionY(), GetPositionZ());
+    }
+
+    // Set our target
+    SetTargetGuid(victim->GetObjectGuid());
+
+    if (meleeAttack)
+        addUnitState(UNIT_STAT_MELEE_ATTACKING);
+
+    m_attacking = victim;
+    m_attacking->_addAttacker(this);
+
+    if (GetTypeId() == TYPEID_UNIT)
+    {
+        ((Creature*)this)->SendAIReaction(AI_REACTION_HOSTILE);
+        ((Creature*)this)->CallAssistance();
+    }
+
+    // delay offhand weapon attack to next attack time
+    if (haveOffhandWeapon())
+        resetAttackTimer(OFF_ATTACK);
+
+    if (meleeAttack)
+        SendMeleeAttackStart(victim);
+
+    return true;
+}
+
+void Unit::AttackedBy(Unit* attacker)
+{
+    // trigger AI reaction
+    if (AI())
+        AI()->AttackedBy(attacker);
+
+    // do not pet reaction for self inflicted damage (like environmental)
+    if (attacker == this)
+        return;
+
+    // trigger pet AI reaction
+    if (Pet* pet = GetPet())
+        pet->AttackedBy(attacker);
+}
+
+bool Unit::AttackStop(bool targetSwitch /*= false*/, bool includingCast /*= false*/)
+{
+    // interrupt cast only id includingCast == true and we have something to interrupt.
+    if (includingCast && IsNonMeleeSpellCasted(false))
+        InterruptNonMeleeSpells(false);
+
+    // Clear our target only if targetSwitch == true
+    if (targetSwitch)
+        SetTargetGuid(ObjectGuid());
+
+    clearUnitState(UNIT_STAT_MELEE_ATTACKING);
+
+    InterruptSpell(CURRENT_MELEE_SPELL);
+
+    if (m_attacking)
+    {
+        SendMeleeAttackStop(m_attacking);
+
+        m_attacking->_removeAttacker(this);
+        m_attacking = nullptr;
+        return true;
+    }
+    return false;
+}
+
+void Unit::CombatStop(bool includingCast)
+{
+    AttackStop(true, includingCast);
+    RemoveAllAttackers();
+
+    if (GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->SendAttackSwingCancelAttack();     // melee and ranged forced attack cancel
+    else
+    {
+        ((Creature*)this)->SetNoCallAssistance(false);
+
+        if (((Creature*)this)->HasSearchedAssistance())
+        {
+            ((Creature*)this)->SetNoSearchAssistance(false);
+            UpdateSpeed(MOVE_RUN, false);
+        }
+
+        if (((Creature*)this)->GetTemporaryFactionFlags() & TEMPFACTION_RESTORE_COMBAT_STOP)
+            ((Creature*)this)->ClearTemporaryFaction();
+    }
+
+    if (AI())
+        AI()->CombatStop();
+
+    ClearInCombat();
+}
+
+struct CombatStopWithPetsHelper
+{
+    explicit CombatStopWithPetsHelper(bool _includingCast) : includingCast(_includingCast) {}
+    void operator()(Unit* unit) const { unit->CombatStop(includingCast); }
+    bool includingCast;
 };
 
-CreatureAI* GetAI_boss_alythess(Creature* pCreature)
+void Unit::CombatStopWithPets(bool includingCast)
 {
-    return new boss_alythessAI(pCreature);
+    CombatStop(includingCast);
+    CallForAllControlledUnits(CombatStopWithPetsHelper(includingCast), CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
 }
 
-CreatureAI* GetAI_boss_sacrolash(Creature* pCreature)
+struct IsAttackingPlayerHelper
 {
-    return new boss_sacrolashAI(pCreature);
+    explicit IsAttackingPlayerHelper() {}
+    bool operator()(Unit const* unit) const { return unit->isAttackingPlayer(); }
+};
+
+bool Unit::isAttackingPlayer() const
+{
+    if (hasUnitState(UNIT_STAT_ATTACK_PLAYER))
+        return true;
+
+    return CheckAllControlledUnits(IsAttackingPlayerHelper(), CONTROLLED_PET | CONTROLLED_TOTEMS | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
 }
 
-CreatureAI* GetAI_npc_shadow_image(Creature* pCreature)
+void Unit::RemoveAllAttackers()
 {
-    return new npc_shadow_imageAI(pCreature);
+    while (!m_attackers.empty())
+    {
+        AttackerSet::iterator iter = m_attackers.begin();
+        (*iter)->AttackStop();
+
+        if (m_attacking)
+        {
+            sLog.outError("WORLD: Unit has an attacker that isn't attacking it!");
+            m_attackers.erase(iter);
+        }
+    }
 }
 
-void AddSC_boss_eredar_twins()
+bool Unit::HasAuraStateForCaster(AuraState flag, ObjectGuid casterGuid) const
 {
-    Script* pNewScript;
+    if (!HasAuraState(flag))
+        return false;
 
-    pNewScript = new Script;
-    pNewScript->Name = "boss_alythess";
-    pNewScript->GetAI = &GetAI_boss_alythess;
-    pNewScript->RegisterSelf();
+    // single per-caster aura state
+    if (flag == AURA_STATE_CONFLAGRATE)
+    {
+        Unit::AuraList const& dotList = GetAurasByType(SPELL_AURA_PERIODIC_DAMAGE);
+        for (Unit::AuraList::const_iterator i = dotList.begin(); i != dotList.end(); ++i)
+        {
+            if ((*i)->GetCasterGuid() == casterGuid &&
+                    //  Immolate
+                    (*i)->GetSpellProto()->IsFitToFamily(SPELLFAMILY_WARLOCK, uint64(0x0000000000000004)))
+            {
+                return true;
+            }
+        }
 
-    pNewScript = new Script;
-    pNewScript->Name = "boss_sacrolash";
-    pNewScript->GetAI = &GetAI_boss_sacrolash;
-    pNewScript->RegisterSelf();
+        return false;
+    }
 
-    pNewScript = new Script;
-    pNewScript->Name = "npc_shadow_image";
-    pNewScript->GetAI = &GetAI_npc_shadow_image;
-    pNewScript->RegisterSelf();
+    return true;
+}
+
+void Unit::ModifyAuraState(AuraState flag, bool apply)
+{
+    if (apply)
+    {
+        if (!HasFlag(UNIT_FIELD_AURASTATE, 1 << (flag - 1)))
+        {
+            SetFlag(UNIT_FIELD_AURASTATE, 1 << (flag - 1));
+            if (GetTypeId() == TYPEID_PLAYER)
+            {
+                const PlayerSpellMap& sp_list = ((Player*)this)->GetSpellMap();
+                for (PlayerSpellMap::const_iterator itr = sp_list.begin(); itr != sp_list.end(); ++itr)
+                {
+                    if (itr->second.state == PLAYERSPELL_REMOVED) continue;
+                    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(itr->first);
+                    if (!spellInfo || !IsPassiveSpell(spellInfo)) continue;
+                    if (AuraState(spellInfo->CasterAuraState) == flag)
+                        CastSpell(this, itr->first, TRIGGERED_OLD_TRIGGERED, nullptr);
+                }
+            }
+        }
+    }
+    else
+    {
+        if (HasFlag(UNIT_FIELD_AURASTATE, 1 << (flag - 1)))
+        {
+            RemoveFlag(UNIT_FIELD_AURASTATE, 1 << (flag - 1));
+
+            Unit::SpellAuraHolderMap& tAuras = GetSpellAuraHolderMap();
+            for (Unit::SpellAuraHolderMap::iterator itr = tAuras.begin(); itr != tAuras.end();)
+            {
+                SpellEntry const* spellProto = (*itr).second->GetSpellProto();
+                if (spellProto->CasterAuraState == flag)
+                {
+                    // exceptions (applied at state but not removed at state change)
+                    // Rampage
+                    if (spellProto->SpellIconID == 2006 && spellProto->IsFitToFamilyMask(uint64(0x0000000000100000)))
+                    {
+                        ++itr;
+                        continue;
+                    }
+
+                    RemoveSpellAuraHolder(itr->second);
+                    itr = tAuras.begin();
+                }
+                else
+                    ++itr;
+            }
+        }
+    }
+}
+
+Unit* Unit::GetOwner() const
+{
+    if (ObjectGuid ownerid = GetOwnerGuid())
+        return ObjectAccessor::GetUnit(*this, ownerid);
+    return nullptr;
+}
+
+Unit* Unit::GetCharmer() const
+{
+    if (ObjectGuid charmerid = GetCharmerGuid())
+        return ObjectAccessor::GetUnit(*this, charmerid);
+    return nullptr;
+}
+
+bool Unit::IsCharmerOrOwnerPlayerOrPlayerItself() const
+{
+    if (GetTypeId() == TYPEID_PLAYER)
+        return true;
+
+    return GetCharmerOrOwnerGuid().IsPlayer();
+}
+
+Player* Unit::GetCharmerOrOwnerPlayerOrPlayerItself()
+{
+    ObjectGuid guid = GetCharmerOrOwnerGuid();
+    if (guid.IsPlayer())
+        return ObjectAccessor::FindPlayer(guid);
+
+    return GetTypeId() == TYPEID_PLAYER ? (Player*)this : nullptr;
+}
+
+Player const* Unit::GetCharmerOrOwnerPlayerOrPlayerItself() const
+{
+    ObjectGuid guid = GetCharmerOrOwnerGuid();
+    if (guid.IsPlayer())
+        return ObjectAccessor::FindPlayer(guid);
+
+    return GetTypeId() == TYPEID_PLAYER ? (Player const*)this : nullptr;
+}
+
+Pet* Unit::GetPet() const
+{
+    if (ObjectGuid pet_guid = GetPetGuid())
+    {
+        if (Pet* pet = GetMap()->GetPet(pet_guid))
+            return pet;
+
+        sLog.outError("Unit::GetPet: %s not exist.", pet_guid.GetString().c_str());
+        const_cast<Unit*>(this)->SetPet(nullptr);
+    }
+
+    return nullptr;
+}
+
+Pet* Unit::_GetPet(ObjectGuid guid) const
+{
+    return GetMap()->GetPet(guid);
+}
+
+Unit* Unit::GetCharm() const
+{
+    if (ObjectGuid charm_guid = GetCharmGuid())
+    {
+        if (Unit* pet = ObjectAccessor::GetUnit(*this, charm_guid))
+            return pet;
+
+        sLog.outError("Unit::GetCharm: Charmed %s not exist.", charm_guid.GetString().c_str());
+        const_cast<Unit*>(this)->SetCharm(nullptr);
+    }
+
+    return nullptr;
+}
+
+void Unit::Uncharm()
+{
+    if (Unit* charm = GetCharm())
+    {
+        charm->RemoveSpellsCausingAura(SPELL_AURA_MOD_CHARM);
+        charm->RemoveSpellsCausingAura(SPELL_AURA_MOD_POSSESS);
+        charm->RemoveSpellsCausingAura(SPELL_AURA_MOD_POSSESS_PET);
+    }
+}
+
+void Unit::SetPet(Pet* pet)
+{
+    SetPetGuid(pet ? pet->GetObjectGuid() : ObjectGuid());
+}
+
+void Unit::SetCharm(Unit* pet)
+{
+    SetCharmGuid(pet ? pet->GetObjectGuid() : ObjectGuid());
+}
+
+void Unit::AddGuardian(Pet* pet)
+{
+    m_guardianPets.insert(pet->GetObjectGuid());
+}
+
+void Unit::RemoveGuardian(Pet* pet)
+{
+    m_guardianPets.erase(pet->GetObjectGuid());
+}
+
+void Unit::RemoveGuardians()
+{
+    while (!m_guardianPets.empty())
+    {
+        ObjectGuid guid = *m_guardianPets.begin();
+
+        if (Pet* pet = GetMap()->GetPet(guid))
+            pet->Unsummon(PET_SAVE_AS_DELETED, this); // can remove pet guid from m_guardianPets
+
+        m_guardianPets.erase(guid);
+    }
+}
+
+Pet* Unit::FindGuardianWithEntry(uint32 entry)
+{
+    for (GuidSet::const_iterator itr = m_guardianPets.begin(); itr != m_guardianPets.end(); ++itr)
+        if (Pet* pet = GetMap()->GetPet(*itr))
+            if (pet->GetEntry() == entry)
+                return pet;
+
+    return nullptr;
+}
+
+Unit* Unit::_GetTotem(TotemSlot slot) const
+{
+    return GetTotem(slot);
+}
+
+Totem* Unit::GetTotem(TotemSlot slot) const
+{
+    if (!IsInWorld() || !m_TotemSlot[slot])
+        return nullptr;
+
+    Creature* totem = GetMap()->GetCreature(m_TotemSlot[slot]);
+    return totem && totem->IsTotem() ? (Totem*)totem : nullptr;
+}
+
+bool Unit::IsAllTotemSlotsUsed() const
+{
+    for (int i = 0; i < MAX_TOTEM_SLOT; ++i)
+        if (!m_TotemSlot[i])
+            return false;
+    return true;
+}
+
+void Unit::_AddTotem(TotemSlot slot, Totem* totem)
+{
+    m_TotemSlot[slot] = totem->GetObjectGuid();
+}
+
+void Unit::_RemoveTotem(Totem* totem)
+{
+    for (int i = 0; i < MAX_TOTEM_SLOT; ++i)
+    {
+        if (m_TotemSlot[i] == totem->GetObjectGuid())
+        {
+            m_TotemSlot[i].Clear();
+            break;
+        }
+    }
+}
+
+void Unit::UnsummonAllTotems() const
+{
+    for (int i = 0; i < MAX_TOTEM_SLOT; ++i)
+        if (Totem* totem = GetTotem(TotemSlot(i)))
+            totem->UnSummon();
+}
+
+int32 Unit::DealHeal(Unit* pVictim, uint32 addhealth, SpellEntry const* spellProto, bool critical)
+{
+    int32 gain = pVictim->ModifyHealth(int32(addhealth));
+
+    Unit* unit = this;
+
+    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem() && ((Totem*)this)->GetTotemType() != TOTEM_STATUE)
+        unit = GetOwner();
+
+    unit->SendHealSpellLog(pVictim, spellProto->Id, addhealth, critical);
+
+    if (unit->GetTypeId() == TYPEID_PLAYER)
+    {
+        if (BattleGround* bg = ((Player*)unit)->GetBattleGround())
+            bg->UpdatePlayerScore((Player*)unit, SCORE_HEALING_DONE, gain);
+    }
+
+    // Script Event HealedBy
+    if (pVictim->AI())
+        pVictim->AI()->HealedBy(this, addhealth);
+
+    return gain;
+}
+
+Unit* Unit::SelectMagnetTarget(Unit* victim, Spell* spell, SpellEffectIndex eff)
+{
+    if (!victim)
+        return nullptr;
+
+    // Magic case
+    if (spell && (spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_NONE || spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_MAGIC))
+    {
+        if (spell->m_spellInfo->HasAttribute(SPELL_ATTR_ABILITY) || spell->m_spellInfo->HasAttribute(SPELL_ATTR_EX_CANT_BE_REDIRECTED) || spell->m_spellInfo->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY))
+            return nullptr;
+
+        Unit::AuraList const& magnetAuras = victim->GetAurasByType(SPELL_AURA_SPELL_MAGNET);
+        for (Unit::AuraList::const_iterator itr = magnetAuras.begin(); itr != magnetAuras.end(); ++itr)
+        {
+            if (Unit* magnet = (*itr)->GetCaster())
+            {
+                if (magnet->isAlive() && magnet->IsWithinLOSInMap(this) && spell->CheckTarget(magnet, eff))
+                {
+                    if (SpellAuraHolder* holder = (*itr)->GetHolder())
+                        if (holder->DropAuraCharge())
+                            victim->RemoveSpellAuraHolder(holder);
+                    return magnet;
+                }
+            }
+        }
+    }
+    // Melee && ranged case
+    else
+    {
+        AuraList const& hitTriggerAuras = victim->GetAurasByType(SPELL_AURA_ADD_CASTER_HIT_TRIGGER);
+        for (AuraList::const_iterator i = hitTriggerAuras.begin(); i != hitTriggerAuras.end(); ++i)
+        {
+            if (Unit* magnet = (*i)->GetCaster())
+            {
+                if (magnet->isAlive() && magnet->IsWithinLOSInMap(this) && (!spell || spell->CheckTarget(magnet, eff)))
+                {
+                    if (roll_chance_i((*i)->GetModifier()->m_amount))
+                    {
+                        if (SpellAuraHolder* holder = (*i)->GetHolder())
+                            if (holder->DropAuraCharge())
+                                victim->RemoveSpellAuraHolder(holder);
+                        return magnet;
+                    }
+                }
+            }
+        }
+    }
+
+    // No magnet Target found
+    return nullptr;
+}
+
+void Unit::SendHealSpellLog(Unit* pVictim, uint32 SpellID, uint32 Damage, bool critical)
+{
+    // we guess size
+    WorldPacket data(SMSG_SPELLHEALLOG, (8 + 8 + 4 + 4 + 1));
+    data << pVictim->GetPackGUID();
+    data << GetPackGUID();
+    data << uint32(SpellID);
+    data << uint32(Damage);
+    data << uint8(critical ? 1 : 0);
+    data << uint8(0);                                       // unused in client?
+    SendMessageToSet(data, true);
+}
+
+void Unit::SendEnergizeSpellLog(Unit* pVictim, uint32 SpellID, uint32 Damage, Powers powertype) const
+{
+    WorldPacket data(SMSG_SPELLENERGIZELOG, (8 + 8 + 4 + 4 + 4 + 1));
+    data << pVictim->GetPackGUID();
+    data << GetPackGUID();
+    data << uint32(SpellID);
+    data << uint32(powertype);
+    data << uint32(Damage);
+    SendMessageToSet(data, true);
+}
+
+void Unit::EnergizeBySpell(Unit* pVictim, uint32 SpellID, uint32 Damage, Powers powertype)
+{
+    SendEnergizeSpellLog(pVictim, SpellID, Damage, powertype);
+    // needs to be called after sending spell log
+    pVictim->ModifyPower(powertype, Damage);
+}
+
+/** Calculate spell coefficents and level penalties for spell/melee damage or heal
+ *
+ * this is the caster of the spell/ melee attacker
+ * @param spellProto SpellEntry of the used spell
+ * @param total current value onto which the Bonus and level penalty will be calculated
+ * @param benefit additional benefit from ie spellpower-auras
+ * @param ap_benefit additional melee attackpower benefit from auras
+ * @param damagetype what kind of damage
+ * @param donePart calculate for done or taken
+ */
+int32 Unit::SpellBonusWithCoeffs(SpellEntry const* spellProto, int32 total, int32 benefit, int32 ap_benefit,  DamageEffectType damagetype, bool donePart)
+{
+    // Distribute Damage over multiple effects, reduce by AoE
+    float coeff = 1.0f;
+
+    // Not apply this to creature casted spells
+    if (GetTypeId() == TYPEID_UNIT && !((Creature*)this)->IsPet())
+        coeff = 1.0f;
+    // Check for table values
+    else if (SpellBonusEntry const* bonus = sSpellMgr.GetSpellBonusData(spellProto->Id))
+    {
+        coeff = damagetype == DOT ? bonus->dot_damage : bonus->direct_damage;
+
+        // apply ap bonus at done part calculation only (it flat total mod so common with taken)
+        if (donePart && (bonus->ap_bonus || bonus->ap_dot_bonus))
+        {
+            float ap_bonus = damagetype == DOT ? bonus->ap_dot_bonus : bonus->ap_bonus;
+
+            total += int32(ap_bonus * (GetTotalAttackPowerValue(IsSpellRequiresRangedAP(spellProto) ? RANGED_ATTACK : BASE_ATTACK) + ap_benefit));
+        }
+    }
+    // Default calculation
+    else if (benefit)
+        coeff = CalculateDefaultCoefficient(spellProto, damagetype);
+
+    if (benefit)
+    {
+        float LvlPenalty = CalculateLevelPenalty(spellProto);
+
+        // Spellmod SpellDamage
+        if (coeff) // If something has 0 coeff to begin with, do not add spellmod
+        {
+            if (Player* modOwner = GetSpellModOwner()) // Spellmod SpellDamage
+            {
+                coeff *= 100.0f;
+                modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_SPELL_BONUS_DAMAGE, coeff);
+                coeff /= 100.0f;
+            }
+        }
+
+        total += int32(benefit * coeff * LvlPenalty);
+    }
+
+    return total;
+};
+
+/**
+ * Calculates caster part of spell damage bonuses,
+ * also includes different bonuses dependent from target auras
+ */
+uint32 Unit::SpellDamageBonusDone(Unit* pVictim, SpellEntry const* spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 stack)
+{
+    if (!spellProto || !pVictim || damagetype == DIRECT_DAMAGE || spellProto->HasAttribute(SPELL_ATTR_EX6_NO_DMG_PERCENT_MODS))
+        return pdamage;
+
+    // For totems get damage bonus from owner (statue isn't totem in fact)
+    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem() && ((Totem*)this)->GetTotemType() != TOTEM_STATUE)
+    {
+        if (Unit* owner = GetOwner())
+            return owner->SpellDamageBonusDone(pVictim, spellProto, pdamage, damagetype);
+    }
+
+    uint32 creatureTypeMask = pVictim->GetCreatureTypeMask();
+    float DoneTotalMod = 1.0f;
+    int32 DoneTotal = 0;
+
+    // Creature damage
+    if (GetTypeId() == TYPEID_UNIT && !((Creature*)this)->IsPet())
+        DoneTotalMod *= Creature::_GetSpellDamageMod(((Creature*)this)->GetCreatureInfo()->Rank);
+
+    AuraList const& mModDamagePercentDone = GetAurasByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
+    for (AuraList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
+    {
+        if (((*i)->GetModifier()->m_miscvalue & GetSpellSchoolMask(spellProto)) &&
+                (*i)->GetSpellProto()->EquippedItemClass == -1 &&
+                // -1 == any item class (not wand then)
+                (*i)->GetSpellProto()->EquippedItemInventoryTypeMask == 0)
+            // 0 == any inventory type (not wand then)
+        {
+            DoneTotalMod *= ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
+        }
+    }
+
+    // Add flat bonus from spell damage versus
+    DoneTotal += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_FLAT_SPELL_DAMAGE_VERSUS, creatureTypeMask);
+
+    // Add pct bonus from spell damage versus
+    DoneTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_DONE_VERSUS, creatureTypeMask);
+
+    // Add flat bonus from spell damage creature
+    DoneTotal += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_DONE_CREATURE, creatureTypeMask);
+
+    // done scripted mod (take it from owner)
+    Unit* owner = GetOwner();
+    if (!owner)
+        owner = this;
+
+    AuraList const& mOverrideClassScript = owner->GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
+    for (AuraList::const_iterator i = mOverrideClassScript.begin(); i != mOverrideClassScript.end(); ++i)
+    {
+        if (!(*i)->isAffectedOnSpell(spellProto))
+            continue;
+        switch ((*i)->GetModifier()->m_miscvalue)
+        {
+            // Molten Fury
+            case 4920:
+            case 4919:
+            {
+                if (pVictim->HasAuraState(AURA_STATE_HEALTHLESS_35_PERCENT))
+                    DoneTotalMod *= (100.0f + (*i)->GetModifier()->m_amount) / 100.0f;
+                break;
+            }
+            // Soul Siphon
+            case 4992:
+            case 4993:
+            {
+                // effect 1 m_amount
+                int32 maxPercent = (*i)->GetModifier()->m_amount;
+                // effect 0 m_amount
+                int32 stepPercent = CalculateSpellDamage(this, (*i)->GetSpellProto(), EFFECT_INDEX_0);
+                // count affliction effects and calc additional damage in percentage
+                int32 modPercent = 0;
+                SpellAuraHolderMap const& victimAuras = pVictim->GetSpellAuraHolderMap();
+                for (SpellAuraHolderMap::const_iterator itr = victimAuras.begin(); itr != victimAuras.end(); ++itr)
+                {
+                    SpellEntry const* m_spell = itr->second->GetSpellProto();
+                    if (m_spell->SpellFamilyName != SPELLFAMILY_WARLOCK || !(m_spell->SpellFamilyFlags & uint64(0x0000871B804CC41A)))
+                        continue;
+                    modPercent += stepPercent * itr->second->GetStackAmount();
+                    if (modPercent >= maxPercent)
+                    {
+                        modPercent = maxPercent;
+                        break;
+                    }
+                }
+                DoneTotalMod *= (modPercent + 100.0f) / 100.0f;
+                break;
+            }
+            // Starfire Bonus
+            case 5481:
+            {
+                if (pVictim->GetAura(SPELL_AURA_PERIODIC_DAMAGE, SPELLFAMILY_DRUID, uint64(0x0000000000200002)))
+                    DoneTotalMod *= ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
+                break;
+            }
+            case 4418: // Increased Shock Damage
+            case 4554: // Increased Lightning Damage
+            case 4555: // Improved Moonfire
+            case 5142: // Increased Lightning Damage
+            case 5147: // Improved Consecration
+            case 5148: // Idol of the Shooting Star
+            case 6008: // Increased Lightning Damage / Totem of Hex
+            {
+                DoneTotal += (*i)->GetModifier()->m_amount;
+                break;
+            }
+        }
+    }
+
+    // Custom scripted damage
+    switch (spellProto->SpellFamilyName)
+    {
+        case SPELLFAMILY_MAGE:
+        {
+            // Ice Lance
+            if (spellProto->SpellIconID == 186)
+            {
+                if (pVictim->isFrozen())
+                    DoneTotalMod *= 3.0f;
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    // Done fixed damage bonus auras
+    int32 DoneAdvertisedBenefit = SpellBaseDamageBonusDone(GetSpellSchoolMask(spellProto));
+
+    // Pets just add their bonus damage to their spell damage
+    // note that their spell damage is just gain of their own auras
+    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsPet())
+        DoneAdvertisedBenefit += ((Pet*)this)->GetBonusDamage();
+
+    // apply ap bonus and benefit affected by spell power implicit coeffs and spell level penalties
+    DoneTotal = SpellBonusWithCoeffs(spellProto, DoneTotal, DoneAdvertisedBenefit, 0, damagetype, true);
+
+    float tmpDamage = (int32(pdamage) + DoneTotal * int32(stack)) * DoneTotalMod;
+    // apply spellmod to Done damage (flat and pct)
+    if (Player* modOwner = GetSpellModOwner())
+        modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, tmpDamage);
+
+    return tmpDamage > 0 ? uint32(tmpDamage) : 0;
+}
+
+/**
+ * Calculates target part of spell damage bonuses,
+ * will be called on each tick for periodic damage over time auras
+ */
+uint32 Unit::SpellDamageBonusTaken(Unit* pCaster, SpellEntry const* spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 stack)
+{
+    if (!spellProto || !pCaster || damagetype == DIRECT_DAMAGE)
+        return pdamage;
+
+    uint32 schoolMask = spellProto->SchoolMask;
+
+    // Taken total percent damage auras
+    float TakenTotalMod = 1.0f;
+    int32 TakenTotal = 0;
+
+    // ..taken
+    TakenTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, schoolMask);
+
+    // .. taken pct: dummy auras
+    AuraList const& mDummyAuras = GetAurasByType(SPELL_AURA_DUMMY);
+    for (AuraList::const_iterator i = mDummyAuras.begin(); i != mDummyAuras.end(); ++i)
+    {
+        switch ((*i)->GetSpellProto()->SpellIconID)
+        {
+            // Cheat Death
+            case 2109:
+                if (((*i)->GetModifier()->m_miscvalue & GetSpellSchoolMask(spellProto)))
+                {
+                    if (GetTypeId() != TYPEID_PLAYER)
+                        continue;
+                    float mod = -((Player*)this)->GetRatingBonusValue(CR_CRIT_TAKEN_SPELL) * 2 * 4;
+                    if (mod < float((*i)->GetModifier()->m_amount))
+                        mod = float((*i)->GetModifier()->m_amount);
+                    TakenTotalMod *= (mod + 100.0f) / 100.0f;
+                }
+                break;
+        }
+    }
+
+    // From caster spells
+    // Mod damage taken from AoE spells
+    if (IsAreaOfEffectSpell(spellProto))
+        TakenTotalMod *= GetTotalAuraMultiplier(SPELL_AURA_MOD_AOE_DAMAGE_AVOIDANCE);
+
+    // Taken fixed damage bonus auras
+    int32 TakenAdvertisedBenefit = SpellBaseDamageBonusTaken(GetSpellSchoolMask(spellProto));
+
+    // apply benefit affected by spell power implicit coeffs and spell level penalties
+    TakenTotal = pCaster->SpellBonusWithCoeffs(spellProto, TakenTotal, TakenAdvertisedBenefit, 0, damagetype, false);
+
+    float tmpDamage = (int32(pdamage) + TakenTotal * int32(stack)) * TakenTotalMod;
+
+    return tmpDamage > 0 ? uint32(tmpDamage) : 0;
+}
+
+int32 Unit::SpellBaseDamageBonusDone(SpellSchoolMask schoolMask)
+{
+    int32 DoneAdvertisedBenefit = 0;
+
+    // ..done
+    AuraList const& mDamageDone = GetAurasByType(SPELL_AURA_MOD_DAMAGE_DONE);
+    for (AuraList::const_iterator i = mDamageDone.begin(); i != mDamageDone.end(); ++i)
+    {
+        if (((*i)->GetModifier()->m_miscvalue & schoolMask) != 0 &&
+                (*i)->GetSpellProto()->EquippedItemClass == -1 &&                   // -1 == any item class (not wand then)
+                (*i)->GetSpellProto()->EquippedItemInventoryTypeMask == 0)          //  0 == any inventory type (not wand then)
+            DoneAdvertisedBenefit += (*i)->GetModifier()->m_amount;
+    }
+
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        // Damage bonus from stats
+        AuraList const& mDamageDoneOfStatPercent = GetAurasByType(SPELL_AURA_MOD_SPELL_DAMAGE_OF_STAT_PERCENT);
+        for (AuraList::const_iterator i = mDamageDoneOfStatPercent.begin(); i != mDamageDoneOfStatPercent.end(); ++i)
+        {
+            if ((*i)->GetModifier()->m_miscvalue & schoolMask)
+            {
+                // stat used stored in miscValueB for this aura
+                Stats usedStat = Stats((*i)->GetMiscBValue());
+                DoneAdvertisedBenefit += int32(GetStat(usedStat) * (*i)->GetModifier()->m_amount / 100.0f);
+            }
+        }
+        // ... and attack power
+        AuraList const& mDamageDonebyAP = GetAurasByType(SPELL_AURA_MOD_SPELL_DAMAGE_OF_ATTACK_POWER);
+        for (AuraList::const_iterator i = mDamageDonebyAP.begin(); i != mDamageDonebyAP.end(); ++i)
+        {
+            if ((*i)->GetModifier()->m_miscvalue & schoolMask)
+                DoneAdvertisedBenefit += int32(GetTotalAttackPowerValue(BASE_ATTACK) * (*i)->GetModifier()->m_amount / 100.0f);
+        }
+    }
+    return DoneAdvertisedBenefit;
+}
+
+int32 Unit::SpellBaseDamageBonusTaken(SpellSchoolMask schoolMask) const
+{
+    int32 TakenAdvertisedBenefit = 0;
+
+    // ..taken
+    AuraList const& mDamageTaken = GetAurasByType(SPELL_AURA_MOD_DAMAGE_TAKEN);
+    for (AuraList::const_iterator i = mDamageTaken.begin(); i != mDamageTaken.end(); ++i)
+    {
+        if (((*i)->GetModifier()->m_miscvalue & schoolMask) != 0)
+            TakenAdvertisedBenefit += (*i)->GetModifier()->m_amount;
+    }
+
+    return TakenAdvertisedBenefit;
+}
+
+bool Unit::IsSpellCrit(Unit* pVictim, SpellEntry const* spellProto, SpellSchoolMask schoolMask, WeaponAttackType attackType)
+{
+    if (!CanCrit(spellProto, schoolMask, attackType))
+        return false;
+
+    const float chance = CalculateSpellCritChance(pVictim, schoolMask, spellProto);
+    return roll_chance_f(chance);
+}
+
+/**
+ * Calculates caster part of healing spell bonuses,
+ * also includes different bonuses dependent from target auras
+ */
+uint32 Unit::SpellHealingBonusDone(Unit* pVictim, SpellEntry const* spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack)
+{
+    // For totems get healing bonus from owner (statue isn't totem in fact)
+    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem() && ((Totem*)this)->GetTotemType() != TOTEM_STATUE)
+        if (Unit* owner = GetOwner())
+            return owner->SpellHealingBonusDone(pVictim, spellProto, healamount, damagetype, stack);
+
+    // No heal amount for this class spells
+    if (spellProto->DmgClass == SPELL_DAMAGE_CLASS_NONE)
+        return healamount < 0 ? 0 : healamount;
+
+    // Healing Done
+    // Done total percent damage auras
+    float  DoneTotalMod = 1.0f;
+    int32  DoneTotal = 0;
+
+    // Healing done percent
+    AuraList const& mHealingDonePct = GetAurasByType(SPELL_AURA_MOD_HEALING_DONE_PERCENT);
+    for (AuraList::const_iterator i = mHealingDonePct.begin(); i != mHealingDonePct.end(); ++i)
+        DoneTotalMod *= (100.0f + (*i)->GetModifier()->m_amount) / 100.0f;
+
+    // done scripted mod (take it from owner)
+    Unit* owner = GetOwner();
+    if (!owner) owner = this;
+    AuraList const& mOverrideClassScript = owner->GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
+    for (AuraList::const_iterator i = mOverrideClassScript.begin(); i != mOverrideClassScript.end(); ++i)
+    {
+        if (!(*i)->isAffectedOnSpell(spellProto))
+            continue;
+        switch ((*i)->GetModifier()->m_miscvalue)
+        {
+            case 4415: // Increased Rejuvenation Healing
+            case 4953:
+            case 3736: // Hateful Totem of the Third Wind / Increased Lesser Healing Wave / LK Arena (4/5/6) Totem of the Third Wind / Savage Totem of the Third Wind
+                DoneTotal += (*i)->GetModifier()->m_amount;
+                break;
+            default:
+                break;
+        }
+    }
+
+    // Done fixed damage bonus auras
+    int32 DoneAdvertisedBenefit  = SpellBaseHealingBonusDone(GetSpellSchoolMask(spellProto));
+
+    // apply ap bonus and benefit affected by spell power implicit coeffs and spell level penalties
+    DoneTotal = SpellBonusWithCoeffs(spellProto, DoneTotal, DoneAdvertisedBenefit, 0, damagetype, true);
+
+    // use float as more appropriate for negative values and percent applying
+    float heal = (healamount + DoneTotal * int32(stack)) * DoneTotalMod;
+    // apply spellmod to Done amount
+    if (Player* modOwner = GetSpellModOwner())
+        modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, heal);
+
+    return heal < 0 ? 0 : uint32(heal);
+}
+
+/**
+ * Calculates target part of healing spell bonuses,
+ * will be called on each tick for periodic damage over time auras
+ */
+uint32 Unit::SpellHealingBonusTaken(Unit* pCaster, SpellEntry const* spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack)
+{
+    float  TakenTotalMod = 1.0f;
+
+    // Healing taken percent
+    float minval = float(GetMaxNegativeAuraModifier(SPELL_AURA_MOD_HEALING_PCT));
+    if (minval)
+        TakenTotalMod *= (100.0f + minval) / 100.0f;
+
+    float maxval = float(GetMaxPositiveAuraModifier(SPELL_AURA_MOD_HEALING_PCT));
+    if (maxval)
+        TakenTotalMod *= (100.0f + maxval) / 100.0f;
+
+    // No heal amount for this class spells
+    if (spellProto->DmgClass == SPELL_DAMAGE_CLASS_NONE)
+    {
+        healamount = int32(healamount * TakenTotalMod);
+        return healamount < 0 ? 0 : healamount;
+    }
+
+    // Healing Done
+    // Done total percent damage auras
+    int32  TakenTotal = 0;
+
+    // Taken fixed damage bonus auras
+    int32 TakenAdvertisedBenefit = SpellBaseHealingBonusTaken(GetSpellSchoolMask(spellProto));
+
+    // Blessing of Light dummy affects healing taken from Holy Light and Flash of Light
+    if (spellProto->SpellFamilyName == SPELLFAMILY_PALADIN && (spellProto->SpellFamilyFlags & uint64(0x00000000C0000000)))
+    {
+        AuraList const& auraDummy = GetAurasByType(SPELL_AURA_DUMMY);
+        for (AuraList::const_iterator i = auraDummy.begin(); i != auraDummy.end(); ++i)
+        {
+            if ((*i)->GetSpellProto()->SpellVisual == 9180)
+            {
+                if (((spellProto->SpellFamilyFlags & uint64(0x0000000040000000)) && (*i)->GetEffIndex() == EFFECT_INDEX_1) ||  // Flash of Light
+                        ((spellProto->SpellFamilyFlags & uint64(0x0000000080000000)) && (*i)->GetEffIndex() == EFFECT_INDEX_0))    // Holy Light
+                    TakenTotal += ((*i)->GetModifier()->m_amount * CalculateLevelPenalty(spellProto));  // BoL is penalized since 2.3.0
+            }
+        }
+    }
+
+    // apply benefit affected by spell power implicit coeffs and spell level penalties
+    TakenTotal = pCaster->SpellBonusWithCoeffs(spellProto, TakenTotal, TakenAdvertisedBenefit, 0, damagetype, false);
+
+    // Healing Way dummy affects healing taken from Healing Wave
+    if (spellProto->SpellFamilyName == SPELLFAMILY_SHAMAN && (spellProto->SpellFamilyFlags & uint64(0x0000000000000040)))
+    {
+        AuraList const& auraDummy = GetAurasByType(SPELL_AURA_DUMMY);
+        for (AuraList::const_iterator i = auraDummy.begin(); i != auraDummy.end(); ++i)
+            if ((*i)->GetId() == 29203)
+                TakenTotalMod *= ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
+    }
+
+    // use float as more appropriate for negative values and percent applying
+    float heal = (healamount + TakenTotal * int32(stack)) * TakenTotalMod;
+
+    return heal < 0 ? 0 : uint32(heal);
+}
+
+int32 Unit::SpellBaseHealingBonusDone(SpellSchoolMask schoolMask)
+{
+    int32 AdvertisedBenefit = 0;
+
+    AuraList const& mHealingDone = GetAurasByType(SPELL_AURA_MOD_HEALING_DONE);
+    for (AuraList::const_iterator i = mHealingDone.begin(); i != mHealingDone.end(); ++i)
+        if (((*i)->GetModifier()->m_miscvalue & schoolMask) != 0)
+            AdvertisedBenefit += (*i)->GetModifier()->m_amount;
+
+    // Healing bonus of spirit, intellect and strength
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        // Healing bonus from stats
+        AuraList const& mHealingDoneOfStatPercent = GetAurasByType(SPELL_AURA_MOD_SPELL_HEALING_OF_STAT_PERCENT);
+        for (AuraList::const_iterator i = mHealingDoneOfStatPercent.begin(); i != mHealingDoneOfStatPercent.end(); ++i)
+        {
+            // stat used dependent from misc value (stat index)
+            Stats usedStat = Stats((*i)->GetSpellProto()->EffectMiscValue[(*i)->GetEffIndex()]);
+            AdvertisedBenefit += int32(GetStat(usedStat) * (*i)->GetModifier()->m_amount / 100.0f);
+        }
+
+        // ... and attack power
+        AuraList const& mHealingDonebyAP = GetAurasByType(SPELL_AURA_MOD_SPELL_HEALING_OF_ATTACK_POWER);
+        for (AuraList::const_iterator i = mHealingDonebyAP.begin(); i != mHealingDonebyAP.end(); ++i)
+            if ((*i)->GetModifier()->m_miscvalue & schoolMask)
+                AdvertisedBenefit += int32(GetTotalAttackPowerValue(BASE_ATTACK) * (*i)->GetModifier()->m_amount / 100.0f);
+    }
+    return AdvertisedBenefit;
+}
+
+int32 Unit::SpellBaseHealingBonusTaken(SpellSchoolMask schoolMask) const
+{
+    int32 AdvertisedBenefit = 0;
+    AuraList const& mDamageTaken = GetAurasByType(SPELL_AURA_MOD_HEALING);
+    for (AuraList::const_iterator i = mDamageTaken.begin(); i != mDamageTaken.end(); ++i)
+        if ((*i)->GetModifier()->m_miscvalue & schoolMask)
+            AdvertisedBenefit += (*i)->GetModifier()->m_amount;
+
+    return AdvertisedBenefit;
+}
+
+bool Unit::IsImmuneToDamage(SpellSchoolMask shoolMask)
+{
+    // If m_immuneToSchool type contain this school type, IMMUNE damage.
+    SpellImmuneList const& schoolList = m_spellImmune[IMMUNITY_SCHOOL];
+    for (SpellImmuneList::const_iterator itr = schoolList.begin(); itr != schoolList.end(); ++itr)
+        if (itr->type & shoolMask)
+            return true;
+
+    // If m_immuneToDamage type contain magic, IMMUNE damage.
+    SpellImmuneList const& damageList = m_spellImmune[IMMUNITY_DAMAGE];
+    for (SpellImmuneList::const_iterator itr = damageList.begin(); itr != damageList.end(); ++itr)
+        if (itr->type & shoolMask)
+            return true;
+
+    return false;
+}
+
+bool Unit::IsImmuneToSpell(SpellEntry const* spellInfo, bool /*castOnSelf*/)
+{
+    if (!spellInfo)
+        return false;
+
+    // TODO add spellEffect immunity checks!, player with flag in bg is immune to immunity buffs from other friendly players!
+    // SpellImmuneList const& dispelList = m_spellImmune[IMMUNITY_EFFECT];
+
+    SpellImmuneList const& dispelList = m_spellImmune[IMMUNITY_DISPEL];
+    for (SpellImmuneList::const_iterator itr = dispelList.begin(); itr != dispelList.end(); ++itr)
+        if (itr->type == spellInfo->Dispel)
+            return true;
+
+    if (!spellInfo->HasAttribute(SPELL_ATTR_EX_UNAFFECTED_BY_SCHOOL_IMMUNE) &&          // unaffected by school immunity
+            !spellInfo->HasAttribute(SPELL_ATTR_EX_DISPEL_AURAS_ON_IMMUNITY))           // can remove immune (by dispell or immune it)
+    {
+        SpellImmuneList const& schoolList = m_spellImmune[IMMUNITY_SCHOOL];
+        for (SpellImmuneList::const_iterator itr = schoolList.begin(); itr != schoolList.end(); ++itr)
+            if (!(IsPositiveSpell(itr->spellId) && IsPositiveSpell(spellInfo->Id)) &&
+                    (itr->type & GetSpellSchoolMask(spellInfo)))
+                return true;
+    }
+
+    if (uint32 mechanic = spellInfo->Mechanic)
+    {
+        SpellImmuneList const& mechanicList = m_spellImmune[IMMUNITY_MECHANIC];
+        for (SpellImmuneList::const_iterator itr = mechanicList.begin(); itr != mechanicList.end(); ++itr)
+            if (itr->type == mechanic)
+                return true;
+
+        AuraList const& immuneAuraApply = GetAurasByType(SPELL_AURA_MECHANIC_IMMUNITY_MASK);
+        for (AuraList::const_iterator iter = immuneAuraApply.begin(); iter != immuneAuraApply.end(); ++iter)
+            if ((*iter)->GetModifier()->m_miscvalue & (1 << (mechanic - 1)))
+                return true;
+    }
+
+    return false;
+}
+
+bool Unit::IsImmuneToSpellEffect(SpellEntry const* spellInfo, SpellEffectIndex index, bool /*castOnSelf*/) const
+{
+    // If m_immuneToEffect type contain this effect type, IMMUNE effect.
+    uint32 effect = spellInfo->Effect[index];
+    SpellImmuneList const& effectList = m_spellImmune[IMMUNITY_EFFECT];
+    for (SpellImmuneList::const_iterator itr = effectList.begin(); itr != effectList.end(); ++itr)
+        if (itr->type == effect)
+            return true;
+
+    if (uint32 mechanic = spellInfo->EffectMechanic[index])
+    {
+        SpellImmuneList const& mechanicList = m_spellImmune[IMMUNITY_MECHANIC];
+        for (SpellImmuneList::const_iterator itr = mechanicList.begin(); itr != mechanicList.end(); ++itr)
+            if (itr->type == mechanic)
+                return true;
+
+        AuraList const& immuneAuraApply = GetAurasByType(SPELL_AURA_MECHANIC_IMMUNITY_MASK);
+        for (AuraList::const_iterator iter = immuneAuraApply.begin(); iter != immuneAuraApply.end(); ++iter)
+            if ((*iter)->GetModifier()->m_miscvalue & (1 << (mechanic - 1)))
+                return true;
+    }
+
+    if (uint32 aura = spellInfo->EffectApplyAuraName[index])
+    {
+        SpellImmuneList const& list = m_spellImmune[IMMUNITY_STATE];
+        for (SpellImmuneList::const_iterator itr = list.begin(); itr != list.end(); ++itr)
+            if (itr->type == aura)
+                return true;
+    }
+    return false;
+}
+
+/**
+ * Calculates caster part of melee damage bonuses,
+ * also includes different bonuses dependent from target auras
+ */
+uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackType attType, SpellEntry const* spellProto, DamageEffectType damagetype, uint32 stack)
+{
+    if (!pVictim || pdamage == 0 || (spellProto && spellProto->HasAttribute(SPELL_ATTR_EX6_NO_DMG_PERCENT_MODS)))
+        return pdamage;
+
+    // differentiate for weapon damage based spells
+    bool isWeaponDamageBasedSpell = !(spellProto && (damagetype == DOT || IsSpellHaveEffect(spellProto, SPELL_EFFECT_SCHOOL_DAMAGE)));
+    Item*  pWeapon          = GetTypeId() == TYPEID_PLAYER ? ((Player*)this)->GetWeaponForAttack(attType, true, false) : nullptr;
+    uint32 creatureTypeMask = pVictim->GetCreatureTypeMask();
+    uint32 schoolMask       = spellProto ? spellProto->SchoolMask : uint32(GetMeleeDamageSchoolMask());
+
+    // FLAT damage bonus auras
+    // =======================
+    int32 DoneFlat  = 0;
+    int32 APbonus   = 0;
+
+    // ..done flat, already included in weapon damage based spells
+    if (!isWeaponDamageBasedSpell)
+    {
+        AuraList const& mModDamageDone = GetAurasByType(SPELL_AURA_MOD_DAMAGE_DONE);
+        for (AuraList::const_iterator i = mModDamageDone.begin(); i != mModDamageDone.end(); ++i)
+        {
+            if ((*i)->GetModifier()->m_miscvalue & schoolMask &&                         // schoolmask has to fit with the intrinsic spell school
+                    (*i)->GetModifier()->m_miscvalue & GetMeleeDamageSchoolMask() &&         // AND schoolmask has to fit with weapon damage school (essential for non-physical spells)
+                    (((*i)->GetSpellProto()->EquippedItemClass == -1) ||                     // general, weapon independent
+                     (pWeapon && pWeapon->IsFitToSpellRequirements((*i)->GetSpellProto()))))  // OR used weapon fits aura requirements
+            {
+                DoneFlat += (*i)->GetModifier()->m_amount;
+            }
+        }
+
+        // Pets just add their bonus damage to their melee damage
+        if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsPet())
+            DoneFlat += ((Pet*)this)->GetBonusDamage();
+    }
+
+    // ..done flat (by creature type mask)
+    DoneFlat += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_DONE_CREATURE, creatureTypeMask);
+
+    // ..done flat (base at attack power for marked target and base at attack power for creature type)
+    if (attType == RANGED_ATTACK)
+    {
+        APbonus += pVictim->GetTotalAuraModifier(SPELL_AURA_RANGED_ATTACK_POWER_ATTACKER_BONUS);
+        APbonus += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_RANGED_ATTACK_POWER_VERSUS, creatureTypeMask);
+    }
+    else
+    {
+        APbonus += pVictim->GetTotalAuraModifier(SPELL_AURA_MELEE_ATTACK_POWER_ATTACKER_BONUS);
+        APbonus += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_MELEE_ATTACK_POWER_VERSUS, creatureTypeMask);
+    }
+
+    // PERCENT damage auras
+    // ====================
+    float DonePercent   = 1.0f;
+
+    // ..done pct, already included in weapon damage based spells
+    if (!isWeaponDamageBasedSpell)
+    {
+        AuraList const& mModDamagePercentDone = GetAurasByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
+        for (AuraList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
+        {
+            if ((*i)->GetModifier()->m_miscvalue & schoolMask &&                         // schoolmask has to fit with the intrinsic spell school
+                    (*i)->GetModifier()->m_miscvalue & GetMeleeDamageSchoolMask() &&         // AND schoolmask has to fit with weapon damage school (essential for non-physical spells)
+                    (((*i)->GetSpellProto()->EquippedItemClass == -1) ||                     // general, weapon independent
+                     (pWeapon && pWeapon->IsFitToSpellRequirements((*i)->GetSpellProto()))))  // OR used weapon fits aura requirements
+            {
+                DonePercent *= ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
+            }
+        }
+
+        if (attType == OFF_ATTACK)
+            DonePercent *= GetModifierValue(UNIT_MOD_DAMAGE_OFFHAND, TOTAL_PCT);                    // no school check required
+    }
+
+    // ..done pct (by creature type mask)
+    DonePercent *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_DONE_VERSUS, creatureTypeMask);
+
+    // special dummys/class scripts and other effects
+    // =============================================
+    Unit* owner = GetOwner();
+    if (!owner)
+        owner = this;
+
+    // .. done (class scripts)
+    AuraList const& mclassScritAuras = GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
+    for (AuraList::const_iterator i = mclassScritAuras.begin(); i != mclassScritAuras.end(); ++i)
+    {
+        switch ((*i)->GetMiscValue())
+        {
+            // Dirty Deeds
+            case 6427:
+            case 6428:
+                if (pVictim->HasAuraState(AURA_STATE_HEALTHLESS_35_PERCENT))
+                {
+                    Aura* eff0 = GetAura((*i)->GetId(), EFFECT_INDEX_0);
+                    if (!eff0 || (*i)->GetEffIndex() != EFFECT_INDEX_1)
+                    {
+                        sLog.outError("Spell structure of DD (%u) changed.", (*i)->GetId());
+                        continue;
+                    }
+
+                    // effect 0 have expected value but in negative state
+                    DonePercent *= (-eff0->GetModifier()->m_amount + 100.0f) / 100.0f;
+                }
+                break;
+        }
+    }
+
+    // final calculation
+    // =================
+
+    float DoneTotal = 0.0f;
+
+    // scaling of non weapon based spells
+    if (!isWeaponDamageBasedSpell)
+    {
+        // apply ap bonus and benefit affected by spell power implicit coeffs and spell level penalties
+        DoneTotal = SpellBonusWithCoeffs(spellProto, DoneTotal, DoneFlat, APbonus, damagetype, true);
+    }
+    // weapon damage based spells
+    else if (APbonus || DoneFlat)
+    {
+        bool normalized = spellProto ? IsSpellHaveEffect(spellProto, SPELL_EFFECT_NORMALIZED_WEAPON_DMG) : false;
+        DoneTotal += int32(APbonus / 14.0f * GetAPMultiplier(attType, normalized));
+
+        // for weapon damage based spells we still have to apply damage done percent mods
+        // (that are already included into pdamage) to not-yet included DoneFlat
+        // e.g. from doneVersusCreature, apBonusVs...
+        UnitMods unitMod;
+        switch (attType)
+        {
+            default:
+            case BASE_ATTACK:   unitMod = UNIT_MOD_DAMAGE_MAINHAND; break;
+            case OFF_ATTACK:    unitMod = UNIT_MOD_DAMAGE_OFFHAND;  break;
+            case RANGED_ATTACK: unitMod = UNIT_MOD_DAMAGE_RANGED;   break;
+        }
+
+        DoneTotal += DoneFlat;
+
+        DoneTotal *= GetModifierValue(unitMod, TOTAL_PCT);
+    }
+
+    float tmpDamage = float(int32(pdamage) + DoneTotal * int32(stack)) * DonePercent;
+
+    // apply spellmod to Done damage
+    if (spellProto)
+    {
+        if (Player* modOwner = GetSpellModOwner())
+            modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, tmpDamage);
+    }
+
+    // bonus result can be negative
+    return tmpDamage > 0 ? uint32(tmpDamage) : 0;
+}
+
+/**
+ * Calculates target part of melee damage bonuses,
+ * will be called on each tick for periodic damage over time auras
+ */
+uint32 Unit::MeleeDamageBonusTaken(Unit* pCaster, uint32 pdamage, WeaponAttackType attType, SpellEntry const* spellProto, DamageEffectType damagetype, uint32 stack)
+{
+    if (!pCaster)
+        return pdamage;
+
+    if (pdamage == 0)
+        return pdamage;
+
+    // differentiate for weapon damage based spells
+    bool isWeaponDamageBasedSpell = !(spellProto && (damagetype == DOT || IsSpellHaveEffect(spellProto, SPELL_EFFECT_SCHOOL_DAMAGE)));
+    uint32 schoolMask       = spellProto ? spellProto->SchoolMask : uint32(GetMeleeDamageSchoolMask());
+    uint32 mechanicMask     = spellProto ? GetAllSpellMechanicMask(spellProto) : 0;
+
+    // Shred also have bonus as MECHANIC_BLEED damages
+    if (spellProto && spellProto->SpellFamilyName == SPELLFAMILY_DRUID && spellProto->SpellFamilyFlags & uint64(0x00008000))
+        mechanicMask |= (1 << (MECHANIC_BLEED - 1));
+
+    // FLAT damage bonus auras
+    // =======================
+    int32 TakenFlat = 0;
+
+    // ..taken flat (base at attack power for marked target and base at attack power for creature type)
+    if (attType == RANGED_ATTACK)
+        TakenFlat += GetTotalAuraModifier(SPELL_AURA_MOD_RANGED_DAMAGE_TAKEN);
+    else
+        TakenFlat += GetTotalAuraModifier(SPELL_AURA_MOD_MELEE_DAMAGE_TAKEN);
+
+    // ..taken flat (by school mask)
+    TakenFlat += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, schoolMask);
+
+    // PERCENT damage auras
+    // ====================
+    float TakenPercent  = 1.0f;
+
+    // ..taken pct (by school mask)
+    TakenPercent *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, schoolMask);
+
+    // ..taken pct (melee/ranged)
+    if (attType == RANGED_ATTACK)
+        TakenPercent *= GetTotalAuraMultiplier(SPELL_AURA_MOD_RANGED_DAMAGE_TAKEN_PCT);
+    else
+        TakenPercent *= GetTotalAuraMultiplier(SPELL_AURA_MOD_MELEE_DAMAGE_TAKEN_PCT);
+
+    // ..taken pct (aoe avoidance)
+    if (spellProto && IsAreaOfEffectSpell(spellProto))
+        TakenPercent *= GetTotalAuraMultiplier(SPELL_AURA_MOD_AOE_DAMAGE_AVOIDANCE);
+
+    // special dummys/class scripts and other effects
+    // =============================================
+
+    // .. taken (dummy auras)
+    AuraList const& mDummyAuras = GetAurasByType(SPELL_AURA_DUMMY);
+    for (AuraList::const_iterator i = mDummyAuras.begin(); i != mDummyAuras.end(); ++i)
+    {
+        switch ((*i)->GetSpellProto()->SpellIconID)
+        {
+            case 2109:                                      // Cheating Death
+                if ((*i)->GetModifier()->m_miscvalue & SPELL_SCHOOL_MASK_NORMAL)
+                {
+                    if (GetTypeId() != TYPEID_PLAYER)
+                        continue;
+
+                    float mod = ((Player*)this)->GetRatingBonusValue(CR_CRIT_TAKEN_MELEE) * (-8.0f);
+                    if (mod < float((*i)->GetModifier()->m_amount))
+                        mod = float((*i)->GetModifier()->m_amount);
+
+                    TakenPercent *= (mod + 100.0f) / 100.0f;
+                }
+                break;
+            case 2312:                                      // Mangle
+                if (mechanicMask & (1 << (MECHANIC_BLEED - 1)))
+                    TakenPercent *= (100.0f + (*i)->GetModifier()->m_amount) / 100.0f;
+                break;
+        }
+    }
+
+    // final calculation
+    // =================
+
+    // scaling of non weapon based spells
+    if (!isWeaponDamageBasedSpell)
+    {
+        // apply benefit affected by spell power implicit coeffs and spell level penalties
+        TakenFlat = pCaster->SpellBonusWithCoeffs(spellProto, 0, TakenFlat, 0, damagetype, false);
+    }
+
+    float tmpDamage = float(int32(pdamage) + TakenFlat * int32(stack)) * TakenPercent;
+
+    // bonus result can be negative
+    return tmpDamage > 0 ? uint32(tmpDamage) : 0;
+}
+
+void Unit::ApplySpellImmune(uint32 spellId, uint32 op, uint32 type, bool apply)
+{
+    if (apply)
+    {
+        for (SpellImmuneList::iterator itr = m_spellImmune[op].begin(), next; itr != m_spellImmune[op].end(); itr = next)
+        {
+            next = itr; ++next;
+            if (itr->type == type)
+            {
+                m_spellImmune[op].erase(itr);
+                next = m_spellImmune[op].begin();
+            }
+        }
+        SpellImmune Immune;
+        Immune.spellId = spellId;
+        Immune.type = type;
+        m_spellImmune[op].push_back(Immune);
+    }
+    else
+    {
+        for (SpellImmuneList::iterator itr = m_spellImmune[op].begin(); itr != m_spellImmune[op].end(); ++itr)
+        {
+            if (itr->spellId == spellId)
+            {
+                m_spellImmune[op].erase(itr);
+                break;
+            }
+        }
+    }
+}
+
+void Unit::ApplySpellDispelImmunity(const SpellEntry* spellProto, DispelType type, bool apply)
+{
+    ApplySpellImmune(spellProto->Id, IMMUNITY_DISPEL, type, apply);
+
+    if (apply && spellProto->HasAttribute(SPELL_ATTR_EX_DISPEL_AURAS_ON_IMMUNITY))
+        RemoveAurasWithDispelType(type);
+}
+
+float Unit::GetWeaponProcChance() const
+{
+    // normalized proc chance for weapon attack speed
+    // (odd formula...)
+    if (isAttackReady(BASE_ATTACK))
+        return (GetAttackTime(BASE_ATTACK) * 1.8f / 1000.0f);
+    else if (haveOffhandWeapon() && isAttackReady(OFF_ATTACK))
+        return (GetAttackTime(OFF_ATTACK) * 1.6f / 1000.0f);
+
+    return 0.0f;
+}
+
+float Unit::GetPPMProcChance(uint32 WeaponSpeed, float PPM) const
+{
+    // proc per minute chance calculation
+    if (PPM <= 0.0f)
+        return 0.0f;
+    return WeaponSpeed * PPM / 600.0f;                      // result is chance in percents (probability = Speed_in_sec * (PPM / 60))
+}
+
+void Unit::Mount(uint32 mount, uint32 spellId)
+{
+    if (!mount)
+        return;
+
+    RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_MOUNTING);
+
+    SetUInt32Value(UNIT_FIELD_MOUNTDISPLAYID, mount);
+
+    SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_MOUNT);
+
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        // Called by Taxi system / GM command
+        if (!spellId)
+            ((Player*)this)->UnsummonPetTemporaryIfAny();
+        // Called by mount aura
+        else if (SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId))
+        {
+            // Flying case (Unsummon any pet)
+            if (IsSpellHaveAura(spellInfo, SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED))
+                ((Player*)this)->UnsummonPetTemporaryIfAny();
+            // Normal case (Unsummon only permanent pet)
+            else if (Pet* pet = GetPet())
+            {
+                if (pet->isControlled() && (!(pet->isTemporarySummoned() || ((Player*)this)->InArena())
+                    || sWorld.getConfig(CONFIG_BOOL_PET_UNSUMMON_AT_MOUNT)))
+                    ((Player*)this)->UnsummonPetTemporaryIfAny();
+                else
+                    pet->SetModeFlags(PET_MODE_DISABLE_ACTIONS);
+            }
+        }
+    }
+}
+
+void Unit::Unmount(bool from_aura)
+{
+    if (!IsMounted())
+        return;
+
+    RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_MOUNTED);
+
+    SetUInt32Value(UNIT_FIELD_MOUNTDISPLAYID, 0);
+    RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_MOUNT);
+
+    // Called NOT by Taxi system / GM command
+    if (from_aura)
+    {
+        WorldPacket data(SMSG_DISMOUNT, 8);
+        data << GetPackGUID();
+        SendMessageToSet(data, true);
+    }
+
+    // only resummon old pet if the player is already added to a map
+    // this prevents adding a pet to a not created map which would otherwise cause a crash
+    // (it could probably happen when logging in after a previous crash)
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        if (Pet* pet = GetPet())
+        {
+            // Get reaction state and display appropriately
+            if (CharmInfo* charmInfo = pet->GetCharmInfo())
+                pet->SetModeFlags(PetModeFlags(charmInfo->GetReactState() | charmInfo->GetCommandState() * 0x100));
+        }
+        else
+            ((Player*)this)->ResummonPetTemporaryUnSummonedIfAny();
+    }
+}
+
+void Unit::SetInCombatWith(Unit* enemy)
+{
+    Unit* eOwner = enemy->GetCharmerOrOwnerOrSelf();
+    if (eOwner->IsPvP())
+    {
+        SetInCombatState(true, enemy);
+        return;
+    }
+
+    // check for duel
+    if (eOwner->GetTypeId() == TYPEID_PLAYER && ((Player*)eOwner)->duel)
+    {
+        if (Player const* myOwner = GetCharmerOrOwnerPlayerOrPlayerItself())
+        {
+            if (myOwner->IsInDuelWith((Player const*)eOwner))
+            {
+                SetInCombatState(true, enemy);
+                return;
+            }
+        }
+    }
+
+    SetInCombatState(false, enemy);
+}
+
+void Unit::SetInCombatState(bool PvP, Unit* enemy)
+{
+    // only alive units can be in combat
+    if (!isAlive())
+        return;
+
+    if (PvP)
+        m_CombatTimer = 5000;
+
+    bool creatureNotInCombat = GetTypeId() == TYPEID_UNIT && !HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IN_COMBAT);
+
+    SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IN_COMBAT);
+
+    if (isCharmed() || (GetTypeId() != TYPEID_PLAYER && ((Creature*)this)->IsPet()))
+        SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PET_IN_COMBAT);
+
+    // interrupt all delayed non-combat casts
+    for (uint32 i = CURRENT_FIRST_NON_MELEE_SPELL; i < CURRENT_MAX_SPELL; ++i)
+        if (Spell* spell = GetCurrentSpell(CurrentSpellTypes(i)))
+            if (IsNonCombatSpell(spell->m_spellInfo))
+                InterruptSpell(CurrentSpellTypes(i), false);
+
+    if (creatureNotInCombat)
+    {
+        // should probably be removed for the attacked (+ it's party/group) only, not global
+        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_OOC_NOT_ATTACKABLE);
+
+        // client does not handle this state on it's own (reset to default at LoadCreatureAddon)
+        if (getStandState() == UNIT_STAND_STATE_CUSTOM)
+            SetStandState(UNIT_STAND_STATE_STAND);
+
+        Creature* pCreature = (Creature*)this;
+
+        if (pCreature->AI())
+            pCreature->AI()->EnterCombat(enemy);
+
+        // Some bosses are set into combat with zone
+        if (GetMap()->IsDungeon() && (pCreature->GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_AGGRO_ZONE) && enemy && enemy->IsControlledByPlayer())
+            pCreature->SetInCombatWithZone();
+
+        if (InstanceData* mapInstance = GetInstanceData())
+            mapInstance->OnCreatureEnterCombat(pCreature);
+
+        if (m_isCreatureLinkingTrigger)
+            GetMap()->GetCreatureLinkingHolder()->DoCreatureLinkingEvent(LINKING_EVENT_AGGRO, pCreature, enemy);
+    }
+}
+
+void Unit::ClearInCombat()
+{
+    m_CombatTimer = 0;
+    RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IN_COMBAT);
+
+    if (isCharmed() || (GetTypeId() != TYPEID_PLAYER && ((Creature*)this)->IsPet()))
+        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PET_IN_COMBAT);
+
+    // Player's state will be cleared in Player::UpdateContestedPvP
+    if (GetTypeId() == TYPEID_UNIT)
+    {
+        Creature* cThis = static_cast<Creature*>(this);
+        if (cThis->GetCreatureInfo()->UnitFlags & UNIT_FLAG_OOC_NOT_ATTACKABLE && !(cThis->GetTemporaryFactionFlags() & TEMPFACTION_TOGGLE_OOC_NOT_ATTACK))
+            SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_OOC_NOT_ATTACKABLE);
+
+        clearUnitState(UNIT_STAT_ATTACK_PLAYER);
+    }
+}
+
+bool Unit::isTargetableForAttack(bool inverseAlive /*=false*/) const
+{
+    if (GetTypeId() == TYPEID_PLAYER && ((Player*)this)->isGameMaster())
+        return false;
+
+    if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE))
+        return false;
+
+    // to be removed if unit by any reason enter combat
+    if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_OOC_NOT_ATTACKABLE))
+        return false;
+
+    // inversealive is needed for some spells which need to be casted at dead targets (aoe)
+    if (isAlive() == inverseAlive)
+        return false;
+
+    return IsInWorld() && !hasUnitState(UNIT_STAT_DIED) && !IsTaxiFlying();
+}
+
+int32 Unit::ModifyHealth(int32 dVal)
+{
+    if (dVal == 0)
+        return 0;
+
+    int32 curHealth = (int32)GetHealth();
+
+    int32 val = dVal + curHealth;
+    if (val <= 0)
+    {
+        SetHealth(0);
+        return -curHealth;
+    }
+
+    int32 maxHealth = (int32)GetMaxHealth();
+
+    int32 gain;
+    if (val < maxHealth)
+    {
+        SetHealth(val);
+        gain = val - curHealth;
+    }
+    else
+    {
+        SetHealth(maxHealth);
+        gain = maxHealth - curHealth;
+    }
+
+    return gain;
+}
+
+int32 Unit::ModifyPower(Powers power, int32 dVal)
+{
+    if (dVal == 0)
+        return 0;
+
+    int32 curPower = (int32)GetPower(power);
+
+    int32 val = dVal + curPower;
+    if (val <= 0)
+    {
+        SetPower(power, 0);
+        return -curPower;
+    }
+
+    int32 maxPower = (int32)GetMaxPower(power);
+
+    int32 gain;
+    if (val < maxPower)
+    {
+        SetPower(power, val);
+        gain = val - curPower;
+    }
+    else
+    {
+        SetPower(power, maxPower);
+        gain = maxPower - curPower;
+    }
+
+    return gain;
+}
+
+bool Unit::isVisibleForOrDetect(Unit const* u, WorldObject const* viewPoint, bool detect, bool inVisibleList, bool is3dDistance) const
+{
+    if (!u || !IsInMap(u))
+        return false;
+
+    // Always can see self
+    if (u == this)
+        return true;
+
+    // player visible for other player if not logout and at same transport
+    // including case when player is out of world
+    bool at_same_transport =
+        GetTypeId() == TYPEID_PLAYER &&  u->GetTypeId() == TYPEID_PLAYER &&
+        !((Player*)this)->GetSession()->PlayerLogout() && !((Player*)u)->GetSession()->PlayerLogout() &&
+        !((Player*)this)->GetSession()->PlayerLoading() && !((Player*)u)->GetSession()->PlayerLoading() &&
+        ((Player*)this)->GetTransport() && ((Player*)this)->GetTransport() == ((Player*)u)->GetTransport();
+
+    // not in world
+    if (!at_same_transport && (!IsInWorld() || !u->IsInWorld()))
+        return false;
+
+    // forbidden to seen (while Removing corpse)
+    if (m_Visibility == VISIBILITY_REMOVE_CORPSE)
+        return false;
+
+    Map& _map = *u->GetMap();
+    // Grid dead/alive checks
+    if (u->GetTypeId() == TYPEID_PLAYER)
+    {
+        // non visible at grid for any stealth state
+        if (!IsVisibleInGridForPlayer((Player*)u))
+            return false;
+
+        // if player is dead then he can't detect anyone in any cases
+        if (!u->isAlive())
+            detect = false;
+    }
+    else
+    {
+        // all dead creatures/players not visible for any creatures
+        if (!u->isAlive() || !isAlive())
+            return false;
+    }
+
+    // different visible distance checks
+    if (u->IsTaxiFlying())                                  // what see player in flight
+    {
+        // use object grey distance for all (only see objects any way)
+        if (!IsWithinDistInMap(viewPoint, World::GetMaxVisibleDistanceInFlight() + (inVisibleList ? World::GetVisibleObjectGreyDistance() : 0.0f), is3dDistance))
+            return false;
+    }
+    else if (!at_same_transport)                            // distance for show player/pet/creature (no transport case)
+    {
+        // Any units far than max visible distance for viewer or not in our map are not visible too
+        if (!IsWithinDistInMap(viewPoint, _map.GetVisibilityDistance() + (inVisibleList ? World::GetVisibleUnitGreyDistance() : 0.0f), is3dDistance))
+            return false;
+    }
+
+    // always seen by owner
+    if (GetCharmerOrOwnerGuid() == u->GetObjectGuid())
+        return true;
+
+    // isInvisibleForAlive() those units can only be seen by dead or if other
+    // unit is also invisible for alive.. if an isinvisibleforalive unit dies we
+    // should be able to see it too
+    if (u->isAlive() && isAlive() && isInvisibleForAlive() != u->isInvisibleForAlive())
+        if (u->GetTypeId() != TYPEID_PLAYER || !((Player*)u)->isGameMaster())
+            return false;
+
+    // Visible units, always are visible for all units, except for units under invisibility
+    if (m_Visibility == VISIBILITY_ON && u->m_invisibilityMask == 0)
+        return true;
+
+    // GMs see any players, not higher GMs and all units
+    if (u->GetTypeId() == TYPEID_PLAYER && ((Player*)u)->isGameMaster())
+    {
+        if (GetTypeId() == TYPEID_PLAYER)
+            return ((Player*)this)->GetSession()->GetSecurity() <= ((Player*)u)->GetSession()->GetSecurity();
+        else
+            return true;
+    }
+
+    // non faction visibility non-breakable for non-GMs
+    if (m_Visibility == VISIBILITY_OFF)
+        return false;
+
+    // grouped players should always see stealthed party members
+    if (GetTypeId() == TYPEID_PLAYER && u->GetTypeId() == TYPEID_PLAYER)
+        if (((Player*)this)->IsGroupVisibleFor(((Player*)u)) && u->IsFriendlyTo(this))
+            return true;
+
+    // raw invisibility
+    bool invisible = (m_invisibilityMask != 0 || u->m_invisibilityMask != 0);
+    if (u->GetTypeId() == TYPEID_PLAYER) // if object is player with mover, use its visibility masks, so that an invisible player MCing a creature can see stuff
+    {
+        if (Player* player = (Player*)u)
+        {
+            if (Unit* mover=player->GetMover())
+            {
+                invisible= (m_invisibilityMask != 0 || mover->m_invisibilityMask != 0);
+            }
+        }
+    }
+
+    // detectable invisibility case
+    if (invisible && (
+                // Invisible units, always are visible for units under same invisibility type
+                (m_invisibilityMask & u->m_invisibilityMask) != 0 ||
+                // Invisible units, always are visible for unit that can detect this invisibility (have appropriate level for detect)
+                u->canDetectInvisibilityOf(this) ||
+                // Units that can detect invisibility always are visible for units that can be detected
+                canDetectInvisibilityOf(u)))
+    {
+        invisible = false;
+    }
+
+    // special cases for always overwrite invisibility/stealth
+    if (invisible || m_Visibility == VISIBILITY_GROUP_STEALTH)
+    {
+        if (u->IsHostileTo(this))
+        {
+            // Hunter mark functionality
+            AuraList const& auras = GetAurasByType(SPELL_AURA_MOD_STALKED);
+            for (AuraList::const_iterator iter = auras.begin(); iter != auras.end(); ++iter)
+                if ((*iter)->GetCasterGuid() == u->GetObjectGuid())
+                    return true;
+        }
+
+        // none other cases for detect invisibility, so invisible
+        if (invisible)
+            return false;
+    }
+
+    // unit got in stealth in this moment and must ignore old detected state
+    if (m_Visibility == VISIBILITY_GROUP_NO_DETECT)
+        return false;
+
+    // GM invisibility checks early, invisibility if any detectable, so if not stealth then visible
+    if (m_Visibility != VISIBILITY_GROUP_STEALTH)
+        return true;
+
+    // NOW ONLY STEALTH CASE
+
+    // if in non-detect mode then invisible for unit
+    // mobs always detect players (detect == true)... return 'false' for those mobs which have (detect == false)
+    // players detect players only in Player::HandleStealthedUnitsDetection()
+    if (!detect)
+        return (u->GetTypeId() == TYPEID_PLAYER) ? ((Player*)u)->HaveAtClient(this) : false;
+
+    // Special cases
+
+    // If is attacked then stealth is lost, some creature can use stealth too
+    if (!getAttackers().empty())
+        return true;
+
+    // If there is collision rogue is seen regardless of level difference
+    if (IsWithinDist(u, 0.24f))
+        return true;
+
+    // If a mob or player is stunned he will not be able to detect stealth
+    if (u->hasUnitState(UNIT_STAT_STUNNED) && (u != this))
+        return false;
+
+    // set max ditance
+    float visibleDistance = (u->GetTypeId() == TYPEID_PLAYER) ? MAX_PLAYER_STEALTH_DETECT_RANGE : ((Creature const*)u)->GetAttackDistance(this);
+
+    // Always invisible from back (when stealth detection is on), also filter max distance cases
+    bool isInFront = viewPoint->isInFrontInMap(this, visibleDistance);
+    if (!isInFront)
+        return false;
+
+    // if doesn't have stealth detection (Shadow Sight), then check how stealthy the unit is, otherwise just check los
+    if (!u->HasAuraType(SPELL_AURA_DETECT_STEALTH))
+    {
+        // Calculation if target is in front
+
+        // Visible distance based on stealth value (stealth rank 4 300MOD, 10.5 - 3 = 7.5)
+        visibleDistance = 10.5f - (GetTotalAuraModifier(SPELL_AURA_MOD_STEALTH) / 100.0f);
+
+        // Visible distance is modified by
+        //-Level Diff (every level diff = 1.0f in visible distance)
+        visibleDistance += int32(u->GetLevelForTarget(this)) - int32(GetLevelForTarget(u));
+
+        // This allows to check talent tree and will add addition stealth dependent on used points)
+        int32 stealthMod = GetTotalAuraModifier(SPELL_AURA_MOD_STEALTH_LEVEL);
+        if (stealthMod < 0)
+            stealthMod = 0;
+
+        //-Stealth Mod(positive like Master of Deception) and Stealth Detection(negative like paranoia)
+        // based on wowwiki every 5 mod we have 1 more level diff in calculation
+        visibleDistance += (int32(u->GetTotalAuraModifier(SPELL_AURA_MOD_STEALTH_DETECT)) - stealthMod) / 5.0f;
+        visibleDistance = visibleDistance > MAX_PLAYER_STEALTH_DETECT_RANGE ? MAX_PLAYER_STEALTH_DETECT_RANGE : visibleDistance;
+
+        // recheck new distance
+        if (visibleDistance <= 0 || !IsWithinDist(viewPoint, visibleDistance))
+            return false;
+    }
+
+    // Now check is target visible with LoS
+    float ox, oy, oz;
+    viewPoint->GetPosition(ox, oy, oz);
+    return IsWithinLOS(ox, oy, oz);
+}
+
+void Unit::UpdateVisibilityAndView()
+{
+    static const AuraType auratypes[] = {SPELL_AURA_BIND_SIGHT, SPELL_AURA_FAR_SIGHT, SPELL_AURA_NONE};
+    for (AuraType const* type = &auratypes[0]; *type != SPELL_AURA_NONE; ++type)
+    {
+        AuraList& alist = m_modAuras[*type];
+        if (alist.empty())
+            continue;
+
+        for (AuraList::iterator it = alist.begin(); it != alist.end();)
+        {
+            Aura* aura = (*it);
+            Unit* owner = aura->GetCaster();
+
+            if (!owner || !isVisibleForOrDetect(owner, this, false))
+            {
+                alist.erase(it);
+                RemoveAura(aura);
+                it = alist.begin();
+            }
+            else
+                ++it;
+        }
+    }
+
+    GetViewPoint().Call_UpdateVisibilityForOwner();
+    UpdateObjectVisibility();
+    ScheduleAINotify(0);
+    GetViewPoint().Event_ViewPointVisibilityChanged();
+}
+
+void Unit::SetVisibility(UnitVisibility x)
+{
+    m_Visibility = x;
+
+    if (IsInWorld())
+        UpdateVisibilityAndView();
+}
+
+bool Unit::canDetectInvisibilityOf(Unit const* u) const
+{
+    if (uint32 mask = (m_detectInvisibilityMask & u->m_invisibilityMask))
+    {
+        for (int32 i = 0; i < 32; ++i)
+        {
+            if (((1 << i) & mask) == 0)
+                continue;
+
+            // find invisibility level
+            int32 invLevel = 0;
+            Unit::AuraList const& iAuras = u->GetAurasByType(SPELL_AURA_MOD_INVISIBILITY);
+            for (Unit::AuraList::const_iterator itr = iAuras.begin(); itr != iAuras.end(); ++itr)
+                if ((*itr)->GetModifier()->m_miscvalue == i && invLevel < (*itr)->GetModifier()->m_amount)
+                    invLevel = (*itr)->GetModifier()->m_amount;
+
+            // find invisibility detect level
+            int32 detectLevel = 0;
+            Unit::AuraList const& dAuras = GetAurasByType(SPELL_AURA_MOD_INVISIBILITY_DETECTION);
+            for (Unit::AuraList::const_iterator itr = dAuras.begin(); itr != dAuras.end(); ++itr)
+                if ((*itr)->GetModifier()->m_miscvalue == i && detectLevel < (*itr)->GetModifier()->m_amount)
+                    detectLevel = (*itr)->GetModifier()->m_amount;
+
+            if (i == 6 && GetTypeId() == TYPEID_PLAYER)     // special drunk detection case
+                detectLevel = ((Player*)this)->GetDrunkValue();
+
+            if (invLevel <= detectLevel)
+                return true;
+        }
+    }
+
+    return false;
+}
+
+void Unit::UpdateSpeed(UnitMoveType mtype, bool forced, float ratio)
+{
+    // not in combat pet have same speed as owner
+    switch (mtype)
+    {
+        case MOVE_RUN:
+        case MOVE_WALK:
+        case MOVE_SWIM:
+            if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsPet() && hasUnitState(UNIT_STAT_FOLLOW))
+            {
+                if (Unit* owner = GetOwner())
+                {
+                    SetSpeedRate(mtype, owner->GetSpeedRate(mtype), forced);
+                    return;
+                }
+            }
+            break;
+        default:
+            break;
+    }
+
+    int32 main_speed_mod  = 0;
+    float stack_bonus     = 1.0f;
+    float non_stack_bonus = 1.0f;
+
+    switch (mtype)
+    {
+        case MOVE_WALK:
+            break;
+        case MOVE_RUN:
+        {
+            if (IsMounted()) // Use on mount auras
+            {
+                main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED);
+                stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_MOUNTED_SPEED_ALWAYS);
+                non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK)) / 100.0f;
+            }
+            else
+            {
+                main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_SPEED);
+                stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_SPEED_ALWAYS);
+                non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_SPEED_NOT_STACK)) / 100.0f;
+            }
+            break;
+        }
+        case MOVE_RUN_BACK:
+            return;
+        case MOVE_SWIM:
+        {
+            main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_SWIM_SPEED);
+            break;
+        }
+        case MOVE_SWIM_BACK:
+            return;
+        case MOVE_FLIGHT:
+        {
+            if (IsMounted()) // Use on mount auras
+            {
+                main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED);
+                stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_STACKING);
+                non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_NOT_STACKING)) / 100.0f;
+            }
+            else             // Use not mount (shapeshift for example) auras (should stack)
+            {
+                main_speed_mod  = GetTotalAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED);
+                stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_FLIGHT_SPEED_STACKING);
+                non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_NOT_STACKING)) / 100.0f;
+            }
+            break;
+        }
+        case MOVE_FLIGHT_BACK:
+            return;
+        default:
+            sLog.outError("Unit::UpdateSpeed: Unsupported move type (%d)", mtype);
+            return;
+    }
+
+    float bonus = non_stack_bonus > stack_bonus ? non_stack_bonus : stack_bonus;
+    // now we ready for speed calculation
+    float speed  = main_speed_mod ? bonus * (100.0f + main_speed_mod) / 100.0f : bonus;
+
+    switch (mtype)
+    {
+        case MOVE_RUN:
+        case MOVE_SWIM:
+        case MOVE_FLIGHT:
+        {
+            // Normalize speed by 191 aura SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED if need
+            // TODO: possible affect only on MOVE_RUN
+            if (int32 normalization = GetMaxPositiveAuraModifier(SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED))
+            {
+                // Use speed from aura
+                float max_speed = normalization / baseMoveSpeed[mtype];
+                if (speed > max_speed)
+                    speed = max_speed;
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    // for creature case, we check explicit if mob searched for assistance
+    if (GetTypeId() == TYPEID_UNIT)
+    {
+        if (((Creature*)this)->HasSearchedAssistance())
+            speed *= 0.66f;                                 // best guessed value, so this will be 33% reduction. Based off initial speed, mob can then "run", "walk fast" or "walk".
+    }
+    // for player case, we look for some custom rates
+    else
+    {
+        if (getDeathState() == CORPSE)
+            speed *= sWorld.getConfig(((Player*)this)->InBattleGround() ? CONFIG_FLOAT_GHOST_RUN_SPEED_BG : CONFIG_FLOAT_GHOST_RUN_SPEED_WORLD);
+    }
+
+    // Apply strongest slow aura mod to speed
+    int32 slow = GetMaxNegativeAuraModifier(SPELL_AURA_MOD_DECREASE_SPEED);
+    if (slow)
+        speed *= (100.0f + slow) / 100.0f;
+
+    if (GetTypeId() == TYPEID_UNIT)
+    {
+        switch (mtype)
+        {
+            case MOVE_RUN:
+                speed *= ((Creature*)this)->GetCreatureInfo()->SpeedRun;
+                break;
+            case MOVE_WALK:
+                speed *= ((Creature*)this)->GetCreatureInfo()->SpeedWalk;
+                break;
+            default:
+                break;
+        }
+    }
+
+    SetSpeedRate(mtype, speed * ratio, forced);
+}
+
+float Unit::GetSpeed(UnitMoveType mtype) const
+{
+    return m_speed_rate[mtype] * baseMoveSpeed[mtype];
+}
+
+struct SetSpeedRateHelper
+{
+    explicit SetSpeedRateHelper(UnitMoveType _mtype, bool _forced) : mtype(_mtype), forced(_forced) {}
+    void operator()(Unit* unit) const { unit->UpdateSpeed(mtype, forced); }
+    UnitMoveType mtype;
+    bool forced;
+};
+
+void Unit::SetSpeedRate(UnitMoveType mtype, float rate, bool forced)
+{
+    rate = std::max(rate, 0.01f);
+
+    // Update speed only on change
+    if (m_speed_rate[mtype] != rate)
+    {
+        m_speed_rate[mtype] = rate;
+        propagateSpeedChange();
+
+        typedef const Opcodes SpeedOpcodePair[2];
+        SpeedOpcodePair SetSpeed2Opc_table[MAX_MOVE_TYPE] =
+        {
+            {SMSG_FORCE_WALK_SPEED_CHANGE,        SMSG_SPLINE_SET_WALK_SPEED},
+            {SMSG_FORCE_RUN_SPEED_CHANGE,         SMSG_SPLINE_SET_RUN_SPEED},
+            {SMSG_FORCE_RUN_BACK_SPEED_CHANGE,    SMSG_SPLINE_SET_RUN_BACK_SPEED},
+            {SMSG_FORCE_SWIM_SPEED_CHANGE,        SMSG_SPLINE_SET_SWIM_SPEED},
+            {SMSG_FORCE_SWIM_BACK_SPEED_CHANGE,   SMSG_SPLINE_SET_SWIM_BACK_SPEED},
+            {SMSG_FORCE_TURN_RATE_CHANGE,         SMSG_SPLINE_SET_TURN_RATE},
+            {SMSG_FORCE_FLIGHT_SPEED_CHANGE,      SMSG_SPLINE_SET_FLIGHT_SPEED},
+            {SMSG_FORCE_FLIGHT_BACK_SPEED_CHANGE, SMSG_SPLINE_SET_FLIGHT_BACK_SPEED},
+        };
+
+        const SpeedOpcodePair& speedOpcodes = SetSpeed2Opc_table[mtype];
+        
+        if (forced && GetTypeId() == TYPEID_PLAYER)
+        {
+            // register forced speed changes for WorldSession::HandleForceSpeedChangeAck
+            // and do it only for real sent packets and use run for run/mounted as client expected
+            ++((Player*)this)->m_forced_speed_changes[mtype];
+
+            WorldPacket data(speedOpcodes[0], 18);
+            data << GetPackGUID();
+            data << (uint32)0;                              // moveEvent, NUM_PMOVE_EVTS = 0x39
+            if (mtype == MOVE_RUN)
+                data << uint8(0);                           // new 2.1.0
+            data << float(GetSpeed(mtype));
+            ((Player*)this)->GetSession()->SendPacket(data);
+        }
+        WorldPacket data(speedOpcodes[1], 12);
+        data << GetPackGUID();
+        data << float(GetSpeed(mtype));
+        SendMessageToSet(data, false);
+    }
+
+    CallForAllControlledUnits(SetSpeedRateHelper(mtype, forced), CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_CHARM | CONTROLLED_MINIPET);
+}
+
+void Unit::SetDeathState(DeathState s)
+{
+    if (s == JUST_DIED)
+    {
+        RemoveAllAurasOnDeath();
+        RemoveGuardians();
+        UnsummonAllTotems();
+
+        StopMoving();
+        i_motionMaster.Clear(false, true);
+        i_motionMaster.MoveIdle();
+
+        ModifyAuraState(AURA_STATE_HEALTHLESS_20_PERCENT, false);
+        ModifyAuraState(AURA_STATE_HEALTHLESS_35_PERCENT, false);
+        // remove aurastates allowing special moves
+        ClearAllReactives();
+        ClearDiminishings();
+    }
+    else if (s == JUST_ALIVED)
+    {
+        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SKINNABLE);  // clear skinnable for creature and player (at battleground)
+    }
+
+    if (s != ALIVE && s != JUST_ALIVED)
+    {
+        CombatStop();
+        DeleteThreatList();
+        ClearComboPointHolders();                           // any combo points pointed to unit lost at it death
+
+        if (IsNonMeleeSpellCasted(false))
+            InterruptNonMeleeSpells(false);
+    }
+
+    // TODO:: what is/was that?
+    /*if (m_deathState != ALIVE && s == ALIVE)
+    {
+        //_ApplyAllAuraMods();
+    }*/
+    m_deathState = s;
+}
+
+/*########################################
+########                          ########
+########       AGGRO SYSTEM       ########
+########                          ########
+########################################*/
+
+// Check if this unit is controlled by provided controller or by one of its friendly faction
+bool Unit::IsTargetUnderControl(Unit const& target) const
+{
+    ObjectGuid charmerGuid = GetCharmerGuid();
+
+    if (!charmerGuid)
+        return false;
+    
+    if (target.GetCharmerGuid() == charmerGuid)
+        return true;
+
+    // also check if this unit is controlled by another creature from friendly faction
+    if (Unit const* charmer = GetMap()->GetUnit(charmerGuid))
+    {
+        FactionTemplateEntry const* charmerFactionEntry = charmer->getFactionTemplateEntry();
+        FactionTemplateEntry const* controllerFactionEntry = target.getFactionTemplateEntry();
+        if (controllerFactionEntry && charmerFactionEntry && !controllerFactionEntry->IsHostileTo(*controllerFactionEntry))
+            return true;
+    }
+
+    return false;
+}
+
+bool Unit::CanHaveThreatList(bool ignoreAliveState/*=false*/) const
+{
+    // only creatures can have threat list
+    if (GetTypeId() != TYPEID_UNIT)
+        return false;
+
+    // only alive units can have threat list
+    if (!isAlive() && !ignoreAliveState)
+        return false;
+
+    Creature const* creature = ((Creature const*)this);
+
+    // totems can not have threat list
+    if (creature->IsTotem())
+        return false;
+
+    // pets can not have a threat list, unless they are controlled by a creature
+    if (creature->IsPet() && creature->GetOwnerGuid().IsPlayer())
+    {
+        Pet const* pet = static_cast<Pet const*>(creature);
+        if (pet->getPetType() == GUARDIAN_PET)
+            return true;
+        return false;
+    }
+
+    // charmed units can not have a threat list if charmed by player
+    if (creature->GetCharmerGuid().IsPlayer())
+        return false;
+
+    return true;
+}
+
+//======================================================================
+
+float Unit::ApplyTotalThreatModifier(float threat, SpellSchoolMask schoolMask)
+{
+    if (!HasAuraType(SPELL_AURA_MOD_THREAT))
+        return threat;
+
+    if (schoolMask == SPELL_SCHOOL_MASK_NONE)
+        return threat;
+
+    SpellSchools school = GetFirstSchoolInMask(schoolMask);
+
+    return threat * m_threatModifier[school];
+}
+
+//======================================================================
+
+void Unit::AddThreat(Unit* pVictim, float threat /*= 0.0f*/, bool crit /*= false*/, SpellSchoolMask schoolMask /*= SPELL_SCHOOL_MASK_NONE*/, SpellEntry const* threatSpell /*= nullptr*/)
+{
+    // Only mobs can manage threat lists
+    if (CanHaveThreatList())
+        getThreatManager().addThreat(pVictim, threat, crit, schoolMask, threatSpell);
+}
+
+//======================================================================
+
+void Unit::DeleteThreatList()
+{
+    getThreatManager().clearReferences();
+}
+
+//======================================================================
+
+void Unit::TauntApply(Unit* taunter)
+{
+    MANGOS_ASSERT(GetTypeId() == TYPEID_UNIT);
+
+    if (!taunter || (taunter->GetTypeId() == TYPEID_PLAYER && ((Player*)taunter)->isGameMaster()))
+        return;
+
+    if (!CanHaveThreatList())
+        return;
+
+    Unit* target = getVictim();
+
+    if (target && target == taunter)
+        return;
+
+    // Only attack taunter if this is a valid target
+    if (CanReactInCombat() && !IsSecondChoiceTarget(taunter, true, true))
+    {
+        if (GetTargetGuid() || !target)
+            SetInFront(taunter);
+
+        if (AI())
+            AI()->AttackStart(taunter);
+    }
+
+    getThreatManager().tauntApply(taunter);
+}
+
+//======================================================================
+
+void Unit::TauntFadeOut(Unit* taunter)
+{
+    MANGOS_ASSERT(GetTypeId() == TYPEID_UNIT);
+
+    if (!taunter || (taunter->GetTypeId() == TYPEID_PLAYER && ((Player*)taunter)->isGameMaster()))
+        return;
+
+    if (!CanHaveThreatList())
+        return;
+
+    Unit* target = getVictim();
+
+    if (!target || target != taunter)
+        return;
+
+    if (getThreatManager().isThreatListEmpty())
+    {
+        m_fixateTargetGuid.Clear();
+
+        if (AI())
+            AI()->EnterEvadeMode();
+
+        if (InstanceData* mapInstance = GetInstanceData())
+            mapInstance->OnCreatureEvade((Creature*)this);
+
+        if (m_isCreatureLinkingTrigger)
+            GetMap()->GetCreatureLinkingHolder()->DoCreatureLinkingEvent(LINKING_EVENT_EVADE, (Creature*)this);
+
+        return;
+    }
+
+    getThreatManager().tauntFadeOut(taunter);
+    target = getThreatManager().getHostileTarget();
+
+    if (target && target != taunter)
+    {
+        if (GetTargetGuid())
+            SetInFront(target);
+
+        if (AI())
+            AI()->AttackStart(target);
+    }
+}
+
+//======================================================================
+/// if pVictim is given, the npc will fixate onto pVictim, if nullptr it will remove current fixation
+void Unit::FixateTarget(Unit* pVictim)
+{
+    if (!pVictim)                                           // Remove Fixation
+        m_fixateTargetGuid.Clear();
+    else if (pVictim->isTargetableForAttack())              // Apply Fixation
+        m_fixateTargetGuid = pVictim->GetObjectGuid();
+
+    // Start attacking the fixated target or the next proper one
+    SelectHostileTarget();
+}
+
+//======================================================================
+
+bool Unit::IsSecondChoiceTarget(Unit* pTarget, bool taunt, bool checkThreatArea)
+{
+    MANGOS_ASSERT(pTarget);
+
+    // little hack before handling threatarea in unit instead of creature as charmed players will act like creature
+    const Creature* thisCreature = GetTypeId() == TYPEID_UNIT ? static_cast<const Creature*>(this) : nullptr;
+
+    return
+        pTarget->IsTargetUnderControl(*this) ||
+        (!taunt && pTarget->IsImmuneToDamage(GetMeleeDamageSchoolMask())) ||
+        pTarget->hasNegativeAuraWithInterruptFlag(AURA_INTERRUPT_FLAG_DAMAGE) ||
+        (thisCreature && checkThreatArea && thisCreature->IsOutOfThreatArea(pTarget));
+}
+
+//======================================================================
+
+bool Unit::SelectHostileTarget()
+{
+    // function provides main threat functionality
+    // next-victim-selection algorithm and evade mode are called
+    // threat list sorting etc.
+
+    MANGOS_ASSERT(GetTypeId() == TYPEID_UNIT);
+
+    if (!this->isAlive())
+        return false;
+
+    // This function only useful once AI has been initialized
+    if (!AI())
+        return false;
+
+    Unit* target = nullptr;
+    Unit* oldTarget = getVictim();
+
+    // first check if we should fixate a target
+    if (m_fixateTargetGuid)
+    {
+        if (oldTarget && oldTarget->GetObjectGuid() == m_fixateTargetGuid)
+            target = oldTarget;
+        else
+        {
+            Unit* pFixateTarget = GetMap()->GetUnit(m_fixateTargetGuid);
+            if (pFixateTarget && pFixateTarget->isAlive() && !IsSecondChoiceTarget(pFixateTarget, false, true))
+                target = pFixateTarget;
+        }
+    }
+    // then checking if we have some taunt on us
+    if (!target)
+    {
+        const AuraList& tauntAuras = GetAurasByType(SPELL_AURA_MOD_TAUNT);
+        Unit* caster;
+
+        // Find first available taunter target
+        // Auras are pushed_back, last caster will be on the end
+        for (AuraList::const_reverse_iterator aura = tauntAuras.rbegin(); aura != tauntAuras.rend(); ++aura)
+        {
+            if ((caster = (*aura)->GetCaster()) && caster->IsInMap(this) &&
+                    caster->isTargetableForAttack() && caster->isInAccessablePlaceFor((Creature*)this) &&
+                    !IsSecondChoiceTarget(caster, true, true))
+            {
+                target = caster;
+                break;
+            }
+        }
+    }
+
+    // No valid fixate target, taunt aura or taunt aura caster is dead, standard target selection
+    if (!target && !getThreatManager().isThreatListEmpty())
+        target = getThreatManager().getHostileTarget();
+
+    if (target)
+    {
+        if (CanReactInCombat())
+        {
+            SetInFront(target);
+            if (oldTarget != target)
+                AI()->AttackStart(target);
+
+            // check if currently selected target is reachable
+            // NOTE: path alrteady generated from AttackStart()
+            if (!GetMotionMaster()->GetCurrent()->IsReachable())
+            {
+                // remove all taunts
+                RemoveSpellsCausingAura(SPELL_AURA_MOD_TAUNT);
+
+                if (getThreatManager().getThreatList().size() < 2)
+                {
+                    // only one target in list, we have to evade after timer
+                    // TODO: make timer - inside Creature class
+                    AI()->EnterEvadeMode();
+                }
+                else
+                {
+                    // remove unreachable target from our threat list
+                    // next iteration we will select next possible target
+                    getHostileRefManager().deleteReference(target);
+                    getThreatManager().modifyThreatPercent(target, -101);
+                    // remove target from current attacker, do not exit combat settings
+                    AttackStop(true);
+                }
+
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // no target but something prevent go to evade mode
+    if (!isInCombat() || HasAuraType(SPELL_AURA_MOD_TAUNT))
+        return false;
+
+    // last case when creature don't must go to evade mode:
+    // it in combat but attacker not make any damage and not enter to aggro radius to have record in threat list
+    // for example at owner command to pet attack some far away creature
+    // Note: creature not have targeted movement generator but have attacker in this case
+    if (GetMotionMaster()->GetCurrentMovementGeneratorType() != CHASE_MOTION_TYPE)
+    {
+        for (AttackerSet::const_iterator itr = m_attackers.begin(); itr != m_attackers.end(); ++itr)
+        {
+            if ((*itr)->IsInMap(this) && (*itr)->isTargetableForAttack() && (*itr)->isInAccessablePlaceFor((Creature*)this))
+                return false;
+        }
+    }
+
+    // enter in evade mode in other case
+    m_fixateTargetGuid.Clear();
+    AI()->EnterEvadeMode();
+
+    if (InstanceData* mapInstance = GetInstanceData())
+        mapInstance->OnCreatureEvade((Creature*)this);
+
+    if (m_isCreatureLinkingTrigger)
+        GetMap()->GetCreatureLinkingHolder()->DoCreatureLinkingEvent(LINKING_EVENT_EVADE, (Creature*)this);
+
+    return false;
+}
+
+//======================================================================
+//======================================================================
+//======================================================================
+
+int32 Unit::CalculateSpellDamage(Unit const* target, SpellEntry const* spellProto, SpellEffectIndex effect_index, int32 const* effBasePoints)
+{
+    Player* unitPlayer = (GetTypeId() == TYPEID_PLAYER) ? (Player*)this : nullptr;
+
+    uint8 comboPoints = unitPlayer ? unitPlayer->GetComboPoints() : 0;
+
+    int32 level = int32(getLevel());
+    if (level > (int32)spellProto->maxLevel && spellProto->maxLevel > 0)
+        level = (int32)spellProto->maxLevel;
+    else if (level < (int32)spellProto->baseLevel)
+        level = (int32)spellProto->baseLevel;
+    level -= (int32)spellProto->spellLevel;
+
+    int32 baseDice = int32(spellProto->EffectBaseDice[effect_index]);
+    float basePointsPerLevel = spellProto->EffectRealPointsPerLevel[effect_index];
+    float randomPointsPerLevel = spellProto->EffectDicePerLevel[effect_index];
+    int32 basePoints = effBasePoints
+                       ? *effBasePoints - baseDice
+                       : spellProto->EffectBasePoints[effect_index];
+
+    basePoints += int32(level * basePointsPerLevel);
+    int32 randomPoints = int32(spellProto->EffectDieSides[effect_index] + level * randomPointsPerLevel);
+    float comboDamage = spellProto->EffectPointsPerComboPoint[effect_index];
+
+    switch (randomPoints)
+    {
+        case 0:
+        case 1: basePoints += baseDice; break;              // range 1..1
+        default:
+        {
+            // range can have positive (1..rand) and negative (rand..1) values, so order its for irand
+            int32 randvalue = baseDice >= randomPoints
+                              ? irand(randomPoints, baseDice)
+                              : irand(baseDice, randomPoints);
+
+            basePoints += randvalue;
+            break;
+        }
+    }
+
+    int32 value = basePoints;
+
+    // random damage
+    if (comboDamage != 0.0f && unitPlayer && target && (target->GetObjectGuid() == unitPlayer->GetComboTargetGuid() || IsOnlySelfTargeting(spellProto)))
+        value += (int32)(comboDamage * comboPoints);
+
+    if (Player* modOwner = GetSpellModOwner())
+    {
+        modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_ALL_EFFECTS, value);
+
+        switch (effect_index)
+        {
+            case EFFECT_INDEX_0:
+                modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_EFFECT1, value);
+                break;
+            case EFFECT_INDEX_1:
+                modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_EFFECT2, value);
+                break;
+            case EFFECT_INDEX_2:
+                modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_EFFECT3, value);
+                break;
+        }
+    }
+
+    if (spellProto->HasAttribute(SPELL_ATTR_LEVEL_DAMAGE_CALCULATION) && spellProto->spellLevel)
+    {
+        if (spellProto->EffectApplyAuraName[effect_index])
+            value += int32(std::max(0, int32(getLevel() - spellProto->maxLevel)) * basePointsPerLevel);
+        else if (spellProto->Effect[effect_index] != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE &&
+                 spellProto->Effect[effect_index] != SPELL_EFFECT_KNOCK_BACK &&
+                 !IsControlledByPlayer())
+        {
+            GtNPCManaCostScalerEntry const* spellScaler = sGtNPCManaCostScalerStore.LookupEntry(spellProto->spellLevel - 1);
+            GtNPCManaCostScalerEntry const* casterScaler = sGtNPCManaCostScalerStore.LookupEntry(this->getLevel() - 1);
+            if (spellScaler && casterScaler)
+                value *= casterScaler->ratio / spellScaler->ratio;
+        }
+    }
+
+    return value;
+}
+
+int32 Unit::CalculateAuraDuration(SpellEntry const* spellProto, uint32 effectMask, int32 duration, Unit const* caster)
+{
+    if (duration <= 0)
+        return duration;
+
+    int32 mechanicMod = 0;
+    uint32 mechanicMask = GetSpellMechanicMask(spellProto, effectMask);
+
+    for (int32 mechanic = FIRST_MECHANIC; mechanic < MAX_MECHANIC; ++mechanic)
+    {
+        if (!(mechanicMask & (1 << (mechanic - 1))))
+            continue;
+
+        int32 stackingMod = GetTotalAuraModifierByMiscValue(SPELL_AURA_MECHANIC_DURATION_MOD, mechanic);
+        int32 nonStackingMod = GetMaxNegativeAuraModifierByMiscValue(SPELL_AURA_MECHANIC_DURATION_MOD_NOT_STACK, mechanic);
+
+        mechanicMod = std::min(mechanicMod, std::min(stackingMod, nonStackingMod));
+    }
+
+    int32 durationMod = mechanicMod;
+
+    if (durationMod != 0)
+    {
+        duration = int32(int64(duration) * (100 + durationMod) / 100);
+
+        if (duration < 0)
+            duration = 0;
+    }
+
+    return duration;
+}
+
+DiminishingLevels Unit::GetDiminishing(DiminishingGroup group)
+{
+    for (Diminishing::iterator i = m_Diminishing.begin(); i != m_Diminishing.end(); ++i)
+    {
+        if (i->DRGroup != group)
+            continue;
+
+        if (!i->hitCount)
+            return DIMINISHING_LEVEL_1;
+
+        if (!i->hitTime)
+            return DIMINISHING_LEVEL_1;
+
+        // If last spell was casted more than 15 seconds ago - reset the count.
+        if (i->stack == 0 && WorldTimer::getMSTimeDiff(i->hitTime, WorldTimer::getMSTime()) > 15 * IN_MILLISECONDS)
+        {
+            i->hitCount = DIMINISHING_LEVEL_1;
+            return DIMINISHING_LEVEL_1;
+        }
+        // or else increase the count.
+        else
+        {
+            return DiminishingLevels(i->hitCount);
+        }
+    }
+    return DIMINISHING_LEVEL_1;
+}
+
+void Unit::IncrDiminishing(DiminishingGroup group)
+{
+    // Checking for existing in the table
+    for (Diminishing::iterator i = m_Diminishing.begin(); i != m_Diminishing.end(); ++i)
+    {
+        if (i->DRGroup != group)
+            continue;
+        if (i->hitCount < DIMINISHING_LEVEL_IMMUNE)
+            i->hitCount += 1;
+        return;
+    }
+    m_Diminishing.push_back(DiminishingReturn(group, WorldTimer::getMSTime(), DIMINISHING_LEVEL_2));
+}
+
+void Unit::ApplyDiminishingToDuration(DiminishingGroup group, int32& duration, Unit* caster, DiminishingLevels Level, bool isReflected)
+{
+    if (duration == -1 || group == DIMINISHING_NONE || (!isReflected && caster->IsFriendlyTo(this)))
+        return;
+
+    // Duration of crowd control abilities on pvp target is limited by 10 sec. (2.2.0)
+    if (duration > 10000 && IsDiminishingReturnsGroupDurationLimited(group))
+    {
+        // test pet/charm masters instead pets/charmeds
+        Unit const* targetOwner = GetCharmerOrOwner();
+        Unit const* casterOwner = caster->GetCharmerOrOwner();
+
+        Unit const* target = targetOwner ? targetOwner : this;
+        Unit const* source = casterOwner ? casterOwner : caster;
+
+        if (target->GetTypeId() == TYPEID_PLAYER && source->GetTypeId() == TYPEID_PLAYER)
+            duration = 10000;
+    }
+
+    float mod = 1.0f;
+
+    // Some diminishings applies to mobs too (for example, Stun)
+    if ((GetDiminishingReturnsGroupType(group) == DRTYPE_PLAYER && GetTypeId() == TYPEID_PLAYER) || GetDiminishingReturnsGroupType(group) == DRTYPE_ALL)
+    {
+        DiminishingLevels diminish = Level;
+        switch (diminish)
+        {
+            case DIMINISHING_LEVEL_1: break;
+            case DIMINISHING_LEVEL_2: mod = 0.5f; break;
+            case DIMINISHING_LEVEL_3: mod = 0.25f; break;
+            case DIMINISHING_LEVEL_IMMUNE: mod = 0.0f; break;
+            default: break;
+        }
+    }
+
+    duration = int32(duration * mod);
+}
+
+void Unit::ApplyDiminishingAura(DiminishingGroup group, bool apply)
+{
+    // Checking for existing in the table
+    for (Diminishing::iterator i = m_Diminishing.begin(); i != m_Diminishing.end(); ++i)
+    {
+        if (i->DRGroup != group)
+            continue;
+
+        if (apply)
+            i->stack += 1;
+        else if (i->stack)
+        {
+            i->stack -= 1;
+            // Remember time after last aura from group removed
+            if (i->stack == 0)
+                i->hitTime = WorldTimer::getMSTime();
+        }
+        break;
+    }
+}
+
+bool Unit::isVisibleForInState(Player const* u, WorldObject const* viewPoint, bool inVisibleList) const
+{
+    return isVisibleForOrDetect(u, viewPoint, false, inVisibleList, false);
+}
+
+/// returns true if creature can't be seen by alive units
+bool Unit::isInvisibleForAlive() const
+{
+    if (m_AuraFlags & UNIT_AURAFLAG_ALIVE_INVISIBLE)
+        return true;
+    // TODO: maybe spiritservices also have just an aura
+    return isSpiritService();
+}
+
+uint32 Unit::GetCreatureType() const
+{
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        SpellShapeshiftFormEntry const* ssEntry = sSpellShapeshiftFormStore.LookupEntry(GetShapeshiftForm());
+        if (ssEntry && ssEntry->creatureType > 0)
+            return ssEntry->creatureType;
+        else
+            return CREATURE_TYPE_HUMANOID;
+    }
+    else
+        return ((Creature*)this)->GetCreatureInfo()->CreatureType;
+}
+
+/*#######################################
+########                         ########
+########       STAT SYSTEM       ########
+########                         ########
+#######################################*/
+
+bool Unit::HandleStatModifier(UnitMods unitMod, UnitModifierType modifierType, float amount, bool apply)
+{
+    if (unitMod >= UNIT_MOD_END || modifierType >= MODIFIER_TYPE_END)
+    {
+        sLog.outError("ERROR in HandleStatModifier(): nonexistent UnitMods or wrong UnitModifierType!");
+        return false;
+    }
+
+    float val;
+
+    switch (modifierType)
+    {
+        case BASE_VALUE:
+        case BASE_EXCLUSIVE:
+        case TOTAL_VALUE:
+            m_auraModifiersGroup[unitMod][modifierType] += apply ? amount : -amount;
+            break;
+        case BASE_PCT:
+        case TOTAL_PCT:
+            if (amount <= -100.0f)                          // small hack-fix for -100% modifiers
+                amount = -200.0f;
+
+            val = (100.0f + amount) / 100.0f;
+            m_auraModifiersGroup[unitMod][modifierType] *= apply ? val : (1.0f / val);
+            break;
+
+        default:
+            break;
+    }
+
+    if (!CanModifyStats())
+        return false;
+
+    switch (unitMod)
+    {
+        case UNIT_MOD_STAT_STRENGTH:
+        case UNIT_MOD_STAT_AGILITY:
+        case UNIT_MOD_STAT_STAMINA:
+        case UNIT_MOD_STAT_INTELLECT:
+        case UNIT_MOD_STAT_SPIRIT:         UpdateStats(GetStatByAuraGroup(unitMod));  break;
+
+        case UNIT_MOD_ARMOR:               UpdateArmor();           break;
+        case UNIT_MOD_HEALTH:              UpdateMaxHealth();       break;
+
+        case UNIT_MOD_MANA:
+        case UNIT_MOD_RAGE:
+        case UNIT_MOD_FOCUS:
+        case UNIT_MOD_ENERGY:
+        case UNIT_MOD_HAPPINESS:           UpdateMaxPower(GetPowerTypeByAuraGroup(unitMod)); break;
+
+        case UNIT_MOD_RESISTANCE_HOLY:
+        case UNIT_MOD_RESISTANCE_FIRE:
+        case UNIT_MOD_RESISTANCE_NATURE:
+        case UNIT_MOD_RESISTANCE_FROST:
+        case UNIT_MOD_RESISTANCE_SHADOW:
+        case UNIT_MOD_RESISTANCE_ARCANE:   UpdateResistances(GetSpellSchoolByAuraGroup(unitMod)); break;
+
+        case UNIT_MOD_ATTACK_POWER:        UpdateAttackPowerAndDamage();         break;
+        case UNIT_MOD_ATTACK_POWER_RANGED: UpdateAttackPowerAndDamage(true);     break;
+
+        case UNIT_MOD_DAMAGE_MAINHAND:     UpdateDamagePhysical(BASE_ATTACK);    break;
+        case UNIT_MOD_DAMAGE_OFFHAND:      UpdateDamagePhysical(OFF_ATTACK);     break;
+        case UNIT_MOD_DAMAGE_RANGED:       UpdateDamagePhysical(RANGED_ATTACK);  break;
+
+        default:
+            break;
+    }
+
+    return true;
+}
+
+float Unit::GetModifierValue(UnitMods unitMod, UnitModifierType modifierType) const
+{
+    if (unitMod >= UNIT_MOD_END || modifierType >= MODIFIER_TYPE_END)
+    {
+        sLog.outError("attempt to access nonexistent modifier value from UnitMods!");
+        return 0.0f;
+    }
+
+    if (modifierType == TOTAL_PCT && m_auraModifiersGroup[unitMod][modifierType] <= 0.0f)
+        return 0.0f;
+
+    return m_auraModifiersGroup[unitMod][modifierType];
+}
+
+float Unit::GetTotalStatValue(Stats stat) const
+{
+    UnitMods unitMod = UnitMods(UNIT_MOD_STAT_START + stat);
+
+    if (m_auraModifiersGroup[unitMod][TOTAL_PCT] <= 0.0f)
+        return 0.0f;
+
+    // value = ((base_value * base_pct) + total_value) * total_pct
+    float value  = m_auraModifiersGroup[unitMod][BASE_VALUE] + GetCreateStat(stat);
+    value *= m_auraModifiersGroup[unitMod][BASE_PCT];
+    value += m_auraModifiersGroup[unitMod][TOTAL_VALUE];
+    value *= m_auraModifiersGroup[unitMod][TOTAL_PCT];
+
+    return value;
+}
+
+float Unit::GetTotalAuraModValue(UnitMods unitMod) const
+{
+    if (unitMod >= UNIT_MOD_END)
+    {
+        sLog.outError("attempt to access nonexistent UnitMods in GetTotalAuraModValue()!");
+        return 0.0f;
+    }
+
+    if (m_auraModifiersGroup[unitMod][TOTAL_PCT] <= 0.0f)
+        return 0.0f;
+
+    float value  = m_auraModifiersGroup[unitMod][BASE_VALUE];
+    value += m_auraModifiersGroup[unitMod][BASE_EXCLUSIVE];
+    value *= m_auraModifiersGroup[unitMod][BASE_PCT];
+    value += m_auraModifiersGroup[unitMod][TOTAL_VALUE];
+    value *= m_auraModifiersGroup[unitMod][TOTAL_PCT];
+
+    return value;
+}
+
+SpellSchools Unit::GetSpellSchoolByAuraGroup(UnitMods unitMod) const
+{
+    SpellSchools school = SPELL_SCHOOL_NORMAL;
+
+    switch (unitMod)
+    {
+        case UNIT_MOD_RESISTANCE_HOLY:     school = SPELL_SCHOOL_HOLY;          break;
+        case UNIT_MOD_RESISTANCE_FIRE:     school = SPELL_SCHOOL_FIRE;          break;
+        case UNIT_MOD_RESISTANCE_NATURE:   school = SPELL_SCHOOL_NATURE;        break;
+        case UNIT_MOD_RESISTANCE_FROST:    school = SPELL_SCHOOL_FROST;         break;
+        case UNIT_MOD_RESISTANCE_SHADOW:   school = SPELL_SCHOOL_SHADOW;        break;
+        case UNIT_MOD_RESISTANCE_ARCANE:   school = SPELL_SCHOOL_ARCANE;        break;
+
+        default:
+            break;
+    }
+
+    return school;
+}
+
+Stats Unit::GetStatByAuraGroup(UnitMods unitMod) const
+{
+    Stats stat = STAT_STRENGTH;
+
+    switch (unitMod)
+    {
+        case UNIT_MOD_STAT_STRENGTH:    stat = STAT_STRENGTH;      break;
+        case UNIT_MOD_STAT_AGILITY:     stat = STAT_AGILITY;       break;
+        case UNIT_MOD_STAT_STAMINA:     stat = STAT_STAMINA;       break;
+        case UNIT_MOD_STAT_INTELLECT:   stat = STAT_INTELLECT;     break;
+        case UNIT_MOD_STAT_SPIRIT:      stat = STAT_SPIRIT;        break;
+
+        default:
+            break;
+    }
+
+    return stat;
+}
+
+Powers Unit::GetPowerTypeByAuraGroup(UnitMods unitMod) const
+{
+    switch (unitMod)
+    {
+        case UNIT_MOD_MANA:       return POWER_MANA;
+        case UNIT_MOD_RAGE:       return POWER_RAGE;
+        case UNIT_MOD_FOCUS:      return POWER_FOCUS;
+        case UNIT_MOD_ENERGY:     return POWER_ENERGY;
+        case UNIT_MOD_HAPPINESS:  return POWER_HAPPINESS;
+        default:                  return POWER_MANA;
+    }
+}
+
+float Unit::GetTotalAttackPowerValue(WeaponAttackType attType) const
+{
+    if (attType == RANGED_ATTACK)
+    {
+        int32 ap = GetInt32Value(UNIT_FIELD_RANGED_ATTACK_POWER) + GetInt32Value(UNIT_FIELD_RANGED_ATTACK_POWER_MODS);
+        if (ap < 0)
+            return 0.0f;
+        return ap * (1.0f + GetFloatValue(UNIT_FIELD_RANGED_ATTACK_POWER_MULTIPLIER));
+    }
+    else
+    {
+        int32 ap = GetInt32Value(UNIT_FIELD_ATTACK_POWER) + GetInt32Value(UNIT_FIELD_ATTACK_POWER_MODS);
+        if (ap < 0)
+            return 0.0f;
+        return ap * (1.0f + GetFloatValue(UNIT_FIELD_ATTACK_POWER_MULTIPLIER));
+    }
+}
+
+float Unit::GetWeaponDamageRange(WeaponAttackType attType , WeaponDamageRange type) const
+{
+    if (attType == OFF_ATTACK && !haveOffhandWeapon())
+        return 0.0f;
+
+    return m_weaponDamage[attType][type];
+}
+
+void Unit::SetLevel(uint32 lvl)
+{
+    SetUInt32Value(UNIT_FIELD_LEVEL, lvl);
+
+    // group update
+    if ((GetTypeId() == TYPEID_PLAYER) && ((Player*)this)->GetGroup())
+        ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_LEVEL);
+}
+
+void Unit::SetHealth(uint32 val)
+{
+    uint32 maxHealth = GetMaxHealth();
+    if (maxHealth < val)
+        val = maxHealth;
+
+    SetUInt32Value(UNIT_FIELD_HEALTH, val);
+
+    // group update
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        if (((Player*)this)->GetGroup())
+            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_CUR_HP);
+    }
+    else if (((Creature*)this)->IsPet())
+    {
+        Pet* pet = ((Pet*)this);
+        if (pet->isControlled())
+        {
+            Unit* owner = GetOwner();
+            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
+                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_CUR_HP);
+        }
+    }
+}
+
+void Unit::SetMaxHealth(uint32 val)
+{
+    uint32 health = GetHealth();
+    SetUInt32Value(UNIT_FIELD_MAXHEALTH, val);
+
+    // group update
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        if (((Player*)this)->GetGroup())
+            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_MAX_HP);
+    }
+    else if (((Creature*)this)->IsPet())
+    {
+        Pet* pet = ((Pet*)this);
+        if (pet->isControlled())
+        {
+            Unit* owner = GetOwner();
+            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
+                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_MAX_HP);
+        }
+    }
+
+    if (val < health)
+        SetHealth(val);
+}
+
+void Unit::SetHealthPercent(float percent)
+{
+    uint32 newHealth = GetMaxHealth() * percent / 100.0f;
+    SetHealth(newHealth);
+}
+
+void Unit::SetPower(Powers power, uint32 val)
+{
+    if (GetPower(power) == val)
+        return;
+
+    uint32 maxPower = GetMaxPower(power);
+    if (maxPower < val)
+        val = maxPower;
+
+    SetStatInt32Value(UNIT_FIELD_POWER1 + power, val);
+
+    // group update
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        if (((Player*)this)->GetGroup())
+            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_CUR_POWER);
+    }
+    else if (((Creature*)this)->IsPet())
+    {
+        Pet* pet = ((Pet*)this);
+        if (pet->isControlled())
+        {
+            Unit* owner = GetOwner();
+            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
+                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_CUR_POWER);
+        }
+
+        // Update the pet's character sheet with happiness damage bonus
+        if (pet->getPetType() == HUNTER_PET && power == POWER_HAPPINESS)
+            pet->UpdateDamagePhysical(BASE_ATTACK);
+    }
+}
+
+void Unit::SetMaxPower(Powers power, uint32 val)
+{
+    uint32 cur_power = GetPower(power);
+    SetStatInt32Value(UNIT_FIELD_MAXPOWER1 + power, val);
+
+    // group update
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        if (((Player*)this)->GetGroup())
+            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_MAX_POWER);
+    }
+    else if (((Creature*)this)->IsPet())
+    {
+        Pet* pet = ((Pet*)this);
+        if (pet->isControlled())
+        {
+            Unit* owner = GetOwner();
+            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
+                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_MAX_POWER);
+        }
+    }
+
+    if (val < cur_power)
+        SetPower(power, val);
+}
+
+void Unit::ApplyPowerMod(Powers power, uint32 val, bool apply)
+{
+    ApplyModUInt32Value(UNIT_FIELD_POWER1 + power, val, apply);
+
+    // group update
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        if (((Player*)this)->GetGroup())
+            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_CUR_POWER);
+    }
+    else if (((Creature*)this)->IsPet())
+    {
+        Pet* pet = ((Pet*)this);
+        if (pet->isControlled())
+        {
+            Unit* owner = GetOwner();
+            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
+                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_CUR_POWER);
+        }
+    }
+}
+
+void Unit::ApplyMaxPowerMod(Powers power, uint32 val, bool apply)
+{
+    ApplyModUInt32Value(UNIT_FIELD_MAXPOWER1 + power, val, apply);
+
+    // group update
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        if (((Player*)this)->GetGroup())
+            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_MAX_POWER);
+    }
+    else if (((Creature*)this)->IsPet())
+    {
+        Pet* pet = ((Pet*)this);
+        if (pet->isControlled())
+        {
+            Unit* owner = GetOwner();
+            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
+                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_MAX_POWER);
+        }
+    }
+}
+
+void Unit::ApplyAuraProcTriggerDamage(Aura* aura, bool apply)
+{
+    AuraList& tAuraProcTriggerDamage = m_modAuras[SPELL_AURA_PROC_TRIGGER_DAMAGE];
+    if (apply)
+        tAuraProcTriggerDamage.push_back(aura);
+    else
+        tAuraProcTriggerDamage.remove(aura);
+}
+
+uint32 Unit::GetCreatePowers(Powers power) const
+{
+    switch (power)
+    {
+        case POWER_HEALTH:      return 0;                   // is it really should be here?
+        case POWER_MANA:        return GetCreateMana();
+        case POWER_RAGE:        return POWER_RAGE_DEFAULT;
+        case POWER_FOCUS:       return (GetTypeId() == TYPEID_PLAYER || !((Creature const*)this)->IsPet() || ((Pet const*)this)->getPetType() != HUNTER_PET ? 0 : POWER_FOCUS_DEFAULT);
+        case POWER_ENERGY:      return POWER_ENERGY_DEFAULT;
+        case POWER_HAPPINESS:   return (GetTypeId() == TYPEID_PLAYER || !((Creature const*)this)->IsPet() || ((Pet const*)this)->getPetType() != HUNTER_PET ? 0 : POWER_HAPPINESS_DEFAULT);
+    }
+
+    return 0;
+}
+
+void Unit::AddToWorld()
+{
+    Object::AddToWorld();
+    ScheduleAINotify(0);
+}
+
+void Unit::RemoveFromWorld()
+{
+    // cleanup
+    if (IsInWorld())
+    {
+        Uncharm();
+        RemoveNotOwnTrackedTargetAuras();
+        RemoveGuardians();
+        RemoveAllGameObjects();
+        RemoveAllDynObjects();
+        CleanupDeletedAuras();
+        GetViewPoint().Event_RemovedFromWorld();
+    }
+
+    Object::RemoveFromWorld();
+}
+
+void Unit::CleanupsBeforeDelete()
+{
+    if (m_uint32Values)                                     // only for fully created object
+    {
+        InterruptNonMeleeSpells(true);
+        m_Events.KillAllEvents(false);                      // non-delatable (currently casted spells) will not deleted now but it will deleted at call in Map::RemoveAllObjectsInRemoveList
+        CombatStop();
+        ClearComboPointHolders();
+        DeleteThreatList();
+        if (GetTypeId() == TYPEID_PLAYER)
+            getHostileRefManager().setOnlineOfflineState(false);
+        else
+            getHostileRefManager().deleteReferences();
+        RemoveAllAuras(AURA_REMOVE_BY_DELETE);
+    }
+    WorldObject::CleanupsBeforeDelete();
+}
+
+CharmInfo* Unit::InitCharmInfo(Unit* charm)
+{
+    delete m_charmInfo;
+    m_charmInfo = new CharmInfo(charm);
+
+    return m_charmInfo;
+}
+
+CharmInfo::CharmInfo(Unit* unit) :
+    m_unit(unit), m_ai(nullptr), m_combatData(nullptr),
+    m_CommandState(COMMAND_FOLLOW), m_reactState(REACT_PASSIVE),
+    m_petnumber(0), m_retreating(false), m_stayPosSet(false),
+    m_stayPosX(0), m_stayPosY(0), m_stayPosZ(0), m_stayPosO(0),
+    m_opener(0), m_openerMinRange(0), m_openerMaxRange(0),
+    m_unitFieldBytes2_1(0)
+{
+    for (int i = 0; i < CREATURE_MAX_SPELLS; ++i)
+        m_charmspells[i].SetActionAndType(0, ACT_DISABLED);
+}
+
+CharmInfo::~CharmInfo()
+{
+    delete m_combatData;
+    delete m_ai;
+}
+
+void CharmInfo::SetCharmState(std::string const & ainame /*= "PetAI"*/, bool withNewThreatList /*= true*/)
+{
+    if (!ainame.empty())
+        m_ai = FactorySelector::GetSpecificAI(m_unit, ainame);
+    else
+        m_ai = FactorySelector::GetSpecificAI(m_unit, "PetAI");
+
+    if (withNewThreatList)
+        m_combatData = new CombatData(m_unit);
+
+    m_unitFieldBytes2_1 = m_unit->GetByteValue(UNIT_FIELD_BYTES_2, 1);
+}
+
+void CharmInfo::ResetCharmState()
+{
+    m_unit->SetByteValue(UNIT_FIELD_BYTES_2, 1, m_unitFieldBytes2_1);
+}
+
+
+void CharmInfo::InitPetActionBar()
+{
+    // the first 3 SpellOrActions are attack, follow and stay
+    for (uint32 i = 0; i < ACTION_BAR_INDEX_PET_SPELL_START - ACTION_BAR_INDEX_START; ++i)
+        SetActionBar(ACTION_BAR_INDEX_START + i, COMMAND_ATTACK - i, ACT_COMMAND);
+
+    // middle 4 SpellOrActions are spells/special attacks/abilities
+    for (uint32 i = 0; i < ACTION_BAR_INDEX_PET_SPELL_END - ACTION_BAR_INDEX_PET_SPELL_START; ++i)
+        SetActionBar(ACTION_BAR_INDEX_PET_SPELL_START + i, 0, ACT_DISABLED);
+
+    // last 3 SpellOrActions are reactions
+    for (uint32 i = 0; i < ACTION_BAR_INDEX_END - ACTION_BAR_INDEX_PET_SPELL_END; ++i)
+        SetActionBar(ACTION_BAR_INDEX_PET_SPELL_END + i, COMMAND_ATTACK - i, ACT_REACTION);
+}
+
+void CharmInfo::InitEmptyActionBar()
+{
+    for (uint32 x = ACTION_BAR_INDEX_START + 1; x < ACTION_BAR_INDEX_END; ++x)
+        SetActionBar(x, 0, ACT_PASSIVE);
+}
+
+void CharmInfo::InitPossessCreateSpells()
+{
+    InitEmptyActionBar();                                   // charm action bar
+
+    SetActionBar(ACTION_BAR_INDEX_START, COMMAND_ATTACK, ACT_COMMAND);
+
+    if (m_unit->GetTypeId() == TYPEID_PLAYER)               // possessed players don't have spells, keep the action bar empty
+        return;
+
+    for (uint32 x = 0; x < CREATURE_MAX_SPELLS; ++x)
+    {
+        if (IsPassiveSpell(((Creature*)m_unit)->m_spells[x]))
+            m_unit->CastSpell(m_unit, ((Creature*)m_unit)->m_spells[x], TRIGGERED_OLD_TRIGGERED);
+        else
+            AddSpellToActionBar(((Creature*)m_unit)->m_spells[x], ACT_PASSIVE);
+    }
+}
+
+void CharmInfo::InitCharmCreateSpells()
+{
+    InitPetActionBar();
+
+    SetActionBar(ACTION_BAR_INDEX_START, COMMAND_ATTACK, ACT_COMMAND);
+
+    if (m_unit->GetTypeId() == TYPEID_PLAYER)               // charmed players don't have spells
+        return;
+
+    for (uint32 x = 0; x < CREATURE_MAX_SPELLS; ++x)
+    {
+        uint32 spellId = ((Creature*)m_unit)->m_spells[x];
+
+        if (!spellId)
+        {
+            m_charmspells[x].SetActionAndType(spellId, ACT_DISABLED);
+            continue;
+        }
+
+        if (IsPassiveSpell(spellId))
+        {
+            m_unit->CastSpell(m_unit, spellId, TRIGGERED_OLD_TRIGGERED);
+            m_charmspells[x].SetActionAndType(spellId, ACT_PASSIVE);
+        }
+        else
+        {
+            m_charmspells[x].SetActionAndType(spellId, ACT_DISABLED);
+
+            ActiveStates newstate;
+            bool onlyselfcast = true;
+            SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
+
+            for (uint32 i = 0; i < 3 && onlyselfcast; ++i)  // nonexistent spell will not make any problems as onlyselfcast would be false -> break right away
+            {
+                if (spellInfo->EffectImplicitTargetA[i] != TARGET_SELF && spellInfo->EffectImplicitTargetA[i] != 0)
+                    onlyselfcast = false;
+            }
+
+            if (onlyselfcast || !IsPositiveSpell(spellId))  // only self cast and spells versus enemies are autocastable
+                newstate = ACT_DISABLED;
+            else
+                newstate = ACT_PASSIVE;
+
+            AddSpellToActionBar(spellId, newstate);
+        }
+    }
+}
+
+bool CharmInfo::AddSpellToActionBar(uint32 spellId, ActiveStates newstate)
+{
+    uint32 first_id = sSpellMgr.GetFirstSpellInChain(spellId);
+
+    // new spell rank can be already listed
+    for (uint8 i = 0; i < MAX_UNIT_ACTION_BAR_INDEX; ++i)
+    {
+        if (uint32 action = PetActionBar[i].GetAction())
+        {
+            if (PetActionBar[i].IsActionBarForSpell() && sSpellMgr.GetFirstSpellInChain(action) == first_id)
+            {
+                PetActionBar[i].SetAction(spellId);
+                return true;
+            }
+        }
+    }
+
+    // or use empty slot in other case
+    for (uint8 i = 0; i < MAX_UNIT_ACTION_BAR_INDEX; ++i)
+    {
+        if (!PetActionBar[i].GetAction() && PetActionBar[i].IsActionBarForSpell())
+        {
+            SetActionBar(i, spellId, newstate == ACT_DECIDE ? IsAutocastable(spellId) ? ACT_DISABLED : ACT_PASSIVE : newstate);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CharmInfo::RemoveSpellFromActionBar(uint32 spell_id)
+{
+    uint32 first_id = sSpellMgr.GetFirstSpellInChain(spell_id);
+
+    for (uint8 i = 0; i < MAX_UNIT_ACTION_BAR_INDEX; ++i)
+    {
+        if (uint32 action = PetActionBar[i].GetAction())
+        {
+            if (PetActionBar[i].IsActionBarForSpell() && sSpellMgr.GetFirstSpellInChain(action) == first_id)
+            {
+                SetActionBar(i, 0, ACT_DISABLED);
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+void CharmInfo::ToggleCreatureAutocast(uint32 spellid, bool apply)
+{
+    if (IsPassiveSpell(spellid))
+        return;
+
+    for (uint32 x = 0; x < CREATURE_MAX_SPELLS; ++x)
+        if (spellid == m_charmspells[x].GetAction())
+            m_charmspells[x].SetType(apply ? ACT_ENABLED : ACT_DISABLED);
+}
+
+void CharmInfo::SetPetNumber(uint32 petnumber, bool statwindow)
+{
+    m_petnumber = petnumber;
+    if (statwindow)
+        m_unit->SetUInt32Value(UNIT_FIELD_PETNUMBER, m_petnumber);
+    else
+        m_unit->SetUInt32Value(UNIT_FIELD_PETNUMBER, 0);
+}
+
+void CharmInfo::SetCommandState(CommandStates st)
+{
+    m_CommandState = st;
+
+    switch (st)
+    {
+        case COMMAND_STAY:
+            SetIsRetreating();
+            SetStayPosition(true);
+            SetSpellOpener();
+            break;
+
+        case COMMAND_FOLLOW:
+            SetStayPosition();
+            SetSpellOpener();
+            break;
+
+        default:
+            break;
+    }
+}
+
+void CharmInfo::LoadPetActionBar(const std::string& data)
+{
+    InitPetActionBar();
+
+    Tokens tokens = StrSplit(data, " ");
+
+    if (tokens.size() != (ACTION_BAR_INDEX_END - ACTION_BAR_INDEX_START) * 2)
+        return;                                             // non critical, will reset to default
+
+    int index;
+    Tokens::iterator iter;
+    for (iter = tokens.begin(), index = ACTION_BAR_INDEX_START; index < ACTION_BAR_INDEX_END; ++iter, ++index)
+    {
+        // use unsigned cast to avoid sign negative format use at long-> ActiveStates (int) conversion
+        uint8 type  = (uint8)std::stoul((*iter).c_str());
+        ++iter;
+        uint32 action = std::stoul((*iter).c_str());
+
+        PetActionBar[index].SetActionAndType(action, ActiveStates(type));
+
+        // check correctness
+        if (PetActionBar[index].IsActionBarForSpell())
+        {
+            SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(PetActionBar[index].GetAction());
+            if (!spellInfo)
+                SetActionBar(index, 0, ACT_DISABLED);
+            else if (!IsAutocastable(spellInfo))
+                SetActionBar(index, PetActionBar[index].GetAction(), ACT_PASSIVE);
+        }
+    }
+}
+
+void CharmInfo::BuildActionBar(WorldPacket& data) const
+{
+    for (uint32 i = 0; i < MAX_UNIT_ACTION_BAR_INDEX; ++i)
+        data << uint32(PetActionBar[i].packedData);
+}
+
+void CharmInfo::SetSpellAutocast(uint32 spell_id, bool state)
+{
+    for (int i = 0; i < MAX_UNIT_ACTION_BAR_INDEX; ++i)
+    {
+        if (spell_id == PetActionBar[i].GetAction() && PetActionBar[i].IsActionBarForSpell())
+        {
+            PetActionBar[i].SetType(state ? ACT_ENABLED : ACT_DISABLED);
+            break;
+        }
+    }
+}
+
+void CharmInfo::SetStayPosition(bool stay)
+{
+    if (stay)
+    {
+        m_stayPosX = m_unit->GetPositionX();
+        m_stayPosY = m_unit->GetPositionY();
+        m_stayPosZ = m_unit->GetPositionZ();
+        m_stayPosO = m_unit->GetOrientation();
+    }
+    else
+    {
+        m_stayPosX = 0;
+        m_stayPosY = 0;
+        m_stayPosZ = 0;
+        m_stayPosO = 0;
+    }
+
+    m_stayPosSet = stay;
+}
+
+bool Unit::isFrozen() const
+{
+    return HasAuraState(AURA_STATE_FROZEN);
+}
+
+struct ProcTriggeredData
+{
+    ProcTriggeredData(SpellProcEventEntry const* _spellProcEvent, SpellAuraHolder* _triggeredByHolder)
+        : spellProcEvent(_spellProcEvent), triggeredByHolder(_triggeredByHolder)
+    {}
+    SpellProcEventEntry const* spellProcEvent;
+    SpellAuraHolder* triggeredByHolder;
+};
+
+typedef std::list< ProcTriggeredData > ProcTriggeredList;
+typedef std::list< uint32> RemoveSpellList;
+
+uint32 createProcExtendMask(SpellNonMeleeDamage* damageInfo, SpellMissInfo missCondition)
+{
+    uint32 procEx = PROC_EX_NONE;
+    // Check victim state
+    if (missCondition != SPELL_MISS_NONE)
+        switch (missCondition)
+        {
+            case SPELL_MISS_MISS:    procEx |= PROC_EX_MISS;   break;
+            case SPELL_MISS_RESIST:  procEx |= PROC_EX_RESIST; break;
+            case SPELL_MISS_DODGE:   procEx |= PROC_EX_DODGE;  break;
+            case SPELL_MISS_PARRY:   procEx |= PROC_EX_PARRY;  break;
+            case SPELL_MISS_BLOCK:   procEx |= PROC_EX_BLOCK;  break;
+            case SPELL_MISS_EVADE:   procEx |= PROC_EX_EVADE;  break;
+            case SPELL_MISS_IMMUNE:  procEx |= PROC_EX_IMMUNE; break;
+            case SPELL_MISS_IMMUNE2: procEx |= PROC_EX_IMMUNE; break;
+            case SPELL_MISS_DEFLECT: procEx |= PROC_EX_DEFLECT; break;
+            case SPELL_MISS_ABSORB:  procEx |= PROC_EX_ABSORB; break;
+            case SPELL_MISS_REFLECT: procEx |= PROC_EX_REFLECT; break;
+            default:
+                break;
+        }
+    else
+    {
+        // On block
+        if (damageInfo->blocked)
+            procEx |= PROC_EX_BLOCK;
+        // On absorb
+        if (damageInfo->absorb)
+            procEx |= PROC_EX_ABSORB;
+        // On crit
+        if (damageInfo->HitInfo & SPELL_HIT_TYPE_CRIT)
+            procEx |= PROC_EX_CRITICAL_HIT;
+        else
+            procEx |= PROC_EX_NORMAL_HIT;
+    }
+    return procEx;
+}
+
+void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* pTarget, uint32 procFlag, uint32 procExtra, WeaponAttackType attType, SpellEntry const* procSpell, uint32 damage)
+{
+    // For melee/ranged based attack need update skills and set some Aura states
+    if (procFlag & MELEE_BASED_TRIGGER_MASK)
+    {
+        // Update skills here for players
+        if (GetTypeId() == TYPEID_PLAYER)
+        {
+            // On melee based hit/miss/resist need update skill (for victim and attacker)
+            if (procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_MISS | PROC_EX_RESIST))
+            {
+                if (pTarget->GetTypeId() != TYPEID_PLAYER && pTarget->GetCreatureType() != CREATURE_TYPE_CRITTER)
+                    ((Player*)this)->UpdateCombatSkills(pTarget, attType, isVictim);
+            }
+            // Update defence if player is victim and parry/dodge/block
+            if (isVictim && procExtra & (PROC_EX_DODGE | PROC_EX_PARRY | PROC_EX_BLOCK))
+                ((Player*)this)->UpdateDefense();
+        }
+        // If exist crit/parry/dodge/block need update aura state (for victim and attacker)
+        if (procExtra & (PROC_EX_CRITICAL_HIT | PROC_EX_PARRY | PROC_EX_DODGE | PROC_EX_BLOCK))
+        {
+            // for victim
+            if (isVictim)
+            {
+                // if victim and dodge attack
+                if (procExtra & PROC_EX_DODGE)
+                {
+                    // Update AURA_STATE on dodge
+                    if (getClass() != CLASS_ROGUE) // skip Rogue Riposte
+                    {
+                        ModifyAuraState(AURA_STATE_DEFENSE, true);
+                        StartReactiveTimer(REACTIVE_DEFENSE);
+                    }
+                }
+                // if victim and parry attack
+                if (procExtra & PROC_EX_PARRY)
+                {
+                    // For Hunters only Counterattack (skip Mongoose bite)
+                    if (getClass() == CLASS_HUNTER)
+                    {
+                        ModifyAuraState(AURA_STATE_HUNTER_PARRY, true);
+                        StartReactiveTimer(REACTIVE_HUNTER_PARRY);
+                    }
+                    else
+                    {
+                        ModifyAuraState(AURA_STATE_DEFENSE, true);
+                        StartReactiveTimer(REACTIVE_DEFENSE);
+                    }
+                }
+                // if and victim block attack
+                if (procExtra & PROC_EX_BLOCK)
+                {
+                    ModifyAuraState(AURA_STATE_DEFENSE, true);
+                    StartReactiveTimer(REACTIVE_DEFENSE);
+                }
+            }
+            else // For attacker
+            {
+                // Overpower on victim dodge
+                if (procExtra & PROC_EX_DODGE && GetTypeId() == TYPEID_PLAYER && getClass() == CLASS_WARRIOR)
+                {
+                    ((Player*)this)->AddComboPoints(pTarget, 1);
+                    StartReactiveTimer(REACTIVE_OVERPOWER);
+                }
+                // Enable AURA_STATE_CRIT on crit
+                if (procExtra & PROC_EX_CRITICAL_HIT)
+                {
+                    ModifyAuraState(AURA_STATE_CRIT, true);
+                    StartReactiveTimer(REACTIVE_CRIT);
+                    if (getClass() == CLASS_HUNTER)
+                    {
+                        ModifyAuraState(AURA_STATE_HUNTER_CRIT_STRIKE, true);
+                        StartReactiveTimer(REACTIVE_HUNTER_CRIT);
+                    }
+                }
+            }
+        }
+    }
+
+    RemoveSpellList removedSpells;
+    ProcTriggeredList procTriggered;
+    // Fill procTriggered list
+    for (SpellAuraHolderMap::const_iterator itr = GetSpellAuraHolderMap().begin(); itr != GetSpellAuraHolderMap().end(); ++itr)
+    {
+        // skip deleted auras (possible at recursive triggered call
+        if (itr->second->GetState() != SPELLAURAHOLDER_STATE_READY || itr->second->IsDeleted())
+            continue;
+
+        SpellProcEventEntry const* spellProcEvent = nullptr;
+        if (!IsTriggeredAtSpellProcEvent(pTarget, itr->second, procSpell, procFlag, procExtra, attType, isVictim, spellProcEvent))
+            continue;
+
+        itr->second->SetInUse(true);                        // prevent holder deletion
+        procTriggered.push_back(ProcTriggeredData(spellProcEvent, itr->second));
+    }
+
+    // Nothing found
+    if (procTriggered.empty())
+        return;
+
+    // Handle effects proceed this time
+    for (ProcTriggeredList::const_iterator itr = procTriggered.begin(); itr != procTriggered.end(); ++itr)
+    {
+        // Some auras can be deleted in function called in this loop (except first, ofc)
+        SpellAuraHolder* triggeredByHolder = itr->triggeredByHolder;
+        if (triggeredByHolder->IsDeleted())
+            continue;
+
+        SpellProcEventEntry const* spellProcEvent = itr->spellProcEvent;
+        bool useCharges = triggeredByHolder->GetAuraCharges() > 0;
+        bool procSuccess = true;
+        bool anyAuraProc = false;
+
+        // For players set spell cooldown if need
+        uint32 cooldown = 0;
+        if (GetTypeId() == TYPEID_PLAYER && spellProcEvent && spellProcEvent->cooldown)
+            cooldown = spellProcEvent->cooldown;
+
+        for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+        {
+            Aura* triggeredByAura = triggeredByHolder->GetAuraByEffectIndex(SpellEffectIndex(i));
+            if (!triggeredByAura)
+                continue;
+
+            Modifier* auraModifier = triggeredByAura->GetModifier();
+
+            if (procSpell)
+            {
+                if (spellProcEvent)
+                {
+                    if (spellProcEvent->spellFamilyMask[i])
+                    {
+                        if (!procSpell->IsFitToFamilyMask(spellProcEvent->spellFamilyMask[i]))
+                            continue;
+                    }
+                    // don't check dbc FamilyFlags if schoolMask exists
+                    else if (!triggeredByAura->CanProcFrom(procSpell, spellProcEvent->procEx, procExtra, damage != 0, !spellProcEvent->schoolMask))
+                        continue;
+                }
+                else if (!triggeredByAura->CanProcFrom(procSpell, PROC_EX_NONE, procExtra, damage != 0, true))
+                    continue;
+            }
+
+            SpellAuraProcResult procResult = (*this.*AuraProcHandler[auraModifier->m_auraname])(pTarget, damage, triggeredByAura, procSpell, procFlag, procExtra, cooldown);
+            switch (procResult)
+            {
+                case SPELL_AURA_PROC_CANT_TRIGGER:
+                    continue;
+                case SPELL_AURA_PROC_FAILED:
+                    procSuccess = false;
+                    break;
+                case SPELL_AURA_PROC_OK:
+                    break;
+            }
+
+            anyAuraProc = true;
+        }
+
+        // Remove charge (aura can be removed by triggers)
+        if (useCharges && procSuccess && anyAuraProc && !triggeredByHolder->IsDeleted())
+        {
+            // If last charge dropped add spell to remove list
+            if (triggeredByHolder->DropAuraCharge())
+                removedSpells.push_back(triggeredByHolder->GetId());
+        }
+
+        triggeredByHolder->SetInUse(false);
+    }
+
+    if (!removedSpells.empty())
+    {
+        // Sort spells and remove duplicates
+        removedSpells.sort();
+        removedSpells.unique();
+        // Remove auras from removedAuras
+        for (RemoveSpellList::const_iterator i = removedSpells.begin(); i != removedSpells.end(); ++i)
+            RemoveAurasDueToSpell(*i);
+    }
+}
+
+SpellSchoolMask Unit::GetMeleeDamageSchoolMask() const
+{
+    return SPELL_SCHOOL_MASK_NORMAL;
+}
+
+Player* Unit::GetSpellModOwner() const
+{
+    if (GetTypeId() == TYPEID_PLAYER)
+        return (Player*)this;
+    if (((Creature*)this)->IsPet() || ((Creature*)this)->IsTotem())
+    {
+        Unit* owner = GetOwner();
+        if (owner && owner->GetTypeId() == TYPEID_PLAYER)
+            return (Player*)owner;
+    }
+    return nullptr;
+}
+
+///----------Pet responses methods-----------------
+void Unit::SendPetActionFeedback(uint8 msg) const
+{
+    Unit* owner = GetOwner();
+    if (!owner || owner->GetTypeId() != TYPEID_PLAYER)
+        return;
+
+    WorldPacket data(SMSG_PET_ACTION_FEEDBACK, 1);
+    data << uint8(msg);
+    ((Player*)owner)->GetSession()->SendPacket(data);
+}
+
+void Unit::SendPetTalk(uint32 pettalk) const
+{
+    Unit* owner = GetOwner();
+    if (!owner || owner->GetTypeId() != TYPEID_PLAYER)
+        return;
+
+    WorldPacket data(SMSG_PET_ACTION_SOUND, 8 + 4);
+    data << GetObjectGuid();
+    data << uint32(pettalk);
+    ((Player*)owner)->GetSession()->SendPacket(data);
+}
+
+void Unit::SendPetAIReaction() const
+{
+    Unit* owner = GetOwner();
+    if (!owner || owner->GetTypeId() != TYPEID_PLAYER)
+        return;
+
+    WorldPacket data(SMSG_AI_REACTION, 8 + 4);
+    data << GetObjectGuid();
+    data << uint32(AI_REACTION_HOSTILE);
+    ((Player*)owner)->GetSession()->SendPacket(data);
+}
+
+///----------End of Pet responses methods----------
+
+void Unit::StopMoving(bool forceSendStop /*=false*/)
+{
+    if (IsStopped() && !forceSendStop)
+        return;
+
+    clearUnitState(UNIT_STAT_MOVING);
+
+    // not need send any packets if not in world
+    if (!IsInWorld())
+        return;
+
+    Movement::MoveSplineInit init(*this);
+    init.Stop(forceSendStop);
+}
+
+void Unit::InterruptMoving(bool forceSendStop /*=false*/)
+{
+    bool isMoving = false;
+
+    if (!movespline->Finalized())
+    {
+        Movement::Location loc = movespline->ComputePosition();
+        movespline->_Interrupt();
+        Relocate(loc.x, loc.y, loc.z, loc.orientation);
+        isMoving = true;
+    }
+
+    StopMoving(forceSendStop || isMoving);
+}
+
+void Unit::SetImmobilizedState(bool apply, bool stun)
+{
+    const uint32 immobilized = (UNIT_STAT_ROOT | UNIT_STAT_STUNNED);
+    const uint32 state = stun ? UNIT_STAT_STUNNED : UNIT_STAT_ROOT;
+    const Unit* charmer = GetCharmer();
+    const bool player = ((charmer ? charmer : this)->GetTypeId() == TYPEID_PLAYER);
+    if (apply)
+    {
+        addUnitState(state);
+        if (!player)
+            StopMoving();
+        else
+        {
+            // Clear unit movement flags
+            m_movementInfo.SetMovementFlags(MOVEFLAG_NONE);
+            if (stun)
+                SetStandState(UNIT_STAND_STATE_STAND); // in 1.5 client
+            SetRoot(true);
+        }
+    }
+    else
+    {
+        clearUnitState(state);
+        // Prevent giving ability to move if more immobilizers are active
+        if (!hasUnitState(immobilized) && (player || m_movementInfo.HasMovementFlag(MOVEFLAG_ROOT)))
+            SetRoot(false);
+    }
+}
+
+void Unit::SetFeared(bool apply, ObjectGuid casterGuid, uint32 spellID, uint32 time)
+{
+    SetIncapacitatedState(apply, UNIT_FLAG_FLEEING, casterGuid, spellID, time);
+}
+
+void Unit::SetConfused(bool apply, ObjectGuid casterGuid, uint32 spellID)
+{
+    SetIncapacitatedState(apply, UNIT_FLAG_CONFUSED, casterGuid, spellID);
+}
+
+void Unit::SetStunned(bool apply, ObjectGuid casterGuid, uint32 spellID)
+{
+    SetIncapacitatedState(apply, UNIT_FLAG_STUNNED, casterGuid, spellID);
+}
+
+void Unit::SetIncapacitatedState(bool apply, uint32 state, ObjectGuid casterGuid, uint32 spellID, uint32 time)
+{
+    // We are interested only in a particular subset of flags:
+    const uint32 filter = (UNIT_FLAG_STUNNED | UNIT_FLAG_CONFUSED | UNIT_FLAG_FLEEING);
+    if (!state || !(state & filter) || (state & ~filter))
+        return;
+
+    Player* controller = GetCharmerOrOwnerPlayerOrPlayerItself();
+    const bool control = controller ? controller->IsClientControl(this) : false;
+    const bool movement = (state != UNIT_FLAG_STUNNED);
+    const bool stun = !!(state & UNIT_FLAG_STUNNED);
+    const bool fleeing = !!(state & UNIT_FLAG_FLEEING);
+
+    if (apply)
+    {
+        if (fleeing && HasAuraType(SPELL_AURA_PREVENTS_FLEEING))
+        {
+            if (state == UNIT_FLAG_FLEEING)
+                return;
+            else
+                state &= ~UNIT_FLAG_FLEEING;
+        }
+        SetFlag(UNIT_FIELD_FLAGS, state);
+    }
+    else
+        RemoveFlag(UNIT_FIELD_FLAGS, state);
+
+    if (movement)
+        GetMotionMaster()->MovementExpired(false);
+    if (apply)
+        CastStop(GetObjectGuid() == casterGuid ? spellID : 0);
+
+    if (GetTypeId() == TYPEID_UNIT)
+    {
+        if (HasFlag(UNIT_FIELD_FLAGS, filter))
+        {
+            if (!GetTargetGuid().IsEmpty()) // Incapacitated creature loses its target
+                SetTargetGuid(ObjectGuid());
+        }
+        else if (isAlive())
+        {
+            if (Unit* victim = getVictim())
+            {
+                SetTargetGuid(victim->GetObjectGuid());  // Restore target
+                if (movement)
+                    GetMotionMaster()->MoveChase(victim); // Restore movement generator
+            }
+            else if (movement)
+                GetMotionMaster()->Initialize(); // Reset movement generator
+
+            if (!apply && fleeing)
+            {
+                // Attack the caster if can on fear expiration
+                if (Unit* caster = IsInWorld() ? GetMap()->GetUnit(casterGuid) : nullptr)
+                    ((Creature*)this)->AttackedBy(caster);
+            }
+        }
+    }
+
+    // Update stun if required:
+    if (stun)
+        SetImmobilizedState(apply, true);
+
+    if (!movement)
+        return;
+
+    // Check if we should return or remove player control after change
+    if (controller)
+    {
+        const bool remove = !controller->IsClientControl(this);
+        if (control && remove)
+            controller->SetClientControl(this, 0);
+        else if (!control && !remove)
+            controller->SetClientControl(this, 1);
+    }
+
+    // Update incapacitated movement if required:
+    if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_CONFUSED))
+    {
+        StopMoving(true);
+        GetMotionMaster()->MoveConfused();
+    }
+    else if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_FLEEING))
+    {
+        StopMoving(true);
+        GetMotionMaster()->MoveFleeing(IsInWorld() ?  GetMap()->GetUnit(casterGuid) : nullptr, time);
+    }
+}
+
+void Unit::SetFeignDeath(bool apply, ObjectGuid casterGuid /*= ObjectGuid()*/)
+{
+    if (apply)
+    {
+        /*
+        WorldPacket data(SMSG_FEIGN_DEATH_RESISTED, 9);
+        data<<GetGUID();
+        data<<uint8(0);
+        SendMessageToSet(data,true);
+        */
+
+        if (GetTypeId() != TYPEID_PLAYER)
+            StopMoving();
+        else
+            ((Player*)this)->m_movementInfo.SetMovementFlags(MOVEFLAG_NONE);
+
+        // blizz like 2.0.x
+        SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNK_29);
+        // blizz like 2.0.x
+        SetFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
+        // blizz like 2.0.x
+        SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
+
+        addUnitState(UNIT_STAT_DIED);
+        CombatStop();
+        RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_IMMUNE_OR_LOST_SELECTION);
+
+        // prevent interrupt message
+        if (casterGuid == GetObjectGuid())
+            FinishSpell(CURRENT_GENERIC_SPELL, false);
+        InterruptNonMeleeSpells(true);
+        getHostileRefManager().deleteReferences();
+    }
+    else
+    {
+        /*
+        WorldPacket data(SMSG_FEIGN_DEATH_RESISTED, 9);
+        data<<GetGUID();
+        data<<uint8(1);
+        SendMessageToSet(data,true);
+        */
+        // blizz like 2.0.x
+        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNK_29);
+        // blizz like 2.0.x
+        RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
+        // blizz like 2.0.x
+        RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
+
+        clearUnitState(UNIT_STAT_DIED);
+
+        if (GetTypeId() != TYPEID_PLAYER && isAlive())
+        {
+            // restore appropriate movement generator
+            if (getVictim())
+                GetMotionMaster()->MoveChase(getVictim());
+            else
+                GetMotionMaster()->Initialize();
+        }
+    }
+}
+
+bool Unit::IsSitState() const
+{
+    uint8 s = getStandState();
+    return
+        s == UNIT_STAND_STATE_SIT_CHAIR        || s == UNIT_STAND_STATE_SIT_LOW_CHAIR  ||
+        s == UNIT_STAND_STATE_SIT_MEDIUM_CHAIR || s == UNIT_STAND_STATE_SIT_HIGH_CHAIR ||
+        s == UNIT_STAND_STATE_SIT;
+}
+
+bool Unit::IsStandState() const
+{
+    uint8 s = getStandState();
+    return !IsSitState() && s != UNIT_STAND_STATE_SLEEP && s != UNIT_STAND_STATE_KNEEL;
+}
+
+void Unit::SetStandState(uint8 state)
+{
+    SetByteValue(UNIT_FIELD_BYTES_1, 0, state);
+
+    if (IsStandState())
+        RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_SEATED);
+
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        WorldPacket data(SMSG_STANDSTATE_UPDATE, 1);
+        data << (uint8)state;
+        ((Player*)this)->GetSession()->SendPacket(data);
+    }
+}
+
+bool Unit::IsPolymorphed() const
+{
+    return IsSpellMagePolymorph(getTransForm());
+}
+
+void Unit::SetDisplayId(uint32 modelId)
+{
+    SetUInt32Value(UNIT_FIELD_DISPLAYID, modelId);
+
+    UpdateModelData();
+
+    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsPet())
+    {
+        Pet* pet = ((Pet*)this);
+        if (!pet->isControlled())
+            return;
+        Unit* owner = GetOwner();
+        if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
+            ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_MODEL_ID);
+    }
+}
+
+void Unit::UpdateModelData()
+{
+    if (CreatureModelInfo const* modelInfo = sObjectMgr.GetCreatureModelInfo(GetDisplayId()))
+    {
+        // we expect values in database to be relative to scale = 1.0
+        SetFloatValue(UNIT_FIELD_BOUNDINGRADIUS, GetObjectScale() * modelInfo->bounding_radius);
+
+        // never actually update combat_reach for player, it's always the same. Below player case is for initialization
+        if (GetTypeId() == TYPEID_PLAYER)
+            SetFloatValue(UNIT_FIELD_COMBATREACH, 1.5f);
+        else
+            SetFloatValue(UNIT_FIELD_COMBATREACH, GetObjectScale() * modelInfo->combat_reach);
+    }
+}
+
+void Unit::ClearComboPointHolders()
+{
+    while (!m_ComboPointHolders.empty())
+    {
+        uint32 lowguid = *m_ComboPointHolders.begin();
+
+        Player* plr = sObjectMgr.GetPlayer(ObjectGuid(HIGHGUID_PLAYER, lowguid));
+        if (plr && plr->GetComboTargetGuid() == GetObjectGuid())// recheck for safe
+            plr->ClearComboPoints();                        // remove also guid from m_ComboPointHolders;
+        else
+            m_ComboPointHolders.erase(lowguid);             // or remove manually
+    }
+}
+
+void Unit::ClearAllReactives()
+{
+    for (int i = 0; i < MAX_REACTIVE; ++i)
+        m_reactiveTimer[i] = 0;
+
+    if (HasAuraState(AURA_STATE_DEFENSE))
+        ModifyAuraState(AURA_STATE_DEFENSE, false);
+    if (getClass() == CLASS_HUNTER && HasAuraState(AURA_STATE_HUNTER_PARRY))
+        ModifyAuraState(AURA_STATE_HUNTER_PARRY, false);
+    if (HasAuraState(AURA_STATE_CRIT))
+        ModifyAuraState(AURA_STATE_CRIT, false);
+    if (getClass() == CLASS_HUNTER && HasAuraState(AURA_STATE_HUNTER_CRIT_STRIKE))
+        ModifyAuraState(AURA_STATE_HUNTER_CRIT_STRIKE, false);
+
+    if (getClass() == CLASS_WARRIOR && GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->ClearComboPoints();
+}
+
+void Unit::UpdateReactives(uint32 p_time)
+{
+    for (int i = 0; i < MAX_REACTIVE; ++i)
+    {
+        ReactiveType reactive = ReactiveType(i);
+
+        if (!m_reactiveTimer[reactive])
+            continue;
+
+        if (m_reactiveTimer[reactive] <= p_time)
+        {
+            m_reactiveTimer[reactive] = 0;
+
+            switch (reactive)
+            {
+                case REACTIVE_DEFENSE:
+                    if (HasAuraState(AURA_STATE_DEFENSE))
+                        ModifyAuraState(AURA_STATE_DEFENSE, false);
+                    break;
+                case REACTIVE_HUNTER_PARRY:
+                    if (getClass() == CLASS_HUNTER && HasAuraState(AURA_STATE_HUNTER_PARRY))
+                        ModifyAuraState(AURA_STATE_HUNTER_PARRY, false);
+                    break;
+                case REACTIVE_CRIT:
+                    if (HasAuraState(AURA_STATE_CRIT))
+                        ModifyAuraState(AURA_STATE_CRIT, false);
+                    break;
+                case REACTIVE_HUNTER_CRIT:
+                    if (getClass() == CLASS_HUNTER && HasAuraState(AURA_STATE_HUNTER_CRIT_STRIKE))
+                        ModifyAuraState(AURA_STATE_HUNTER_CRIT_STRIKE, false);
+                    break;
+                case REACTIVE_OVERPOWER:
+                    if (getClass() == CLASS_WARRIOR && GetTypeId() == TYPEID_PLAYER)
+                        ((Player*)this)->ClearComboPoints();
+                    break;
+                default:
+                    break;
+            }
+        }
+        else
+        {
+            m_reactiveTimer[reactive] -= p_time;
+        }
+    }
+}
+
+Unit* Unit::SelectRandomUnfriendlyTarget(Unit* except /*= nullptr*/, float radius /*= ATTACK_DISTANCE*/) const
+{
+    std::list<Unit*> targets;
+
+    MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck u_check(this, radius);
+    MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(targets, u_check);
+    Cell::VisitAllObjects(this, searcher, radius);
+
+    // remove current target
+    if (except)
+        targets.remove(except);
+
+    // remove not LoS targets
+    for (std::list<Unit*>::iterator tIter = targets.begin(); tIter != targets.end();)
+    {
+        if (!IsWithinLOSInMap(*tIter))
+        {
+            std::list<Unit*>::iterator tIter2 = tIter;
+            ++tIter;
+            targets.erase(tIter2);
+        }
+        else
+            ++tIter;
+    }
+
+    // no appropriate targets
+    if (targets.empty())
+        return nullptr;
+
+    // select random
+    uint32 rIdx = urand(0, targets.size() - 1);
+    std::list<Unit*>::const_iterator tcIter = targets.begin();
+    for (uint32 i = 0; i < rIdx; ++i)
+        ++tcIter;
+
+    return *tcIter;
+}
+
+Unit* Unit::SelectRandomFriendlyTarget(Unit* except /*= nullptr*/, float radius /*= ATTACK_DISTANCE*/) const
+{
+    std::list<Unit*> targets;
+
+    MaNGOS::AnyFriendlyUnitInObjectRangeCheck u_check(this, radius);
+    MaNGOS::UnitListSearcher<MaNGOS::AnyFriendlyUnitInObjectRangeCheck> searcher(targets, u_check);
+
+    Cell::VisitAllObjects(this, searcher, radius);
+
+    // remove current target
+    if (except)
+        targets.remove(except);
+
+    // remove not LoS targets
+    for (std::list<Unit*>::iterator tIter = targets.begin(); tIter != targets.end();)
+    {
+        if (!IsWithinLOSInMap(*tIter))
+        {
+            std::list<Unit*>::iterator tIter2 = tIter;
+            ++tIter;
+            targets.erase(tIter2);
+        }
+        else
+            ++tIter;
+    }
+
+    // no appropriate targets
+    if (targets.empty())
+        return nullptr;
+
+    // select random
+    uint32 rIdx = urand(0, targets.size() - 1);
+    std::list<Unit*>::const_iterator tcIter = targets.begin();
+    for (uint32 i = 0; i < rIdx; ++i)
+        ++tcIter;
+
+    return *tcIter;
+}
+
+bool Unit::hasNegativeAuraWithInterruptFlag(uint32 flag) const
+{
+    for (SpellAuraHolderMap::const_iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end(); ++iter)
+    {
+        if (!iter->second->IsPositive() && iter->second->GetSpellProto()->AuraInterruptFlags & flag)
+            return true;
+    }
+    return false;
+}
+
+void Unit::ApplyAttackTimePercentMod(WeaponAttackType att, float val, bool apply)
+{
+    if (val > 0)
+    {
+        ApplyPercentModFloatVar(m_modAttackSpeedPct[att], val, !apply);
+        ApplyPercentModFloatValue(UNIT_FIELD_BASEATTACKTIME + att, val, !apply);
+    }
+    else
+    {
+        ApplyPercentModFloatVar(m_modAttackSpeedPct[att], -val, apply);
+        ApplyPercentModFloatValue(UNIT_FIELD_BASEATTACKTIME + att, -val, apply);
+    }
+}
+
+void Unit::ApplyCastTimePercentMod(float val, bool apply)
+{
+    if (val > 0)
+        ApplyPercentModFloatValue(UNIT_MOD_CAST_SPEED, val, !apply);
+    else
+        ApplyPercentModFloatValue(UNIT_MOD_CAST_SPEED, -val, apply);
+}
+
+void Unit::UpdateAuraForGroup(uint8 slot)
+{
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        Player* player = (Player*)this;
+        if (player->GetGroup())
+        {
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_AURAS);
+            player->SetAuraUpdateMask(slot);
+        }
+    }
+    else if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsPet())
+    {
+        Pet* pet = ((Pet*)this);
+        if (pet->isControlled())
+        {
+            Unit* owner = GetOwner();
+            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
+            {
+                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_AURAS);
+                pet->SetAuraUpdateMask(slot);
+            }
+        }
+    }
+}
+
+float Unit::GetAPMultiplier(WeaponAttackType attType, bool normalized)
+{
+    if (!normalized || GetTypeId() != TYPEID_PLAYER)
+        return float(GetAttackTime(attType)) / 1000.0f;
+
+    Item* Weapon = ((Player*)this)->GetWeaponForAttack(attType, true, false);
+    if (!Weapon)
+        return 2.4f;                                        // fist attack
+
+    switch (Weapon->GetProto()->InventoryType)
+    {
+        case INVTYPE_2HWEAPON:
+            return 3.3f;
+        case INVTYPE_RANGED:
+        case INVTYPE_RANGEDRIGHT:
+        case INVTYPE_THROWN:
+            return 2.8f;
+        case INVTYPE_WEAPON:
+        case INVTYPE_WEAPONMAINHAND:
+        case INVTYPE_WEAPONOFFHAND:
+        default:
+            return Weapon->GetProto()->SubClass == ITEM_SUBCLASS_WEAPON_DAGGER ? 1.7f : 2.4f;
+    }
+}
+
+Aura* Unit::GetDummyAura(uint32 spell_id) const
+{
+    Unit::AuraList const& mDummy = GetAurasByType(SPELL_AURA_DUMMY);
+    for (Unit::AuraList::const_iterator itr = mDummy.begin(); itr != mDummy.end(); ++itr)
+        if ((*itr)->GetId() == spell_id)
+            return *itr;
+
+    return nullptr;
+}
+
+void Unit::SetContestedPvP(Player* attackedPlayer)
+{
+    Player* player = GetCharmerOrOwnerPlayerOrPlayerItself();
+
+    if (!player || (attackedPlayer && (attackedPlayer == player || player->IsInDuelWith(attackedPlayer))))
+        return;
+
+    player->SetContestedPvPTimer(30000);
+
+    if (!player->hasUnitState(UNIT_STAT_ATTACK_PLAYER))
+    {
+        player->addUnitState(UNIT_STAT_ATTACK_PLAYER);
+        player->SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_CONTESTED_PVP);
+        // call MoveInLineOfSight for nearby contested guards
+        UpdateVisibilityAndView();
+    }
+
+    if (!hasUnitState(UNIT_STAT_ATTACK_PLAYER))
+    {
+        addUnitState(UNIT_STAT_ATTACK_PLAYER);
+        // call MoveInLineOfSight for nearby contested guards
+        UpdateVisibilityAndView();
+    }
+}
+
+void Unit::AddPetAura(PetAura const* petSpell)
+{
+    m_petAuras.insert(petSpell);
+    if (Pet* pet = GetPet())
+        pet->CastPetAura(petSpell);
+}
+
+void Unit::RemovePetAura(PetAura const* petSpell)
+{
+    m_petAuras.erase(petSpell);
+    if (Pet* pet = GetPet())
+        pet->RemoveAurasDueToSpell(petSpell->GetAura(pet->GetEntry()));
+}
+
+void Unit::RemoveAurasAtMechanicImmunity(uint32 mechMask, uint32 exceptSpellId, bool non_positive /*= false*/)
+{
+    Unit::SpellAuraHolderMap& auras = GetSpellAuraHolderMap();
+    for (Unit::SpellAuraHolderMap::iterator iter = auras.begin(); iter != auras.end();)
+    {
+        SpellEntry const* spell = iter->second->GetSpellProto();
+        if (spell->Id == exceptSpellId)
+            ++iter;
+        else if (non_positive && iter->second->IsPositive())
+            ++iter;
+        else if (spell->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY))
+            ++iter;
+        else if (iter->second->HasMechanicMask(mechMask))
+        {
+            RemoveAurasDueToSpell(spell->Id);
+
+            if (auras.empty())
+                break;
+            else
+                iter = auras.begin();
+        }
+        else
+            ++iter;
+    }
+}
+
+void Unit::NearTeleportTo(float x, float y, float z, float orientation, bool casting /*= false*/)
+{
+    DisableSpline();
+
+    if (GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->TeleportTo(GetMapId(), x, y, z, orientation, TELE_TO_NOT_LEAVE_TRANSPORT | TELE_TO_NOT_LEAVE_COMBAT | TELE_TO_NOT_UNSUMMON_PET | (casting ? TELE_TO_SPELL : 0));
+    else
+    {
+        Creature* c = (Creature*)this;
+        // Creature relocation acts like instant movement generator, so current generator expects interrupt/reset calls to react properly
+        if (!c->GetMotionMaster()->empty())
+            if (MovementGenerator* movgen = c->GetMotionMaster()->top())
+                movgen->Interrupt(*c);
+
+        GetMap()->CreatureRelocation((Creature*)this, x, y, z, orientation);
+
+        SendHeartBeat();
+
+        // finished relocation, movegen can different from top before creature relocation,
+        // but apply Reset expected to be safe in any case
+        if (!c->GetMotionMaster()->empty())
+            if (MovementGenerator* movgen = c->GetMotionMaster()->top())
+                movgen->Reset(*c);
+    }
+}
+
+void Unit::MonsterMoveWithSpeed(float x, float y, float z, float speed, bool generatePath, bool forceDestination)
+{
+    Movement::MoveSplineInit init(*this);
+    init.MoveTo(x, y, z, generatePath, forceDestination);
+    init.SetVelocity(speed);
+    init.Launch();
+}
+
+struct SetPvPHelper
+{
+    explicit SetPvPHelper(bool _state) : state(_state) {}
+    void operator()(Unit* unit) const { unit->SetPvP(state); }
+    bool state;
+};
+
+void Unit::SetPvP(bool state)
+{
+    if (state)
+        SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP);
+    else
+        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP);
+
+    if (GetTypeId() == TYPEID_PLAYER && ((Player*)this)->GetGroup())
+        ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
+
+    CallForAllControlledUnits(SetPvPHelper(state), CONTROLLED_PET | CONTROLLED_TOTEMS | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
+}
+
+void Unit::RestoreOriginalFaction()
+{
+    if (GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->setFactionForRace(getRace());
+    else
+    {
+        Creature* creature = (Creature*)this;
+
+        if (creature->IsPet() || creature->IsTotem())
+        {
+            if (Unit* owner = GetOwner())
+                setFaction(owner->getFaction());
+        }
+        else
+            setFaction(creature->GetCreatureInfo()->FactionAlliance);
+    }
+}
+
+float Unit::GetCombatRatingReduction(CombatRating cr) const
+{
+    if (GetTypeId() == TYPEID_PLAYER)
+        return ((Player const*)this)->GetRatingBonusValue(cr);
+
+    return 0.0f;
+}
+
+uint32 Unit::GetCombatRatingDamageReduction(CombatRating cr, float rate, float cap, uint32 damage) const
+{
+    float percent = GetCombatRatingReduction(cr) * rate;
+    if (percent > cap)
+        percent = cap;
+    return uint32(percent * damage / 100.0f);
+}
+
+struct StopAttackFactionHelper
+{
+    explicit StopAttackFactionHelper(uint32 _faction_id) : faction_id(_faction_id) {}
+    void operator()(Unit* unit) const { unit->StopAttackFaction(faction_id); }
+    uint32 faction_id;
+};
+
+void Unit::StopAttackFaction(uint32 faction_id)
+{
+    if (Unit* victim = getVictim())
+    {
+        if (victim->getFactionTemplateEntry()->faction == faction_id)
+        {
+            AttackStop();
+            if (IsNonMeleeSpellCasted(false))
+                InterruptNonMeleeSpells(false);
+
+            // melee and ranged forced attack cancel
+            if (GetTypeId() == TYPEID_PLAYER)
+                ((Player*)this)->SendAttackSwingCancelAttack();
+        }
+    }
+
+    AttackerSet const& attackers = getAttackers();
+    for (AttackerSet::const_iterator itr = attackers.begin(); itr != attackers.end();)
+    {
+        if ((*itr)->getFactionTemplateEntry()->faction == faction_id)
+        {
+            (*itr)->AttackStop();
+            itr = attackers.begin();
+        }
+        else
+            ++itr;
+    }
+
+    getHostileRefManager().deleteReferencesForFaction(faction_id);
+
+    CallForAllControlledUnits(StopAttackFactionHelper(faction_id), CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
+}
+
+void Unit::CleanupDeletedAuras()
+{
+    for (SpellAuraHolderList::const_iterator iter = m_deletedHolders.begin(); iter != m_deletedHolders.end(); ++iter)
+        delete *iter;
+    m_deletedHolders.clear();
+
+    // really delete auras "deleted" while processing its ApplyModify code
+    for (AuraList::const_iterator itr = m_deletedAuras.begin(); itr != m_deletedAuras.end(); ++itr)
+        delete *itr;
+    m_deletedAuras.clear();
+}
+
+bool Unit::CheckAndIncreaseCastCounter()
+{
+    uint32 maxCasts = sWorld.getConfig(CONFIG_UINT32_MAX_SPELL_CASTS_IN_CHAIN);
+
+    if (maxCasts && m_castCounter >= maxCasts)
+        return false;
+
+    ++m_castCounter;
+    return true;
+}
+
+SpellAuraHolder* Unit::GetSpellAuraHolder(uint32 spellid) const
+{
+    SpellAuraHolderMap::const_iterator itr = m_spellAuraHolders.find(spellid);
+    return itr != m_spellAuraHolders.end() ? itr->second : nullptr;
+}
+
+SpellAuraHolder* Unit::GetSpellAuraHolder(uint32 spellid, ObjectGuid casterGuid) const
+{
+    SpellAuraHolderConstBounds bounds = GetSpellAuraHolderBounds(spellid);
+    for (SpellAuraHolderMap::const_iterator iter = bounds.first; iter != bounds.second; ++iter)
+        if (iter->second->GetCasterGuid() == casterGuid)
+            return iter->second;
+
+    return nullptr;
+}
+
+bool Unit::IsAllowedDamageInArea(Unit* pVictim) const
+{
+    // can damage self anywhere
+    if (pVictim == this)
+        return true;
+
+    // can damage own pet anywhere
+    if (pVictim->GetOwnerGuid() == GetObjectGuid())
+        return true;
+
+    // non player controlled unit can damage anywhere
+    Player const* pOwner = GetCharmerOrOwnerPlayerOrPlayerItself();
+    if (!pOwner)
+        return true;
+
+    // can damage non player controlled victim anywhere
+    Player const* vOwner = pVictim->GetCharmerOrOwnerPlayerOrPlayerItself();
+    if (!vOwner)
+        return true;
+
+    // can damage opponent in duel
+    if (pOwner->IsInDuelWith(vOwner))
+        return true;
+
+    // can't damage player controlled unit by player controlled unit in sanctuary
+    AreaTableEntry const* area = GetAreaEntryByAreaID(pVictim->GetAreaId());
+    if (area && area->flags & AREA_FLAG_SANCTUARY)
+        return false;
+
+    return true;
+}
+
+class RelocationNotifyEvent : public BasicEvent
+{
+    public:
+        RelocationNotifyEvent(Unit& owner) : BasicEvent(), m_owner(owner)
+        {
+            m_owner._SetAINotifyScheduled(true);
+        }
+
+        bool Execute(uint64 /*e_time*/, uint32 /*p_time*/)
+        {
+            float radius = MAX_CREATURE_ATTACK_RADIUS * sWorld.getConfig(CONFIG_FLOAT_RATE_CREATURE_AGGRO);
+            if (m_owner.GetTypeId() == TYPEID_PLAYER)
+            {
+                MaNGOS::PlayerRelocationNotifier notify((Player&)m_owner);
+                Cell::VisitAllObjects(&m_owner, notify, radius);
+            }
+            else // if(m_owner.GetTypeId() == TYPEID_UNIT)
+            {
+                MaNGOS::CreatureRelocationNotifier notify((Creature&)m_owner);
+                Cell::VisitAllObjects(&m_owner, notify, radius);
+            }
+            m_owner._SetAINotifyScheduled(false);
+            return true;
+        }
+
+        void Abort(uint64)
+        {
+            m_owner._SetAINotifyScheduled(false);
+        }
+
+    private:
+        Unit& m_owner;
+};
+
+void Unit::ScheduleAINotify(uint32 delay)
+{
+    if (!IsAINotifyScheduled())
+        m_Events.AddEvent(new RelocationNotifyEvent(*this), m_Events.CalculateTime(delay));
+}
+
+void Unit::OnRelocated()
+{
+    // switch to use G3D::Vector3 is good idea, maybe
+    float dx = m_last_notified_position.x - GetPositionX();
+    float dy = m_last_notified_position.y - GetPositionY();
+    float dz = m_last_notified_position.z - GetPositionZ();
+    float distsq = dx * dx + dy * dy + dz * dz;
+    if (distsq > World::GetRelocationLowerLimitSq())
+    {
+        m_last_notified_position.x = GetPositionX();
+        m_last_notified_position.y = GetPositionY();
+        m_last_notified_position.z = GetPositionZ();
+
+        GetViewPoint().Call_UpdateVisibilityForOwner();
+        UpdateObjectVisibility();
+    }
+    ScheduleAINotify(World::GetRelocationAINotifyDelay());
+}
+
+void Unit::UpdateSplineMovement(uint32 t_diff)
+{
+    enum
+    {
+        POSITION_UPDATE_DELAY = 400,
+    };
+
+    if (movespline->Finalized())
+        return;
+
+    movespline->updateState(t_diff);
+    bool arrived = movespline->Finalized();
+
+    if (arrived)
+        DisableSpline();
+
+    m_movesplineTimer.Update(t_diff);
+    if (m_movesplineTimer.Passed() || arrived)
+    {
+        m_movesplineTimer.Reset(POSITION_UPDATE_DELAY);
+        Movement::Location loc = movespline->ComputePosition();
+
+        if (GetTypeId() == TYPEID_PLAYER)
+            ((Player*)this)->SetPosition(loc.x, loc.y, loc.z, loc.orientation);
+        else
+            GetMap()->CreatureRelocation((Creature*)this, loc.x, loc.y, loc.z, loc.orientation);
+    }
+}
+
+void Unit::DisableSpline()
+{
+    m_movementInfo.RemoveMovementFlag(MovementFlags(MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_FORWARD));
+    movespline->_Interrupt();
+}
+
+// This will create a new creature and set the current unit as the controller of that new creature
+Unit* Unit::TakePossessOf(SpellEntry const* spellEntry, SummonPropertiesEntry const* summonProp, uint32 effIdx, float x, float y, float z, float ang)
+{
+    int32 const& creatureEntry = spellEntry->EffectMiscValue[effIdx];
+    CreatureInfo const* cinfo = ObjectMgr::GetCreatureTemplate(creatureEntry);
+    if (!cinfo)
+    {
+        sLog.outErrorDb("WorldObject::SummonCreature: Creature (Entry: %u) not existed for summoner: %s. ", creatureEntry, GetGuidStr().c_str());
+        return nullptr;
+    }
+
+    if (GetCharm())
+    {
+        sLog.outError("Unit::TakePossessOf> There is already a charmed creature for %s its : %s. ", GetGuidStr().c_str(), GetCharm()->GetGuidStr().c_str());
+        return nullptr;
+    }
+
+    TemporarySummon* pCreature = new TemporarySummon(GetObjectGuid());
+
+    CreatureCreatePos pos(GetMap(), x, y, z, ang);
+
+    if (x == 0.0f && y == 0.0f && z == 0.0f)
+        pos = CreatureCreatePos(this, GetOrientation(), CONTACT_DISTANCE, ang);
+
+    if (!pCreature->Create(GetMap()->GenerateLocalLowGuid(cinfo->GetHighGuid()), pos, cinfo))
+    {
+        delete pCreature;
+        return nullptr;
+    }
+
+    Player* player = GetTypeId() == TYPEID_PLAYER ? static_cast<Player*>(this) : nullptr;
+
+    pCreature->SetFactionTemporary(getFaction(), TEMPFACTION_NONE);     // set same faction than player
+    pCreature->SetRespawnCoord(pos);                                    // set spawn coord
+    pCreature->SetCharmerGuid(GetObjectGuid());                         // save guid of the charmer
+    pCreature->SetUInt32Value(UNIT_CREATED_BY_SPELL, spellEntry->Id);   // set the spell id used to create this (may be used for removing corresponding aura
+    pCreature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED);  // set flag for client that mean this unit is controlled by a player
+    pCreature->addUnitState(UNIT_STAT_CONTROLLED);                      // also set internal unit state flag
+    pCreature->SelectLevel(getLevel());                                 // set level to same level than summoner TODO:: not sure its always the case...
+    pCreature->SetLinkedToOwnerAura(TEMPSUMMON_LINKED_AURA_OWNER_CHECK | TEMPSUMMON_LINKED_AURA_REMOVE_OWNER); // set what to do if linked aura is removed or the creature is dead.
+    pCreature->SetWalk(IsWalking(), true);                              // sync the walking state with the summoner
+
+                                                                        // important before adding to the map!
+    SetCharmGuid(pCreature->GetObjectGuid());                           // save guid of charmed creature
+
+    pCreature->SetSummonProperties(TEMPSUMMON_CORPSE_TIMED_DESPAWN, 5000); // set 5s corpse decay
+    GetMap()->Add(static_cast<Creature*>(pCreature));                   // create the creature in the client
+    pCreature->AIM_Initialize();                                        // even if this will be replaced it need to be initialized to take care of spawn spells
+
+                                                                        // Give the control to the player
+    if (player)
+    {
+        player->GetCamera().SetView(pCreature);                         // modify camera view to the creature view
+        player->SetClientControl(pCreature, 1);                         // transfer client control to the creature
+        player->SetMover(pCreature);                                    // set mover so now we know that creature is "moved" by this unit
+        player->SendForcedObjectUpdate();                               // we have to update client data here to avoid problem with the "release spirit" windows reappear.
+
+        pCreature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP_ATTACKABLE); // this seem to be needed for controlled creature (else cannot attack neutral creature)
+
+        // player pet is unsumoned while possessing
+        player->UnsummonPetTemporaryIfAny();
+    }
+
+    // init CharmInfo class that will hold charm data
+    CharmInfo* charmInfo = pCreature->InitCharmInfo(pCreature);
+
+    // set temp possess ai (creature will not be able to react by itself)
+    charmInfo->SetCharmState("PossessedAI");
+
+    if (player)
+    {
+        // Initialize pet bar
+        if (CharmInfo* charmInfo = pCreature->InitCharmInfo(pCreature))
+            charmInfo->InitPossessCreateSpells();
+        player->PossessSpellInitialize();
+    }
+
+    // Creature Linking, Initial load is handled like respawn
+    if (pCreature->IsLinkingEventTrigger())
+        GetMap()->GetCreatureLinkingHolder()->DoCreatureLinkingEvent(LINKING_EVENT_RESPAWN, pCreature);
+
+    // return the creature therewith the summoner has access to it
+    return pCreature;
+}
+
+bool Unit::TakePossessOf(Unit* possessed)
+{
+    Player* player = nullptr;
+    if (GetTypeId() == TYPEID_PLAYER)
+        player = static_cast<Player *>(this);
+
+    // stop combat but keep threat list
+    possessed->AttackStop(true, true);
+    possessed->ClearInCombat();
+
+    possessed->addUnitState(UNIT_STAT_CONTROLLED);
+    possessed->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED);
+    possessed->SetCharmerGuid(GetObjectGuid());
+
+    SetCharm(possessed);
+
+    Creature* possessedCreature = nullptr;
+    Player* possessedPlayer = nullptr;
+    CharmInfo* charmInfo = possessed->InitCharmInfo(possessed);
+
+    // stop any generated movement TODO:: this may not be correct! what about possessing a feared creature?
+    possessed->GetMotionMaster()->Clear();
+    possessed->GetMotionMaster()->MoveIdle();
+    possessed->StopMoving(true);
+
+    if (possessed->GetTypeId() == TYPEID_UNIT)
+    {
+        possessedCreature = static_cast<Creature *>(possessed);
+        possessedCreature->SetFactionTemporary(getFaction(), TEMPFACTION_NONE);
+        possessedCreature->SetWalk(IsWalking(), true);
+        charmInfo->SetCharmState("PossessedAI");
+        getHostileRefManager().deleteReference(possessedCreature);
+
+        // this seem to be needed for controlled creature (else cannot attack neutral creature)
+        if (player)
+            possessed->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP_ATTACKABLE);
+    }
+    else if (possessed->GetTypeId() == TYPEID_PLAYER)
+    {
+        possessedPlayer = static_cast<Player *>(possessed);
+
+        if (player && player->IsInDuelWith(possessedPlayer))
+            possessedPlayer->SetUInt32Value(PLAYER_DUEL_TEAM, player->GetUInt32Value(PLAYER_DUEL_TEAM));
+        else
+            possessedPlayer->setFaction(getFaction());
+    }
+
+    if (player)
+    {
+        player->GetCamera().SetView(possessed);
+        player->SetClientControl(possessed, player->IsClientControl(possessed));
+        player->SetMover(possessed);
+        player->SendForcedObjectUpdate();
+
+        if (possessedCreature)
+        {
+            if (possessedCreature->IsPet() && possessedCreature->GetObjectGuid() == GetPetGuid())
+            {
+                // possessing own pet, pet bar already initialized
+                return true;
+            }
+        }
+
+        // player pet is unsmumoned while possessing
+        player->UnsummonPetTemporaryIfAny();
+
+        charmInfo->InitPossessCreateSpells();
+        charmInfo->SetReactState(REACT_PASSIVE);
+        charmInfo->SetCommandState(COMMAND_STAY);
+        player->PossessSpellInitialize();
+    }
+
+    if (possessedPlayer)
+        possessedPlayer->SetClientControl(possessed, 0);
+
+    return true;
+}
+
+bool Unit::TakeCharmOf(Unit* charmed)
+{
+
+    Player* charmerPlayer = nullptr;
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        charmerPlayer = static_cast<Player *>(this);
+
+        // player pet is unsmumoned while possessing
+        charmerPlayer->UnsummonPetTemporaryIfAny();
+    }
+
+    // stop combat but keep threat list
+    charmed->AttackStop(true, true);
+    charmed->ClearInCombat();
+
+    charmed->SetCharmerGuid(GetObjectGuid());
+    SetCharm(charmed);
+
+    CharmInfo* charmInfo = charmed->InitCharmInfo(charmed);
+
+    if (charmed->GetTypeId() == TYPEID_PLAYER)
+    {
+        Player* charmedPlayer = static_cast<Player *>(charmed);
+        if (charmerPlayer && charmerPlayer->IsInDuelWith(charmedPlayer))
+            charmedPlayer->SetUInt32Value(PLAYER_DUEL_TEAM, charmerPlayer->GetUInt32Value(PLAYER_DUEL_TEAM));
+        else
+            charmedPlayer->setFaction(getFaction());
+
+        charmInfo->SetCharmState("PetAI");
+        charmed->SetByteValue(UNIT_FIELD_BYTES_2, 1, UNIT_BYTE2_FLAG_SUPPORTABLE | UNIT_BYTE2_FLAG_AURAS); // important have to be after charminfo initialization
+                                                                                                           //charmedPlayer->SetWalk(IsWalking(), true);
+
+        charmInfo->InitCharmCreateSpells();
+        charmInfo->SetReactState(REACT_DEFENSIVE);
+        charmInfo->SetCommandState(COMMAND_FOLLOW);
+        charmInfo->SetIsRetreating(true);
+
+        charmedPlayer->SetClientControl(charmedPlayer, 0);
+        charmedPlayer->SendForcedObjectUpdate();
+    }
+    else if (charmed->GetTypeId() == TYPEID_UNIT)
+    {
+        Creature* charmedCreature = static_cast<Creature *>(charmed);
+        charmInfo->SetCharmState("PetAI");
+        getHostileRefManager().deleteReference(charmedCreature);
+        charmedCreature->SetFactionTemporary(getFaction(), TEMPFACTION_NONE);
+        charmedCreature->SetWalk(IsWalking(), true);
+
+        charmInfo->InitCharmCreateSpells();
+        charmInfo->SetReactState(REACT_DEFENSIVE);
+        charmInfo->SetCommandState(COMMAND_FOLLOW);
+        charmInfo->SetIsRetreating(true);
+
+        if (charmerPlayer)
+        {
+            // without this charmed unit will not be able to attack neutral target
+            charmed->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP_ATTACKABLE);
+
+            if (getClass() == CLASS_WARLOCK)
+            {
+                CreatureInfo const* cinfo = charmedCreature->GetCreatureInfo();
+                if (cinfo && cinfo->CreatureType == CREATURE_TYPE_DEMON)
+                {
+                    // creature with pet number expected have class set
+                    if (charmedCreature->GetByteValue(UNIT_FIELD_BYTES_0, 1) == 0)
+                    {
+                        if (cinfo->UnitClass == 0)
+                            sLog.outErrorDb("Creature (Entry: %u) have UnitClass = 0 but used in charmed spell, that will be result client crash.", cinfo->Entry);
+                        else
+                            sLog.outError("Creature (Entry: %u) have UnitClass = %u but at charming have class 0!!! that will be result client crash.", cinfo->Entry, cinfo->UnitClass);
+
+                        charmedCreature->SetByteValue(UNIT_FIELD_BYTES_0, 1, CLASS_MAGE);
+                    }
+
+                    // just to enable stat window
+                    charmInfo->SetPetNumber(sObjectMgr.GeneratePetNumber(), true);
+                    // if charmed two demons the same session, the 2nd gets the 1st one's name
+                    charmedCreature->SetUInt32Value(UNIT_FIELD_PET_NAME_TIMESTAMP, uint32(time(nullptr)));
+                }
+            }
+        }
+    }
+
+    if (charmerPlayer)
+        charmerPlayer->CharmSpellInitialize();
+
+    return true;
+}
+
+void Unit::ResetControlState(bool attackCharmer /*= true*/)
+{
+    Player* player = nullptr;
+    if (GetTypeId() == TYPEID_PLAYER)
+        player = static_cast<Player *>(this);
+
+    Unit* possessed = GetCharm();
+
+    if (!possessed)
+    {
+        if (player)
+        {
+            player->GetCamera().ResetView();
+            player->SetClientControl(player, player->IsClientControl(player));
+            player->SetMover(nullptr);
+        }
+        return;
+    }
+
+    possessed->clearUnitState(UNIT_STAT_CONTROLLED);
+    possessed->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED);
+    possessed->SetCharmerGuid(ObjectGuid());
+
+    // may be not correct we have to remove only some generator taking account of the current situation
+    possessed->StopMoving(true);
+    possessed->GetMotionMaster()->Clear();
+
+    SetCharmGuid(ObjectGuid());
+    Creature* possessedCreature = nullptr;
+    CharmInfo* charmInfo = possessed->GetCharmInfo();
+
+    if (possessed->GetTypeId() == TYPEID_UNIT)
+    {
+        // now we have to clean threat list to be able to restore normal creature behavior
+        FactionTemplateEntry const* factionEntry = possessed->getFactionTemplateEntry();
+
+        possessedCreature = static_cast<Creature *>(possessed);
+        if (!possessedCreature->IsPet())
+        {
+            possessedCreature->ClearTemporaryFaction();
+
+            // first find friendly target (stopping combat here is not recommended because m_attackers will be modified)
+            AttackerSet friendlyTargets;
+            for (Unit::AttackerSet::const_iterator itr = possessed->getAttackers().begin(); itr != possessed->getAttackers().end(); ++itr)
+            {
+                Unit* attacker = (*itr);
+                if (attacker->GetTypeId() != TYPEID_UNIT)
+                    continue;
+
+                if (!factionEntry->IsHostileTo(*attacker->getFactionTemplateEntry()))
+                    friendlyTargets.insert(attacker);
+            }
+
+            // now stop attackers combat and transfer threat generated from this to owner, also get the total generated threat
+            for (Unit::AttackerSet::iterator itr = friendlyTargets.begin(); itr != friendlyTargets.end(); ++itr)
+            {
+                Unit* attacker = (*itr);
+                attacker->AttackStop(true, true);
+                attacker->m_Events.KillAllEvents(true);
+                attacker->getThreatManager().modifyThreatPercent(possessed, -101);     // only remove the possessed creature from threat list because it can be filled by other players
+                attacker->AddThreat(this);
+            }
+
+            possessed->AttackStop(true, true);
+            possessed->m_Events.KillAllEvents(true);
+
+            charmInfo->ResetCharmState();
+            possessed->DeleteCharmInfo();
+
+            // we have to restore initial MotionMaster
+            while (possessed->GetMotionMaster()->GetCurrentMovementGeneratorType() == FOLLOW_MOTION_TYPE)
+                possessed->GetMotionMaster()->MovementExpired(true);
+
+            if (possessed->isAlive())
+            {
+                possessedCreature->SetCombatStartPosition(GetPositionX(), GetPositionY(), GetPositionZ()); // needed for creature not yet entered in combat or SelectHostileTarget() will fail
+
+                                                                                                           // TODO:: iam not sure we need that faction check
+                if (!factionEntry->IsFriendlyTo(*getFactionTemplateEntry()))
+                    possessed->getThreatManager().addThreat(this, GetMaxHealth());     // generating threat by max life amount best way i found to make it realistic
+            }
+            else
+                possessed->GetCombatData()->threatManager.clearReferences();
+
+            // we can remove that flag if its set, that is supposed to be only for creature controlled by player
+            // however player's pet should keep it
+            possessed->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP_ATTACKABLE);
+        }
+        else
+        {
+            possessed->setFaction(possessedCreature->GetOwner()->getFaction());
+
+            charmInfo->ResetCharmState();
+
+            // as possessed is a pet we have to restore original charminfo so Pet::DeleteCharmInfo will take care of that
+            possessed->DeleteCharmInfo();
+        }
+    }
+    else if (possessed->GetTypeId() == TYPEID_PLAYER)
+    {
+        possessed->AttackStop(true, true);
+
+        Player* possessedPlayer = static_cast<Player *>(possessed);
+
+        if (player && player->IsInDuelWith(possessedPlayer))
+            possessedPlayer->SetUInt32Value(PLAYER_DUEL_TEAM, player->GetUInt32Value(PLAYER_DUEL_TEAM) == 1 ? 2 : 1);
+        else
+            possessedPlayer->setFactionForRace(possessedPlayer->getRace());
+
+        possessedPlayer->SetClientControl(possessedPlayer, possessedPlayer->IsClientControl(possessedPlayer));
+        charmInfo->ResetCharmState();
+        possessedPlayer->DeleteCharmInfo();
+
+        while (possessedPlayer->GetMotionMaster()->GetCurrentMovementGeneratorType() == FOLLOW_MOTION_TYPE)
+            possessedPlayer->GetMotionMaster()->MovementExpired(true);
+    }
+
+    if (player)
+    {
+        player->SetClientControl(possessed, 0);
+        player->SetMover(nullptr);
+        player->GetCamera().ResetView();
+
+        // player pet can be re summoned here
+        player->ResummonPetTemporaryUnSummonedIfAny();
+
+        // remove pet bar only if no pet
+        if (!player->GetPet())
+            player->RemovePetActionBar();
+        else
+            player->PetSpellInitialize();   // reset spell on pet bar
+    }
+
+    // be sure all those change will be made for clients
+    SendForcedObjectUpdate();
+}
+
+float Unit::GetAttackDistance(Unit const* pl) const
+{
+    float aggroRate = sWorld.getConfig(CONFIG_FLOAT_RATE_CREATURE_AGGRO);
+    if (aggroRate == 0)
+        return 0.0f;
+
+    uint32 playerlevel = pl->GetLevelForTarget(this);
+    uint32 creaturelevel = GetLevelForTarget(pl);
+
+    int32 leveldif = int32(playerlevel) - int32(creaturelevel);
+
+    // "The maximum Aggro Radius has a cap of 25 levels under. Example: A level 30 char has the same Aggro Radius of a level 5 char on a level 60 mob."
+    if (leveldif < -25)
+        leveldif = -25;
+
+    // "The aggro radius of a mob having the same level as the player is roughly 20 yards"
+    float RetDistance = 20;
+
+    // "Aggro Radius varies with level difference at a rate of roughly 1 yard/level"
+    // radius grow if playlevel < creaturelevel
+    RetDistance -= (float)leveldif;
+
+    if (creaturelevel + 5 <= sWorld.getConfig(CONFIG_UINT32_MAX_PLAYER_LEVEL))
+    {
+        // detect range auras
+        RetDistance += GetTotalAuraModifier(SPELL_AURA_MOD_DETECT_RANGE);
+
+        // detected range auras
+        RetDistance += pl->GetTotalAuraModifier(SPELL_AURA_MOD_DETECTED_RANGE);
+    }
+
+    // "Minimum Aggro Radius for a mob seems to be combat range (5 yards)"
+    if (RetDistance < 5)
+        RetDistance = 5;
+
+    return (RetDistance * aggroRate);
 }

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -16,6461 +16,2456 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include "Unit.h"
+#include "Common.h"
 #include "Log.h"
-#include "Opcodes.h"
-#include "WorldPacket.h"
-#include "WorldSession.h"
-#include "World.h"
 #include "ObjectMgr.h"
-#include "ObjectGuid.h"
 #include "SpellMgr.h"
 #include "Player.h"
-#include "Creature.h"
+#include "Unit.h"
 #include "Spell.h"
-#include "Group.h"
 #include "SpellAuras.h"
-#include "ObjectAccessor.h"
-#include "AI/CreatureAISelector.h"
-#include "TemporarySummon.h"
-#include "Pet.h"
-#include "Util.h"
 #include "Totem.h"
-#include "BattleGround/BattleGround.h"
-#include "InstanceData.h"
-#include "OutdoorPvP/OutdoorPvP.h"
-#include "MapPersistentStateMgr.h"
-#include "GridNotifiersImpl.h"
-#include "CellImpl.h"
-#include "MovementGenerator.h"
-#include "movement/MoveSplineInit.h"
-#include "movement/MoveSpline.h"
-#include "CreatureLinkingMgr.h"
+#include "Creature.h"
+#include "ScriptMgr.h"
+#include "Util.h"
 
-#include <math.h>
-#include <array>
-
-float baseMoveSpeed[MAX_MOVE_TYPE] =
+pAuraProcHandler AuraProcHandler[TOTAL_AURAS] =
 {
-    2.5f,                                                   // MOVE_WALK
-    7.0f,                                                   // MOVE_RUN
-    4.5f,                                                   // MOVE_RUN_BACK
-    4.722222f,                                              // MOVE_SWIM
-    2.5f,                                                   // MOVE_SWIM_BACK
-    3.141594f,                                              // MOVE_TURN_RATE
-    7.0f,                                                   // MOVE_FLIGHT
-    4.5f,                                                   // MOVE_FLIGHT_BACK
+    &Unit::HandleNULLProc,                                  //  0 SPELL_AURA_NONE
+    &Unit::HandleNULLProc,                                  //  1 SPELL_AURA_BIND_SIGHT
+    &Unit::HandleNULLProc,                                  //  2 SPELL_AURA_MOD_POSSESS
+    &Unit::HandleNULLProc,                                  //  3 SPELL_AURA_PERIODIC_DAMAGE
+    &Unit::HandleDummyAuraProc,                             //  4 SPELL_AURA_DUMMY
+    &Unit::HandleNULLProc,                                  //  5 SPELL_AURA_MOD_CONFUSE
+    &Unit::HandleNULLProc,                                  //  6 SPELL_AURA_MOD_CHARM
+    &Unit::HandleRemoveByDamageChanceProc,                  //  7 SPELL_AURA_MOD_FEAR
+    &Unit::HandleNULLProc,                                  //  8 SPELL_AURA_PERIODIC_HEAL
+    &Unit::HandleNULLProc,                                  //  9 SPELL_AURA_MOD_ATTACKSPEED
+    &Unit::HandleNULLProc,                                  // 10 SPELL_AURA_MOD_THREAT
+    &Unit::HandleNULLProc,                                  // 11 SPELL_AURA_MOD_TAUNT
+    &Unit::HandleNULLProc,                                  // 12 SPELL_AURA_MOD_STUN
+    &Unit::HandleNULLProc,                                  // 13 SPELL_AURA_MOD_DAMAGE_DONE
+    &Unit::HandleNULLProc,                                  // 14 SPELL_AURA_MOD_DAMAGE_TAKEN
+    &Unit::HandleNULLProc,                                  // 15 SPELL_AURA_DAMAGE_SHIELD
+    &Unit::HandleNULLProc,                                  // 16 SPELL_AURA_MOD_STEALTH
+    &Unit::HandleNULLProc,                                  // 17 SPELL_AURA_MOD_STEALTH_DETECT
+    &Unit::HandleInvisibilityAuraProc,                      // 18 SPELL_AURA_MOD_INVISIBILITY
+    &Unit::HandleNULLProc,                                  // 19 SPELL_AURA_MOD_INVISIBILITY_DETECTION
+    &Unit::HandleNULLProc,                                  // 20 SPELL_AURA_OBS_MOD_HEALTH
+    &Unit::HandleNULLProc,                                  // 21 SPELL_AURA_OBS_MOD_MANA
+    &Unit::HandleModResistanceAuraProc,                     // 22 SPELL_AURA_MOD_RESISTANCE
+    &Unit::HandleNULLProc,                                  // 23 SPELL_AURA_PERIODIC_TRIGGER_SPELL
+    &Unit::HandleNULLProc,                                  // 24 SPELL_AURA_PERIODIC_ENERGIZE
+    &Unit::HandleNULLProc,                                  // 25 SPELL_AURA_MOD_PACIFY
+    &Unit::HandleRemoveByDamageChanceProc,                  // 26 SPELL_AURA_MOD_ROOT
+    &Unit::HandleNULLProc,                                  // 27 SPELL_AURA_MOD_SILENCE
+    &Unit::HandleNULLProc,                                  // 28 SPELL_AURA_REFLECT_SPELLS
+    &Unit::HandleNULLProc,                                  // 29 SPELL_AURA_MOD_STAT
+    &Unit::HandleNULLProc,                                  // 30 SPELL_AURA_MOD_SKILL
+    &Unit::HandleNULLProc,                                  // 31 SPELL_AURA_MOD_INCREASE_SPEED
+    &Unit::HandleNULLProc,                                  // 32 SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED
+    &Unit::HandleNULLProc,                                  // 33 SPELL_AURA_MOD_DECREASE_SPEED
+    &Unit::HandleNULLProc,                                  // 34 SPELL_AURA_MOD_INCREASE_HEALTH
+    &Unit::HandleNULLProc,                                  // 35 SPELL_AURA_MOD_INCREASE_ENERGY
+    &Unit::HandleNULLProc,                                  // 36 SPELL_AURA_MOD_SHAPESHIFT
+    &Unit::HandleNULLProc,                                  // 37 SPELL_AURA_EFFECT_IMMUNITY
+    &Unit::HandleNULLProc,                                  // 38 SPELL_AURA_STATE_IMMUNITY
+    &Unit::HandleNULLProc,                                  // 39 SPELL_AURA_SCHOOL_IMMUNITY
+    &Unit::HandleNULLProc,                                  // 40 SPELL_AURA_DAMAGE_IMMUNITY
+    &Unit::HandleNULLProc,                                  // 41 SPELL_AURA_DISPEL_IMMUNITY
+    &Unit::HandleProcTriggerSpellAuraProc,                  // 42 SPELL_AURA_PROC_TRIGGER_SPELL
+    &Unit::HandleProcTriggerDamageAuraProc,                 // 43 SPELL_AURA_PROC_TRIGGER_DAMAGE
+    &Unit::HandleNULLProc,                                  // 44 SPELL_AURA_TRACK_CREATURES
+    &Unit::HandleNULLProc,                                  // 45 SPELL_AURA_TRACK_RESOURCES
+    &Unit::HandleNULLProc,                                  // 46 SPELL_AURA_46
+    &Unit::HandleNULLProc,                                  // 47 SPELL_AURA_MOD_PARRY_PERCENT
+    &Unit::HandleNULLProc,                                  // 48 SPELL_AURA_48
+    &Unit::HandleNULLProc,                                  // 49 SPELL_AURA_MOD_DODGE_PERCENT
+    &Unit::HandleNULLProc,                                  // 50 SPELL_AURA_MOD_BLOCK_SKILL    obsolete?
+    &Unit::HandleNULLProc,                                  // 51 SPELL_AURA_MOD_BLOCK_PERCENT
+    &Unit::HandleNULLProc,                                  // 52 SPELL_AURA_MOD_CRIT_PERCENT
+    &Unit::HandleNULLProc,                                  // 53 SPELL_AURA_PERIODIC_LEECH
+    &Unit::HandleNULLProc,                                  // 54 SPELL_AURA_MOD_HIT_CHANCE
+    &Unit::HandleNULLProc,                                  // 55 SPELL_AURA_MOD_SPELL_HIT_CHANCE
+    &Unit::HandleNULLProc,                                  // 56 SPELL_AURA_TRANSFORM
+    &Unit::HandleNULLProc,                                  // 57 SPELL_AURA_MOD_SPELL_CRIT_CHANCE
+    &Unit::HandleNULLProc,                                  // 58 SPELL_AURA_MOD_INCREASE_SWIM_SPEED
+    &Unit::HandleNULLProc,                                  // 59 SPELL_AURA_MOD_DAMAGE_DONE_CREATURE
+    &Unit::HandleRemoveByDamageChanceProc,                  // 60 SPELL_AURA_MOD_PACIFY_SILENCE
+    &Unit::HandleNULLProc,                                  // 61 SPELL_AURA_MOD_SCALE
+    &Unit::HandleNULLProc,                                  // 62 SPELL_AURA_PERIODIC_HEALTH_FUNNEL
+    &Unit::HandleNULLProc,                                  // 63 SPELL_AURA_PERIODIC_MANA_FUNNEL obsolete?
+    &Unit::HandleNULLProc,                                  // 64 SPELL_AURA_PERIODIC_MANA_LEECH
+    &Unit::HandleModCastingSpeedNotStackAuraProc,           // 65 SPELL_AURA_MOD_CASTING_SPEED_NOT_STACK
+    &Unit::HandleNULLProc,                                  // 66 SPELL_AURA_FEIGN_DEATH
+    &Unit::HandleNULLProc,                                  // 67 SPELL_AURA_MOD_DISARM
+    &Unit::HandleNULLProc,                                  // 68 SPELL_AURA_MOD_STALKED
+    &Unit::HandleNULLProc,                                  // 69 SPELL_AURA_SCHOOL_ABSORB
+    &Unit::HandleNULLProc,                                  // 70 SPELL_AURA_EXTRA_ATTACKS      Useless, used by only one spell that has only visual effect
+    &Unit::HandleNULLProc,                                  // 71 SPELL_AURA_MOD_SPELL_CRIT_CHANCE_SCHOOL
+    &Unit::HandleModPowerCostSchoolAuraProc,                // 72 SPELL_AURA_MOD_POWER_COST_SCHOOL_PCT
+    &Unit::HandleModPowerCostSchoolAuraProc,                // 73 SPELL_AURA_MOD_POWER_COST_SCHOOL
+    &Unit::HandleReflectSpellsSchoolAuraProc,               // 74 SPELL_AURA_REFLECT_SPELLS_SCHOOL
+    &Unit::HandleNULLProc,                                  // 75 SPELL_AURA_MOD_LANGUAGE
+    &Unit::HandleNULLProc,                                  // 76 SPELL_AURA_FAR_SIGHT
+    &Unit::HandleMechanicImmuneResistanceAuraProc,          // 77 SPELL_AURA_MECHANIC_IMMUNITY
+    &Unit::HandleNULLProc,                                  // 78 SPELL_AURA_MOUNTED
+    &Unit::HandleNULLProc,                                  // 79 SPELL_AURA_MOD_DAMAGE_PERCENT_DONE
+    &Unit::HandleNULLProc,                                  // 80 SPELL_AURA_MOD_PERCENT_STAT
+    &Unit::HandleNULLProc,                                  // 81 SPELL_AURA_SPLIT_DAMAGE_PCT
+    &Unit::HandleNULLProc,                                  // 82 SPELL_AURA_WATER_BREATHING
+    &Unit::HandleNULLProc,                                  // 83 SPELL_AURA_MOD_BASE_RESISTANCE
+    &Unit::HandleNULLProc,                                  // 84 SPELL_AURA_MOD_REGEN
+    &Unit::HandleCantTrigger,                               // 85 SPELL_AURA_MOD_POWER_REGEN
+    &Unit::HandleNULLProc,                                  // 86 SPELL_AURA_CHANNEL_DEATH_ITEM
+    &Unit::HandleNULLProc,                                  // 87 SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN
+    &Unit::HandleNULLProc,                                  // 88 SPELL_AURA_MOD_HEALTH_REGEN_PERCENT
+    &Unit::HandleNULLProc,                                  // 89 SPELL_AURA_PERIODIC_DAMAGE_PERCENT
+    &Unit::HandleNULLProc,                                  // 90 SPELL_AURA_MOD_RESIST_CHANCE  Useless
+    &Unit::HandleNULLProc,                                  // 91 SPELL_AURA_MOD_DETECT_RANGE
+    &Unit::HandleNULLProc,                                  // 92 SPELL_AURA_PREVENTS_FLEEING
+    &Unit::HandleNULLProc,                                  // 93 SPELL_AURA_MOD_UNATTACKABLE
+    &Unit::HandleNULLProc,                                  // 94 SPELL_AURA_INTERRUPT_REGEN
+    &Unit::HandleNULLProc,                                  // 95 SPELL_AURA_GHOST
+    &Unit::HandleNULLProc,                                  // 96 SPELL_AURA_SPELL_MAGNET
+    &Unit::HandleManaShieldAuraProc,                        // 97 SPELL_AURA_MANA_SHIELD
+    &Unit::HandleNULLProc,                                  // 98 SPELL_AURA_MOD_SKILL_TALENT
+    &Unit::HandleNULLProc,                                  // 99 SPELL_AURA_MOD_ATTACK_POWER
+    &Unit::HandleNULLProc,                                  //100 SPELL_AURA_AURAS_VISIBLE obsolete? all player can see all auras now
+    &Unit::HandleNULLProc,                                  //101 SPELL_AURA_MOD_RESISTANCE_PCT
+    &Unit::HandleNULLProc,                                  //102 SPELL_AURA_MOD_MELEE_ATTACK_POWER_VERSUS
+    &Unit::HandleNULLProc,                                  //103 SPELL_AURA_MOD_TOTAL_THREAT
+    &Unit::HandleNULLProc,                                  //104 SPELL_AURA_WATER_WALK
+    &Unit::HandleNULLProc,                                  //105 SPELL_AURA_FEATHER_FALL
+    &Unit::HandleNULLProc,                                  //106 SPELL_AURA_HOVER
+    &Unit::HandleNULLProc,                                  //107 SPELL_AURA_ADD_FLAT_MODIFIER
+    &Unit::HandleNULLProc,                                  //108 SPELL_AURA_ADD_PCT_MODIFIER
+    &Unit::HandleNULLProc,                                  //109 SPELL_AURA_ADD_TARGET_TRIGGER
+    &Unit::HandleNULLProc,                                  //110 SPELL_AURA_MOD_POWER_REGEN_PERCENT
+    &Unit::HandleNULLProc,                                  //111 SPELL_AURA_ADD_CASTER_HIT_TRIGGER
+    &Unit::HandleOverrideClassScriptAuraProc,               //112 SPELL_AURA_OVERRIDE_CLASS_SCRIPTS
+    &Unit::HandleNULLProc,                                  //113 SPELL_AURA_MOD_RANGED_DAMAGE_TAKEN
+    &Unit::HandleNULLProc,                                  //114 SPELL_AURA_MOD_RANGED_DAMAGE_TAKEN_PCT
+    &Unit::HandleNULLProc,                                  //115 SPELL_AURA_MOD_HEALING
+    &Unit::HandleNULLProc,                                  //116 SPELL_AURA_MOD_REGEN_DURING_COMBAT
+    &Unit::HandleMechanicImmuneResistanceAuraProc,          //117 SPELL_AURA_MOD_MECHANIC_RESISTANCE
+    &Unit::HandleNULLProc,                                  //118 SPELL_AURA_MOD_HEALING_PCT
+    &Unit::HandleNULLProc,                                  //119 SPELL_AURA_SHARE_PET_TRACKING useless
+    &Unit::HandleNULLProc,                                  //120 SPELL_AURA_UNTRACKABLE
+    &Unit::HandleNULLProc,                                  //121 SPELL_AURA_EMPATHY
+    &Unit::HandleNULLProc,                                  //122 SPELL_AURA_MOD_OFFHAND_DAMAGE_PCT
+    &Unit::HandleNULLProc,                                  //123 SPELL_AURA_MOD_TARGET_RESISTANCE
+    &Unit::HandleNULLProc,                                  //124 SPELL_AURA_MOD_RANGED_ATTACK_POWER
+    &Unit::HandleNULLProc,                                  //125 SPELL_AURA_MOD_MELEE_DAMAGE_TAKEN
+    &Unit::HandleNULLProc,                                  //126 SPELL_AURA_MOD_MELEE_DAMAGE_TAKEN_PCT
+    &Unit::HandleAttackPowerAttackerBonusAuraProc,          //127 SPELL_AURA_RANGED_ATTACK_POWER_ATTACKER_BONUS
+    &Unit::HandleNULLProc,                                  //128 SPELL_AURA_MOD_POSSESS_PET
+    &Unit::HandleNULLProc,                                  //129 SPELL_AURA_MOD_SPEED_ALWAYS
+    &Unit::HandleNULLProc,                                  //130 SPELL_AURA_MOD_MOUNTED_SPEED_ALWAYS
+    &Unit::HandleNULLProc,                                  //131 SPELL_AURA_MOD_RANGED_ATTACK_POWER_VERSUS
+    &Unit::HandleNULLProc,                                  //132 SPELL_AURA_MOD_INCREASE_ENERGY_PERCENT
+    &Unit::HandleNULLProc,                                  //133 SPELL_AURA_MOD_INCREASE_HEALTH_PERCENT
+    &Unit::HandleNULLProc,                                  //134 SPELL_AURA_MOD_MANA_REGEN_INTERRUPT
+    &Unit::HandleNULLProc,                                  //135 SPELL_AURA_MOD_HEALING_DONE
+    &Unit::HandleNULLProc,                                  //136 SPELL_AURA_MOD_HEALING_DONE_PERCENT
+    &Unit::HandleNULLProc,                                  //137 SPELL_AURA_MOD_TOTAL_STAT_PERCENTAGE
+    &Unit::HandleHasteAuraProc,                             //138 SPELL_AURA_MOD_MELEE_HASTE
+    &Unit::HandleNULLProc,                                  //139 SPELL_AURA_FORCE_REACTION
+    &Unit::HandleNULLProc,                                  //140 SPELL_AURA_MOD_RANGED_HASTE
+    &Unit::HandleNULLProc,                                  //141 SPELL_AURA_MOD_RANGED_AMMO_HASTE
+    &Unit::HandleNULLProc,                                  //142 SPELL_AURA_MOD_BASE_RESISTANCE_PCT
+    &Unit::HandleNULLProc,                                  //143 SPELL_AURA_MOD_RESISTANCE_EXCLUSIVE
+    &Unit::HandleNULLProc,                                  //144 SPELL_AURA_SAFE_FALL
+    &Unit::HandleNULLProc,                                  //145 SPELL_AURA_CHARISMA obsolete?
+    &Unit::HandleNULLProc,                                  //146 SPELL_AURA_PERSUADED obsolete?
+    &Unit::HandleNULLProc,                                  //147 SPELL_AURA_MECHANIC_IMMUNITY_MASK
+    &Unit::HandleNULLProc,                                  //148 SPELL_AURA_RETAIN_COMBO_POINTS
+    &Unit::HandleCantTrigger,                               //149 SPELL_AURA_RESIST_PUSHBACK
+    &Unit::HandleNULLProc,                                  //150 SPELL_AURA_MOD_SHIELD_BLOCKVALUE_PCT
+    &Unit::HandleNULLProc,                                  //151 SPELL_AURA_TRACK_STEALTHED
+    &Unit::HandleNULLProc,                                  //152 SPELL_AURA_MOD_DETECTED_RANGE
+    &Unit::HandleNULLProc,                                  //153 SPELL_AURA_SPLIT_DAMAGE_FLAT
+    &Unit::HandleNULLProc,                                  //154 SPELL_AURA_MOD_STEALTH_LEVEL
+    &Unit::HandleNULLProc,                                  //155 SPELL_AURA_MOD_WATER_BREATHING
+    &Unit::HandleNULLProc,                                  //156 SPELL_AURA_MOD_REPUTATION_GAIN
+    &Unit::HandleNULLProc,                                  //157 SPELL_AURA_PET_DAMAGE_MULTI (single test like spell 20782, also single for 214 aura)
+    &Unit::HandleNULLProc,                                  //158 SPELL_AURA_MOD_SHIELD_BLOCKVALUE
+    &Unit::HandleNULLProc,                                  //159 SPELL_AURA_NO_PVP_CREDIT      only for Honorless Target spell
+    &Unit::HandleNULLProc,                                  //160 SPELL_AURA_MOD_AOE_AVOIDANCE
+    &Unit::HandleNULLProc,                                  //161 SPELL_AURA_MOD_HEALTH_REGEN_IN_COMBAT
+    &Unit::HandleNULLProc,                                  //162 SPELL_AURA_POWER_BURN_MANA
+    &Unit::HandleNULLProc,                                  //163 SPELL_AURA_MOD_CRIT_DAMAGE_BONUS
+    &Unit::HandleNULLProc,                                  //164 useless, only one test spell
+    &Unit::HandleAttackPowerAttackerBonusAuraProc,          //165 SPELL_AURA_MELEE_ATTACK_POWER_ATTACKER_BONUS
+    &Unit::HandleNULLProc,                                  //166 SPELL_AURA_MOD_ATTACK_POWER_PCT
+    &Unit::HandleNULLProc,                                  //167 SPELL_AURA_MOD_RANGED_ATTACK_POWER_PCT
+    &Unit::HandleNULLProc,                                  //168 SPELL_AURA_MOD_DAMAGE_DONE_VERSUS
+    &Unit::HandleNULLProc,                                  //169 SPELL_AURA_MOD_CRIT_PERCENT_VERSUS
+    &Unit::HandleNULLProc,                                  //170 SPELL_AURA_DETECT_AMORE       only for Detect Amore spell
+    &Unit::HandleNULLProc,                                  //171 SPELL_AURA_MOD_SPEED_NOT_STACK
+    &Unit::HandleNULLProc,                                  //172 SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK
+    &Unit::HandleNULLProc,                                  //173 SPELL_AURA_ALLOW_CHAMPION_SPELLS  only for Proclaim Champion spell
+    &Unit::HandleNULLProc,                                  //174 SPELL_AURA_MOD_SPELL_DAMAGE_OF_STAT_PERCENT
+    &Unit::HandleNULLProc,                                  //175 SPELL_AURA_MOD_SPELL_HEALING_OF_STAT_PERCENT
+    &Unit::HandleNULLProc,                                  //176 SPELL_AURA_SPIRIT_OF_REDEMPTION   only for Spirit of Redemption spell, die at aura end
+    &Unit::HandleNULLProc,                                  //177 SPELL_AURA_AOE_CHARM
+    &Unit::HandleNULLProc,                                  //178 SPELL_AURA_MOD_DEBUFF_RESISTANCE
+    &Unit::HandleNULLProc,                                  //179 SPELL_AURA_MOD_ATTACKER_SPELL_CRIT_CHANCE
+    &Unit::HandleNULLProc,                                  //180 SPELL_AURA_MOD_FLAT_SPELL_DAMAGE_VERSUS
+    &Unit::HandleNULLProc,                                  //181 SPELL_AURA_MOD_FLAT_SPELL_CRIT_DAMAGE_VERSUS unused
+    &Unit::HandleNULLProc,                                  //182 SPELL_AURA_MOD_RESISTANCE_OF_STAT_PERCENT
+    &Unit::HandleNULLProc,                                  //183 SPELL_AURA_MOD_CRITICAL_THREAT only used in 28746
+    &Unit::HandleNULLProc,                                  //184 SPELL_AURA_MOD_ATTACKER_MELEE_HIT_CHANCE
+    &Unit::HandleNULLProc,                                  //185 SPELL_AURA_MOD_ATTACKER_RANGED_HIT_CHANCE
+    &Unit::HandleNULLProc,                                  //186 SPELL_AURA_MOD_ATTACKER_SPELL_HIT_CHANCE
+    &Unit::HandleNULLProc,                                  //187 SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_CHANCE
+    &Unit::HandleNULLProc,                                  //188 SPELL_AURA_MOD_ATTACKER_RANGED_CRIT_CHANCE
+    &Unit::HandleNULLProc,                                  //189 SPELL_AURA_MOD_RATING
+    &Unit::HandleNULLProc,                                  //190 SPELL_AURA_MOD_FACTION_REPUTATION_GAIN
+    &Unit::HandleNULLProc,                                  //191 SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED
+    &Unit::HandleNULLProc,                                  //192 SPELL_AURA_HASTE_MELEE
+    &Unit::HandleNULLProc,                                  //193 SPELL_AURA_HASTE_ALL (in fact combat (any type attack) speed pct)
+    &Unit::HandleNULLProc,                                  //194 SPELL_AURA_MOD_DEPRICATED_1 not used now (old SPELL_AURA_MOD_SPELL_DAMAGE_OF_INTELLECT)
+    &Unit::HandleNULLProc,                                  //195 SPELL_AURA_MOD_DEPRICATED_2 not used now (old SPELL_AURA_MOD_SPELL_HEALING_OF_INTELLECT)
+    &Unit::HandleNULLProc,                                  //196 SPELL_AURA_MOD_COOLDOWN
+    &Unit::HandleNULLProc,                                  //197 SPELL_AURA_MOD_ATTACKER_SPELL_AND_WEAPON_CRIT_CHANCE
+    &Unit::HandleNULLProc,                                  //198 SPELL_AURA_MOD_ALL_WEAPON_SKILLS
+    &Unit::HandleNULLProc,                                  //199 SPELL_AURA_MOD_INCREASES_SPELL_PCT_TO_HIT
+    &Unit::HandleNULLProc,                                  //200 SPELL_AURA_MOD_XP_PCT
+    &Unit::HandleNULLProc,                                  //201 SPELL_AURA_FLY                             this aura enable flight mode...
+    &Unit::HandleNULLProc,                                  //202 SPELL_AURA_IGNORE_COMBAT_RESULT
+    &Unit::HandleNULLProc,                                  //203 SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_DAMAGE
+    &Unit::HandleNULLProc,                                  //204 SPELL_AURA_MOD_ATTACKER_RANGED_CRIT_DAMAGE
+    &Unit::HandleNULLProc,                                  //205 SPELL_AURA_MOD_ATTACKER_SPELL_CRIT_DAMAGE
+    &Unit::HandleNULLProc,                                  //206 SPELL_AURA_MOD_FLIGHT_SPEED
+    &Unit::HandleNULLProc,                                  //207 SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED
+    &Unit::HandleNULLProc,                                  //208 SPELL_AURA_MOD_FLIGHT_SPEED_STACKING
+    &Unit::HandleNULLProc,                                  //209 SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_STACKING
+    &Unit::HandleNULLProc,                                  //210 SPELL_AURA_MOD_FLIGHT_SPEED_NOT_STACKING
+    &Unit::HandleNULLProc,                                  //211 SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_NOT_STACKING
+    &Unit::HandleNULLProc,                                  //212 SPELL_AURA_MOD_RANGED_ATTACK_POWER_OF_STAT_PERCENT
+    &Unit::HandleNULLProc,                                  //213 SPELL_AURA_MOD_RAGE_FROM_DAMAGE_DEALT implemented in Player::RewardRage
+    &Unit::HandleNULLProc,                                  //214 Tamed Pet Passive
+    &Unit::HandleNULLProc,                                  //215 SPELL_AURA_ARENA_PREPARATION
+    &Unit::HandleNULLProc,                                  //216 SPELL_AURA_HASTE_SPELLS
+    &Unit::HandleNULLProc,                                  //217                                   unused
+    &Unit::HandleNULLProc,                                  //218 SPELL_AURA_HASTE_RANGED
+    &Unit::HandleNULLProc,                                  //219 SPELL_AURA_MOD_MANA_REGEN_FROM_STAT
+    &Unit::HandleNULLProc,                                  //220 SPELL_AURA_MOD_RATING_FROM_STAT
+    &Unit::HandleNULLProc,                                  //221 ignored
+    &Unit::HandleNULLProc,                                  //222 unused
+    &Unit::HandleNULLProc,                                  //223 Cold Stare
+    &Unit::HandleNULLProc,                                  //224 unused
+    &Unit::HandleMendingAuraProc,                           //225 SPELL_AURA_PRAYER_OF_MENDING
+    &Unit::HandleNULLProc,                                  //226 SPELL_AURA_PERIODIC_DUMMY
+    &Unit::HandleNULLProc,                                  //227 SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE
+    &Unit::HandleNULLProc,                                  //228 SPELL_AURA_DETECT_STEALTH
+    &Unit::HandleNULLProc,                                  //229 SPELL_AURA_MOD_AOE_DAMAGE_AVOIDANCE
+    &Unit::HandleNULLProc,                                  //230 Commanding Shout
+    &Unit::HandleProcTriggerSpellAuraProc,                  //231 SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE
+    &Unit::HandleNULLProc,                                  //232 SPELL_AURA_MECHANIC_DURATION_MOD
+    &Unit::HandleNULLProc,                                  //233 set model id to the one of the creature with id m_modifier.m_miscvalue
+    &Unit::HandleNULLProc,                                  //234 SPELL_AURA_MECHANIC_DURATION_MOD_NOT_STACK
+    &Unit::HandleNULLProc,                                  //235 SPELL_AURA_MOD_DISPEL_RESIST
+    &Unit::HandleNULLProc,                                  //236 unused
+    &Unit::HandleNULLProc,                                  //237 SPELL_AURA_MOD_SPELL_DAMAGE_OF_ATTACK_POWER
+    &Unit::HandleNULLProc,                                  //238 SPELL_AURA_MOD_SPELL_HEALING_OF_ATTACK_POWER
+    &Unit::HandleNULLProc,                                  //239 SPELL_AURA_MOD_SCALE_2 only in Noggenfogger Elixir (16595) before 2.3.0 aura 61
+    &Unit::HandleNULLProc,                                  //240 SPELL_AURA_MOD_EXPERTISE
+    &Unit::HandleNULLProc,                                  //241 Forces the player to move forward
+    &Unit::HandleNULLProc,                                  //242 SPELL_AURA_MOD_SPELL_DAMAGE_FROM_HEALING
+    &Unit::HandleNULLProc,                                  //243 used by two test spells
+    &Unit::HandleNULLProc,                                  //244 Comprehend language
+    &Unit::HandleNULLProc,                                  //245 SPELL_AURA_MOD_DURATION_OF_MAGIC_EFFECTS
+    &Unit::HandleNULLProc,                                  //246 unused
+    &Unit::HandleNULLProc,                                  //247 unused
+    &Unit::HandleNULLProc,                                  //248 SPELL_AURA_MOD_COMBAT_RESULT_CHANCE
+    &Unit::HandleNULLProc,                                  //249
+    &Unit::HandleNULLProc,                                  //250 SPELL_AURA_MOD_INCREASE_HEALTH_2
+    &Unit::HandleNULLProc,                                  //251 SPELL_AURA_MOD_ENEMY_DODGE
+    &Unit::HandleNULLProc,                                  //252 unused
+    &Unit::HandleNULLProc,                                  //253 unused
+    &Unit::HandleNULLProc,                                  //254 unused
+    &Unit::HandleNULLProc,                                  //255 unused
+    &Unit::HandleNULLProc,                                  //256 unused
+    &Unit::HandleNULLProc,                                  //257 unused
+    &Unit::HandleNULLProc,                                  //258 unused
+    &Unit::HandleNULLProc,                                  //259 unused
+    &Unit::HandleNULLProc,                                  //260 unused
+    &Unit::HandleNULLProc,                                  //261 SPELL_AURA_261 some phased state (44856 spell)
 };
 
-typedef std::array<uint32, NUM_SPELL_PARTIAL_RESISTS> SpellPartialResistChanceEntry;
-typedef std::vector<SpellPartialResistChanceEntry> SpellPartialResistDistribution;
-static inline SpellPartialResistDistribution InitSpellPartialResistDistribution()
+bool Unit::IsTriggeredAtSpellProcEvent(Unit* pVictim, SpellAuraHolder* holder, SpellEntry const* procSpell, uint32 procFlag, uint32 procExtra, WeaponAttackType attType, bool isVictim, SpellProcEventEntry const*& spellProcEvent)
 {
-    // Precalculated chances for 0-100% mitigation
-    // We use integer random instead of floats, so each chance is premultiplied by 100 (100.00 becomes 10000)
-    const SpellPartialResistDistribution precalculated = {
-        {{10000,0,0,0,0}},
-        {{9700,200,100,0,0}},
-        {{9400,400,200,0,0}},
-        {{9000,800,200,0,0}},
-        {{8700,1000,300,0,0}},
-        {{8400,1200,400,0,0}},
-        {{8200,1300,400,100,0}},
-        {{7900,1500,500,100,0}},
-        {{7600,1700,600,100,0}},
-        {{7300,1900,700,100,0}},
-        {{6900,2300,700,100,0}},
-        {{6600,2500,800,100,0}},
-        {{6300,2700,900,100,0}},
-        {{6000,2900,1000,100,0}},
-        {{5800,3000,1000,200,0}},
-        {{5400,3300,1100,200,0}},
-        {{5100,3600,1100,200,0}},
-        {{4800,3800,1200,200,0}},
-        {{4400,4200,1200,200,0}},
-        {{4100,4400,1300,200,0}},
-        {{3700,4800,1300,200,0}},
-        {{3400,5000,1400,200,0}},
-        {{3100,5200,1500,200,0}},
-        {{3000,5200,1500,200,100}},
-        {{2800,5300,1500,300,100}},
-        {{2500,5500,1600,300,100}},
-        {{2400,5400,1700,400,100}},
-        {{2300,5300,1800,500,100}},
-        {{2200,5100,2100,500,100}},
-        {{2100,5000,2200,600,100}},
-        {{2000,4900,2400,600,100}},
-        {{1900,4700,2600,700,100}},
-        {{1800,4600,2700,800,100}},
-        {{1700,4400,3000,800,100}},
-        {{1600,4300,3100,900,100}},
-        {{1500,4200,3200,1000,100}},
-        {{1400,4100,3300,1100,100}},
-        {{1300,3900,3600,1100,100}},
-        {{1300,3600,3800,1200,100}},
-        {{1200,3500,3900,1300,100}},
-        {{1100,3400,4000,1400,100}},
-        {{1000,3300,4100,1500,100}},
-        {{900,3100,4400,1500,100}},
-        {{800,3000,4500,1600,100}},
-        {{800,2700,4700,1700,100}},
-        {{700,2600,4800,1800,100}},
-        {{600,2500,4900,1900,100}},
-        {{600,2300,5000,1900,200}},
-        {{500,2200,5100,2000,200}},
-        {{300,2200,5300,2000,200}},
-        {{200,2100,5400,2100,200}},
-        {{200,2000,5300,2200,300}},
-        {{200,2000,5100,2200,500}},
-        {{200,1900,5000,2300,600}},
-        {{100,1900,4900,2500,600}},
-        {{100,1800,4800,2600,700}},
-        {{100,1700,4700,2700,800}},
-        {{100,1600,4500,3000,800}},
-        {{100,1500,4400,3100,900}},
-        {{100,1500,4100,3300,1000}},
-        {{100,1400,4000,3400,1100}},
-        {{100,1300,3900,3500,1200}},
-        {{100,1200,3800,3600,1300}},
-        {{100,1100,3600,3900,1300}},
-        {{100,1100,3300,4100,1400}},
-        {{100,1000,3200,4200,1500}},
-        {{100,900,3100,4300,1600}},
-        {{100,800,3000,4400,1700}},
-        {{100,800,2700,4600,1800}},
-        {{100,700,2600,4700,1900}},
-        {{100,600,2400,4900,2000}},
-        {{100,600,2200,5000,2100}},
-        {{100,500,2100,5100,2200}},
-        {{100,500,1800,5300,2300}},
-        {{100,400,1700,5400,2400}},
-        {{100,300,1600,5500,2500}},
-        {{100,300,1500,5300,2800}},
-        {{100,200,1500,5200,3000}},
-        {{0,200,1500,5200,3100}},
-        {{0,200,1400,5000,3400}},
-        {{0,200,1300,4800,3700}},
-        {{0,200,1300,4400,4100}},
-        {{0,200,1200,4200,4400}},
-        {{0,200,1200,3800,4800}},
-        {{0,200,1100,3600,5100}},
-        {{0,200,1100,3300,5400}},
-        {{0,200,1000,3000,5800}},
-        {{0,100,1000,2900,6000}},
-        {{0,100,900,2700,6300}},
-        {{0,100,800,2500,6600}},
-        {{0,100,700,2300,6900}},
-        {{0,100,700,1900,7300}},
-        {{0,100,600,1700,7600}},
-        {{0,100,500,1500,7900}},
-        {{0,100,400,1300,8200}},
-        {{0,0,400,1200,8400}},
-        {{0,0,300,1000,8700}},
-        {{0,0,200,800,9000}},
-        {{0,0,200,400,9400}},
-        {{0,0,100,200,9700}},
-        {{0,0,0,0,10000}},
-    };
-    // Inflate up to two decimal places of chance %: add all intermediate values and 100% value (100*100 + 1)
-    SpellPartialResistDistribution inflated(10001, {{}});
-    for (size_t row = 0; row < precalculated.size(); ++row)
+    SpellEntry const* spellProto = holder->GetSpellProto();
+
+    // Get proc Event Entry
+    spellProcEvent = sSpellMgr.GetSpellProcEvent(spellProto->Id);
+
+    // Get EventProcFlag
+    uint32 EventProcFlag;
+    if (spellProcEvent && spellProcEvent->procFlags) // if exist get custom spellProcEvent->procFlags
+        EventProcFlag = spellProcEvent->procFlags;
+    else
+        EventProcFlag = spellProto->procFlags;       // else get from spell proto
+    // Continue if no trigger exist
+    if (!EventProcFlag)
+        return false;
+
+    // Check spellProcEvent data requirements
+    if (!SpellMgr::IsSpellProcEventCanTriggeredBy(spellProcEvent, EventProcFlag, procSpell, procFlag, procExtra))
+        return false;
+
+    // In most cases req get honor or XP from kill
+    if (EventProcFlag & PROC_FLAG_KILL && GetTypeId() == TYPEID_PLAYER)
     {
-        const size_t next = (row + 1);
-        const size_t shift = (row * 100);
-        const auto &source = precalculated.at(row);
-        // Check if this is the last one first
-        if (next == precalculated.size())
+        bool allow = ((Player*)this)->isHonorOrXPTarget(pVictim);
+        // Shadow Word: Death - can trigger from every kill
+        if (holder->GetId() == 32409)
+            allow = true;
+        if (!allow)
+            return false;
+    }
+    // Aura added by spell can`t trigger from self (prevent drop charges/do triggers)
+    // But except periodic triggers (can triggered from self)
+    if (procSpell && procSpell->Id == spellProto->Id && !(EventProcFlag & PROC_FLAG_ON_TAKE_PERIODIC))
+        return false;
+
+    // Check if current equipment allows aura to proc
+    if (!isVictim && GetTypeId() == TYPEID_PLAYER)
+    {
+        if (spellProto->EquippedItemClass == ITEM_CLASS_WEAPON)
         {
-            for (uint8 column = SPELL_PARTIAL_RESIST_NONE; column < NUM_SPELL_PARTIAL_RESISTS; ++column)
-                inflated[shift][column] = source.at(column);
-            break;
-        }
-        const auto &ahead = precalculated.at(next);
-        for (size_t intermediate = 0; intermediate < 100; ++intermediate)
-        {
-            const size_t index = (shift + intermediate);
-            auto &values = inflated[index];
-            for (uint8 column = SPELL_PARTIAL_RESIST_NONE; column < NUM_SPELL_PARTIAL_RESISTS; ++column)
-            {
-                const uint32 base = source.at(column);
-                const uint32 upcoming = ahead.at(column);
-                const int64 diff = (int64(upcoming) - base);
-                // Use bigger types signed math to avoid potential erratic behavior on some compilers...
-                values[column] = uint32(std::max(0.0, (base + std::round(diff * (intermediate / double(100.0))))));
-            }
-        }
-    }
-    return inflated;
-}
-
-static const SpellPartialResistDistribution SPELL_PARTIAL_RESIST_DISTRIBUTION = InitSpellPartialResistDistribution();
-
-////////////////////////////////////////////////////////////
-// Methods of class MovementInfo
-
-void MovementInfo::Read(ByteBuffer& data)
-{
-    data >> moveFlags;
-    data >> moveFlags2;
-    data >> time;
-    data >> pos.x;
-    data >> pos.y;
-    data >> pos.z;
-    data >> pos.o;
-
-    if (HasMovementFlag(MOVEFLAG_ONTRANSPORT))
-    {
-        data >> t_guid;
-        data >> t_pos.x;
-        data >> t_pos.y;
-        data >> t_pos.z;
-        data >> t_pos.o;
-        data >> t_time;
-    }
-
-    if (HasMovementFlag(MovementFlags(MOVEFLAG_SWIMMING | MOVEFLAG_FLYING2)))
-    {
-        data >> s_pitch;
-    }
-
-    data >> fallTime;
-
-    if (HasMovementFlag(MOVEFLAG_FALLING))
-    {
-        data >> jump.velocity;
-        data >> jump.sinAngle;
-        data >> jump.cosAngle;
-        data >> jump.xyspeed;
-    }
-
-    if (HasMovementFlag(MOVEFLAG_SPLINE_ELEVATION))
-    {
-        data >> u_unk1;
-    }
-}
-
-void MovementInfo::Write(ByteBuffer& data) const
-{
-    data << moveFlags;
-    data << moveFlags2;
-    data << time;
-    data << pos.x;
-    data << pos.y;
-    data << pos.z;
-    data << pos.o;
-
-    if (HasMovementFlag(MOVEFLAG_ONTRANSPORT))
-    {
-        data << t_guid;
-        data << t_pos.x;
-        data << t_pos.y;
-        data << t_pos.z;
-        data << t_pos.o;
-        data << t_time;
-    }
-
-    if (HasMovementFlag(MovementFlags(MOVEFLAG_SWIMMING | MOVEFLAG_FLYING2)))
-    {
-        data << s_pitch;
-    }
-
-    data << fallTime;
-
-    if (HasMovementFlag(MOVEFLAG_FALLING))
-    {
-        data << jump.velocity;
-        data << jump.sinAngle;
-        data << jump.cosAngle;
-        data << jump.xyspeed;
-    }
-
-    if (HasMovementFlag(MOVEFLAG_SPLINE_ELEVATION))
-    {
-        data << u_unk1;
-    }
-}
-
-////////////////////////////////////////////////////////////
-// Methods of class GlobalCooldownMgr
-
-bool GlobalCooldownMgr::HasGlobalCooldown(SpellEntry const* spellInfo) const
-{
-    GlobalCooldownList::const_iterator itr = m_GlobalCooldowns.find(spellInfo->StartRecoveryCategory);
-    return itr != m_GlobalCooldowns.end() && itr->second.duration && WorldTimer::getMSTimeDiff(itr->second.cast_time, WorldTimer::getMSTime()) < itr->second.duration;
-}
-
-void GlobalCooldownMgr::AddGlobalCooldown(SpellEntry const* spellInfo, uint32 gcd)
-{
-    m_GlobalCooldowns[spellInfo->StartRecoveryCategory] = GlobalCooldown(gcd, WorldTimer::getMSTime());
-}
-
-void GlobalCooldownMgr::CancelGlobalCooldown(SpellEntry const* spellInfo)
-{
-    m_GlobalCooldowns[spellInfo->StartRecoveryCategory].duration = 0;
-}
-
-////////////////////////////////////////////////////////////
-// Methods of class Unit
-
-Unit::Unit() :
-    movespline(new Movement::MoveSpline()),
-    m_charmInfo(nullptr),
-    i_motionMaster(this),
-    m_regenTimer(0),
-    m_combatData(new CombatData(this))
-{
-    m_objectType |= TYPEMASK_UNIT;
-    m_objectTypeId = TYPEID_UNIT;
-    // 2.3.2 - 0x70
-    m_updateFlag = (UPDATEFLAG_HIGHGUID | UPDATEFLAG_LIVING | UPDATEFLAG_HAS_POSITION);
-
-    m_attackTimer[BASE_ATTACK]   = 0;
-    m_attackTimer[OFF_ATTACK]    = 0;
-    m_attackTimer[RANGED_ATTACK] = 0;
-    m_modAttackSpeedPct[BASE_ATTACK] = 1.0f;
-    m_modAttackSpeedPct[OFF_ATTACK] = 1.0f;
-    m_modAttackSpeedPct[RANGED_ATTACK] = 1.0f;
-
-    m_extraAttacks = 0;
-
-    m_state = 0;
-    m_deathState = ALIVE;
-
-    for (uint32 i = 0; i < CURRENT_MAX_SPELL; ++i)
-        m_currentSpells[i] = nullptr;
-
-    m_castCounter = 0;
-
-    // m_Aura = nullptr;
-    // m_AurasCheck = 2000;
-    // m_removeAuraTimer = 4;
-    m_spellAuraHoldersUpdateIterator = m_spellAuraHolders.end();
-    m_AuraFlags = 0;
-
-    m_Visibility = VISIBILITY_ON;
-    m_AINotifyScheduled = false;
-
-    m_detectInvisibilityMask = 0;
-    m_invisibilityMask = 0;
-    m_transform = 0;
-    m_canModifyStats = false;
-
-    for (int i = 0; i < MAX_SPELL_IMMUNITY; ++i)
-        m_spellImmune[i].clear();
-    for (int i = 0; i < UNIT_MOD_END; ++i)
-    {
-        m_auraModifiersGroup[i][BASE_VALUE] = 0.0f;
-        m_auraModifiersGroup[i][BASE_EXCLUSIVE] = 0.0f;
-        m_auraModifiersGroup[i][BASE_PCT] = 1.0f;
-        m_auraModifiersGroup[i][TOTAL_VALUE] = 0.0f;
-        m_auraModifiersGroup[i][TOTAL_PCT] = 1.0f;
-    }
-
-    // implement 50% base damage from offhand
-    m_auraModifiersGroup[UNIT_MOD_DAMAGE_OFFHAND][TOTAL_PCT] = 0.5f;
-
-    for (int i = 0; i < MAX_ATTACK; ++i)
-    {
-        m_weaponDamage[i][MINDAMAGE] = BASE_MINDAMAGE;
-        m_weaponDamage[i][MAXDAMAGE] = BASE_MAXDAMAGE;
-    }
-    for (int i = 0; i < MAX_STATS; ++i)
-        m_createStats[i] = 0.0f;
-
-    m_attacking = nullptr;
-    m_modMeleeHitChance = 0.0f;
-    m_modRangedHitChance = 0.0f;
-    m_modSpellHitChance = 0.0f;
-    for (int i = 0; i < MAX_SPELL_SCHOOL; ++i)
-        m_modSpellCritChance[i] = 0.0f;
-
-    for (int i = 0; i < MAX_ATTACK; ++i)
-        m_modCritChance[i] = 0.0f;
-    m_modDodgeChance = 0.0f;
-    m_modParryChance = 0.0f;
-    m_modBlockChance = 0.0f;
-
-    m_canDodge = true;
-    m_canParry = true;
-    m_canBlock = true;
-
-    m_CombatTimer = 0;
-    m_lastManaUseTimer = 0;
-
-    // m_victimThreat = 0.0f;
-    for (int i = 0; i < MAX_SPELL_SCHOOL; ++i)
-        m_threatModifier[i] = 1.0f;
-    m_isSorted = true;
-    for (int i = 0; i < MAX_MOVE_TYPE; ++i)
-        m_speed_rate[i] = 1.0f;
-
-    // remove aurastates allowing special moves
-    for (int i = 0; i < MAX_REACTIVE; ++i)
-        m_reactiveTimer[i] = 0;
-
-    m_isCreatureLinkingTrigger = false;
-    m_isSpawningLinked = false;
-}
-
-Unit::~Unit()
-{
-    // set current spells as deletable
-    for (uint32 i = 0; i < CURRENT_MAX_SPELL; ++i)
-    {
-        if (m_currentSpells[i])
-        {
-            m_currentSpells[i]->SetReferencedFromCurrent(false);
-            m_currentSpells[i] = nullptr;
-        }
-    }
-
-    delete m_combatData;
-    delete m_charmInfo;
-    delete movespline;
-
-    // those should be already removed at "RemoveFromWorld()" call
-    MANGOS_ASSERT(m_gameObj.size() == 0);
-    MANGOS_ASSERT(m_dynObjGUIDs.size() == 0);
-    MANGOS_ASSERT(m_deletedAuras.size() == 0);
-    MANGOS_ASSERT(m_deletedHolders.size() == 0);
-}
-
-void Unit::Update(uint32 update_diff, uint32 p_time)
-{
-    if (!IsInWorld())
-        return;
-
-    /*if(p_time > m_AurasCheck)
-    {
-    m_AurasCheck = 2000;
-    _UpdateAura();
-    }else
-    m_AurasCheck -= p_time;*/
-
-    // WARNING! Order of execution here is important, do not change.
-    // Spells must be processed with event system BEFORE they go to _UpdateSpells.
-    // Or else we may have some SPELL_STATE_FINISHED spells stalled in pointers, that is bad.
-    m_Events.Update(update_diff);
-    _UpdateSpells(update_diff);
-
-    CleanupDeletedAuras();
-
-    if (m_lastManaUseTimer)
-    {
-        if (update_diff >= m_lastManaUseTimer)
-            m_lastManaUseTimer = 0;
-        else
-            m_lastManaUseTimer -= update_diff;
-    }
-
-    if (!CanHaveThreatList() && isInCombat())
-    {
-        // update combat timer only for players and pets (they have no threat list)
-        // Check UNIT_STAT_MELEE_ATTACKING or UNIT_STAT_CHASE (without UNIT_STAT_FOLLOW in this case) so pets can reach far away
-        // targets without stopping half way there and running off.
-        // These flags are reset after target dies or another command is given.
-        if (getHostileRefManager().isEmpty())
-        {
-            // m_CombatTimer set at aura start and it will be freeze until aura removing
-            if (m_CombatTimer <= update_diff)
-                CombatStop();
+            Item* item;
+            if (attType == BASE_ATTACK)
+                item = ((Player*)this)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+            else if (attType == OFF_ATTACK)
+                item = ((Player*)this)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
             else
-                m_CombatTimer -= update_diff;
+                item = ((Player*)this)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_RANGED);
+
+            if (!CanUseEquippedWeapon(attType))
+                return false;
+
+            if (!item || item->IsBroken() || item->GetProto()->Class != ITEM_CLASS_WEAPON || !((1 << item->GetProto()->SubClass) & spellProto->EquippedItemSubClassMask))
+                return false;
+        }
+        else if (spellProto->EquippedItemClass == ITEM_CLASS_ARMOR)
+        {
+            // Check if player is wearing shield
+            Item* item = ((Player*)this)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
+            if (!item || item->IsBroken() || item->GetProto()->Class != ITEM_CLASS_ARMOR || !((1 << item->GetProto()->SubClass) & spellProto->EquippedItemSubClassMask))
+                return false;
         }
     }
-
-    if (uint32 base_att = getAttackTimer(BASE_ATTACK))
+    // Get chance from spell
+    float chance = (float)spellProto->procChance;
+    // If in spellProcEvent exist custom chance, chance = spellProcEvent->customChance;
+    if (spellProcEvent && spellProcEvent->customChance)
+        chance = spellProcEvent->customChance;
+    // If PPM exist calculate chance from PPM
+    if (!isVictim && spellProcEvent && spellProcEvent->ppmRate != 0)
     {
-        setAttackTimer(BASE_ATTACK, (update_diff >= base_att ? 0 : base_att - update_diff));
+        uint32 WeaponSpeed = GetAttackTime(attType);
+        chance = GetPPMProcChance(WeaponSpeed, spellProcEvent->ppmRate);
+    }
+    // Apply chance modifier aura
+    if (Player* modOwner = GetSpellModOwner())
+    {
+        modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_CHANCE_OF_SUCCESS, chance);
     }
 
-    if (uint32 base_att = getAttackTimer(OFF_ATTACK))
-    {
-        setAttackTimer(OFF_ATTACK, (update_diff >= base_att ? 0 : base_att - update_diff));
-    }
-
-    // update abilities available only for fraction of time
-    UpdateReactives(update_diff);
-
-    UpdateSplineMovement(p_time);
-    i_motionMaster.UpdateMotion(p_time);
-
-    if (AI() && isAlive())
-        AI()->UpdateAI(p_time);   // AI not react good at real update delays (while freeze in non-active part of map)
-
-    if (isAlive())
-    {
-        ModifyAuraState(AURA_STATE_HEALTHLESS_20_PERCENT, GetHealth() < GetMaxHealth() * 0.20f);
-        ModifyAuraState(AURA_STATE_HEALTHLESS_35_PERCENT, GetHealth() < GetMaxHealth() * 0.35f);
-    }
+    return roll_chance_f(chance);
 }
 
-bool Unit::UpdateMeleeAttackingState()
+SpellAuraProcResult Unit::HandleHasteAuraProc(Unit* pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 cooldown)
 {
-    Unit* victim = getVictim();
-    if (!victim || IsNonMeleeSpellCasted(false))
-        return false;
+    SpellEntry const* hasteSpell = triggeredByAura->GetSpellProto();
 
-    if (!isAttackReady(BASE_ATTACK) && !(isAttackReady(OFF_ATTACK) && haveOffhandWeapon()))
-        return false;
+    Item* castItem = triggeredByAura->GetCastItemGuid() && GetTypeId() == TYPEID_PLAYER
+                     ? ((Player*)this)->GetItemByGuid(triggeredByAura->GetCastItemGuid()) : nullptr;
 
-    uint8 swingError = 0;
-    if (!CanReachWithMeleeAttack(victim))
+    uint32 triggered_spell_id = 0;
+    Unit* target = pVictim;
+    int32 basepoints0 = 0;
+
+    switch (hasteSpell->SpellFamilyName)
     {
-        setAttackTimer(BASE_ATTACK, 100);
-        setAttackTimer(OFF_ATTACK, 100);
-        swingError = 1;
-    }
-    // 120 degrees of radiant range
-    else if (!HasInArc(2 * M_PI_F / 3, victim))
-    {
-        setAttackTimer(BASE_ATTACK, 100);
-        setAttackTimer(OFF_ATTACK, 100);
-        swingError = 2;
-    }
-    else
-    {
-        if (isAttackReady(BASE_ATTACK))
+        case SPELLFAMILY_ROGUE:
         {
-            // prevent base and off attack in same time, delay attack at 0.2 sec
-            if (haveOffhandWeapon())
+            switch (hasteSpell->Id)
             {
-                if (getAttackTimer(OFF_ATTACK) < ATTACK_DISPLAY_DELAY)
-                    setAttackTimer(OFF_ATTACK, ATTACK_DISPLAY_DELAY);
-            }
-            AttackerStateUpdate(victim, BASE_ATTACK);
-            resetAttackTimer(BASE_ATTACK);
-        }
-        if (haveOffhandWeapon() && isAttackReady(OFF_ATTACK))
-        {
-            // prevent base and off attack in same time, delay attack at 0.2 sec
-            uint32 base_att = getAttackTimer(BASE_ATTACK);
-            if (base_att < ATTACK_DISPLAY_DELAY)
-                setAttackTimer(BASE_ATTACK, ATTACK_DISPLAY_DELAY);
-            // do attack
-            AttackerStateUpdate(victim, OFF_ATTACK);
-            resetAttackTimer(OFF_ATTACK);
-        }
-    }
-
-    Player* player = (GetTypeId() == TYPEID_PLAYER ? (Player*)this : nullptr);
-    if (player && swingError != player->LastSwingErrorMsg())
-    {
-        if (swingError == 1)
-            player->SendAttackSwingNotInRange();
-        else if (swingError == 2)
-            player->SendAttackSwingBadFacingAttack();
-        player->SwingErrorMsg(swingError);
-    }
-
-    return !!swingError;
-}
-
-bool Unit::haveOffhandWeapon() const
-{
-    if (!CanUseEquippedWeapon(OFF_ATTACK))
-        return false;
-
-    if (GetTypeId() == TYPEID_PLAYER)
-        return !!((Player*)this)->GetWeaponForAttack(OFF_ATTACK, true, true);
-    else
-    {
-        uint8 itemClass = GetByteValue(UNIT_VIRTUAL_ITEM_INFO + (1 * 2) + 0, VIRTUAL_ITEM_INFO_0_OFFSET_CLASS);
-        if (itemClass == ITEM_CLASS_WEAPON)
-            return true;
-
-        return false;
-    }
-}
-
-void Unit::SendHeartBeat()
-{
-    m_movementInfo.UpdateTime(WorldTimer::getMSTime());
-    WorldPacket data(MSG_MOVE_HEARTBEAT, 64);
-    data << GetPackGUID();
-    data << m_movementInfo;
-    SendMessageToSet(data, true);
-}
-
-void Unit::resetAttackTimer(WeaponAttackType type)
-{
-    m_attackTimer[type] = uint32(GetAttackTime(type) * m_modAttackSpeedPct[type]);
-}
-
-float Unit::GetCombatReach(Unit const* pVictim, bool forMeleeRange /*=true*/, float flat_mod /*=0.0f*/) const
-{
-    // The measured values show BASE_MELEE_OFFSET in (1.3224, 1.342)
-    float reach = GetFloatValue(UNIT_FIELD_COMBATREACH) + pVictim->GetFloatValue(UNIT_FIELD_COMBATREACH) +
-                  BASE_MELEERANGE_OFFSET + flat_mod;
-
-    if (forMeleeRange && reach < ATTACK_DISTANCE)
-        reach = ATTACK_DISTANCE;
-
-    return reach;
-}
-
-float Unit::GetCombatDistance(Unit const* target, bool forMeleeRange) const
-{
-    float radius = GetCombatReach(target, forMeleeRange);
-
-    float dx = GetPositionX() - target->GetPositionX();
-    float dy = GetPositionY() - target->GetPositionY();
-    float dz = GetPositionZ() - target->GetPositionZ();
-    float dist = sqrt((dx * dx) + (dy * dy) + (dz * dz)) - radius;
-
-    return (dist > 0.0f ? dist : 0.0f);
-}
-
-bool Unit::CanReachWithMeleeAttack(Unit const* pVictim, float flat_mod /*= 0.0f*/) const
-{
-    MANGOS_ASSERT(pVictim);
-
-    float reach = GetCombatReach(pVictim, true, flat_mod);
-
-    // This check is not related to bounding radius
-    float dx = GetPositionX() - pVictim->GetPositionX();
-    float dy = GetPositionY() - pVictim->GetPositionY();
-    float dz = GetPositionZ() - pVictim->GetPositionZ();
-
-    return dx * dx + dy * dy + dz * dz < reach * reach;
-}
-
-void Unit::RemoveSpellsCausingAura(AuraType auraType)
-{
-    for (AuraList::const_iterator iter = m_modAuras[auraType].begin(); iter != m_modAuras[auraType].end();)
-    {
-        RemoveAurasDueToSpell((*iter)->GetId());
-        iter = m_modAuras[auraType].begin();
-    }
-}
-
-void Unit::RemoveSpellsCausingAura(AuraType auraType, SpellAuraHolder* except)
-{
-    for (AuraList::const_iterator iter = m_modAuras[auraType].begin(); iter != m_modAuras[auraType].end();)
-    {
-        // skip `except` aura
-        if ((*iter)->GetHolder() == except)
-        {
-            ++iter;
-            continue;
-        }
-
-        RemoveAurasDueToSpell((*iter)->GetId(), except);
-        iter = m_modAuras[auraType].begin();
-    }
-}
-
-void Unit::RemoveSpellsCausingAura(AuraType auraType, ObjectGuid casterGuid)
-{
-    for (AuraList::const_iterator iter = m_modAuras[auraType].begin(); iter != m_modAuras[auraType].end();)
-    {
-        if ((*iter)->GetCasterGuid() == casterGuid)
-        {
-            RemoveAuraHolderFromStack((*iter)->GetId(), 1, casterGuid);
-            iter = m_modAuras[auraType].begin();
-        }
-        else
-            ++iter;
-    }
-}
-
-void Unit::DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb, DamageEffectType damagetype, SpellEntry const* spellProto)
-{
-    if (!pVictim->isAlive() || pVictim->IsTaxiFlying() || (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode()))
-    {
-        if (absorb)
-            *absorb += damage;
-        damage = 0;
-        return;
-    }
-
-    // You don't lose health from damage taken from another player while in a sanctuary
-    // You still see it in the combat log though
-    if (!IsAllowedDamageInArea(pVictim))
-    {
-        if (absorb)
-            *absorb += damage;
-        damage = 0;
-    }
-
-    uint32 originalDamage = damage;
-
-    // Script Event damage Deal
-    if (AI())
-        AI()->DamageDeal(pVictim, damage, damagetype, spellProto);
-    // Script Event damage taken
-    if (pVictim->AI())
-        pVictim->AI()->DamageTaken(this, damage, damagetype, spellProto);
-
-    if (absorb && originalDamage > damage)
-        *absorb += (originalDamage - damage);
-}
-
-uint32 Unit::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDamage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask, SpellEntry const* spellProto, bool durabilityLoss)
-{
-    // remove affects from attacker at any non-DoT damage (including 0 damage)
-    if (damagetype != DOT)
-    {
-        if (damagetype != SELF_DAMAGE_ROGUE_FALL)
-            RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
-        RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
-
-        if (pVictim->GetTypeId() == TYPEID_PLAYER && !pVictim->IsStandState() && !pVictim->hasUnitState(UNIT_STAT_STUNNED))
-            pVictim->SetStandState(UNIT_STAND_STATE_STAND);
-    }
-
-    if (!damage)
-    {
-        // Rage from physical damage received .
-        if (cleanDamage && cleanDamage->damage && (damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL) && pVictim->GetTypeId() == TYPEID_PLAYER && (pVictim->GetPowerType() == POWER_RAGE))
-            ((Player*)pVictim)->RewardRage(cleanDamage->damage, 0, false);
-
-        return 0;
-    }
-
-    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamageStart");
-
-    uint32 health = pVictim->GetHealth();
-    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "deal dmg:%d to health:%d ", damage, health);
-
-    // Rage from Damage made (only from direct weapon damage)
-    if (cleanDamage && damagetype == DIRECT_DAMAGE && this != pVictim && GetTypeId() == TYPEID_PLAYER && (GetPowerType() == POWER_RAGE))
-    {
-        uint32 weaponSpeedHitFactor;
-
-        switch (cleanDamage->attackType)
-        {
-            case BASE_ATTACK:
-            {
-                if (cleanDamage->hitOutCome == MELEE_HIT_CRIT)
-                    weaponSpeedHitFactor = uint32(GetAttackTime(cleanDamage->attackType) / 1000.0f * 7);
-                else
-                    weaponSpeedHitFactor = uint32(GetAttackTime(cleanDamage->attackType) / 1000.0f * 3.5f);
-
-                ((Player*)this)->RewardRage(damage, weaponSpeedHitFactor, true);
-
-                break;
-            }
-            case OFF_ATTACK:
-            {
-                if (cleanDamage->hitOutCome == MELEE_HIT_CRIT)
-                    weaponSpeedHitFactor = uint32(GetAttackTime(cleanDamage->attackType) / 1000.0f * 3.5f);
-                else
-                    weaponSpeedHitFactor = uint32(GetAttackTime(cleanDamage->attackType) / 1000.0f * 1.75f);
-
-                ((Player*)this)->RewardRage(damage, weaponSpeedHitFactor, true);
-
-                break;
-            }
-            case RANGED_ATTACK:
-                break;
-        }
-    }
-
-    // no xp,health if type 8 /critters/
-    if (pVictim->GetTypeId() == TYPEID_UNIT && pVictim->GetCreatureType() == CREATURE_TYPE_CRITTER)
-    {
-        // TODO: fix this part
-        // Critter may not die of damage taken, instead expect it to run away (no fighting back)
-        // If (this) is TYPEID_PLAYER, (this) will enter combat w/victim, but after some time, automatically leave combat.
-        // It is unclear how it should work for other cases.
-        DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamage critter, critter dies");
-
-        ((Creature*)pVictim)->SetLootRecipient(this);
-
-        JustKilledCreature((Creature*)pVictim, nullptr);
-        pVictim->SetHealth(0);
-
-        return damage;
-    }
-
-    // duel ends when player has 1 or less hp
-    bool duel_hasEnded = false;
-    if (pVictim->GetTypeId() == TYPEID_PLAYER && ((Player*)pVictim)->duel && damage >= (health - 1))
-    {
-        // prevent kill only if killed in duel and killed by opponent or opponent controlled creature
-        if (((Player*)pVictim)->duel->opponent == this || ((Player*)pVictim)->duel->opponent->GetObjectGuid() == GetOwnerGuid())
-            damage = health - 1;
-
-        duel_hasEnded = true;
-    }
-
-    // Get in CombatState
-    if (pVictim != this && damagetype != DOT && (!spellProto || (!IsPositiveSpellTargetMode(spellProto, this, pVictim) && !spellProto->HasAttribute(SPELL_ATTR_EX3_NO_INITIAL_AGGRO))))
-    {
-        SetInCombatWith(pVictim);
-        pVictim->SetInCombatWith(this);
-
-        if (Player* attackedPlayer = pVictim->GetCharmerOrOwnerPlayerOrPlayerItself())
-            SetContestedPvP(attackedPlayer);
-    }
-
-    if (GetTypeId() == TYPEID_PLAYER && this != pVictim)
-    {
-        Player* killer = ((Player*)this);
-
-        // in bg, count dmg if victim is also a player
-        if (pVictim->GetTypeId() == TYPEID_PLAYER)
-        {
-            if (BattleGround* bg = killer->GetBattleGround())
-            {
-                // FIXME: kept by compatibility. don't know in BG if the restriction apply.
-                bg->UpdatePlayerScore(killer, SCORE_DAMAGE_DONE, damage);
-            }
-        }
-    }
-
-    if (pVictim->GetTypeId() == TYPEID_UNIT && !((Creature*)pVictim)->IsPet() && !((Creature*)pVictim)->HasLootRecipient())
-        ((Creature*)pVictim)->SetLootRecipient(this);
-
-    if (health <= damage)
-    {
-        DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamage %s Killed %s", GetGuidStr().c_str(), pVictim->GetGuidStr().c_str());
-
-        /*
-         *                      Preparation: Who gets credit for killing whom, invoke SpiritOfRedemtion?
-         */
-        // for loot will be used only if group_tap == nullptr
-        Player* player_tap = GetCharmerOrOwnerPlayerOrPlayerItself();
-        Group* group_tap = nullptr;
-
-        // in creature kill case group/player tap stored for creature
-        if (pVictim->GetTypeId() == TYPEID_UNIT)
-        {
-            group_tap = ((Creature*)pVictim)->GetGroupLootRecipient();
-
-            if (Player* recipient = ((Creature*)pVictim)->GetOriginalLootRecipient())
-                player_tap = recipient;
-        }
-        // in player kill case group tap selected by player_tap (killer-player itself, or charmer, or owner, etc)
-        else
-        {
-            if (player_tap)
-                group_tap = player_tap->GetGroup();
-        }
-
-        // Spirit of Redemtion Talent
-        bool damageFromSpiritOfRedemtionTalent = spellProto && spellProto->Id == 27795;
-        // if talent known but not triggered (check priest class for speedup check)
-        Aura* spiritOfRedemtionTalentReady = nullptr;
-        if (!damageFromSpiritOfRedemtionTalent &&           // not called from SPELL_AURA_SPIRIT_OF_REDEMPTION
-                pVictim->GetTypeId() == TYPEID_PLAYER && pVictim->getClass() == CLASS_PRIEST)
-        {
-            AuraList const& vDummyAuras = pVictim->GetAurasByType(SPELL_AURA_DUMMY);
-            for (AuraList::const_iterator itr = vDummyAuras.begin(); itr != vDummyAuras.end(); ++itr)
-            {
-                if ((*itr)->GetSpellProto()->SpellIconID == 1654)
+                // Blade Flurry
+                case 13877:
+                case 33735:
                 {
-                    spiritOfRedemtionTalentReady = *itr;
+                    target = SelectRandomUnfriendlyTarget(pVictim);
+                    if (!target)
+                        return SPELL_AURA_PROC_FAILED;
+                    basepoints0 = damage;
+                    triggered_spell_id = 22482;
                     break;
                 }
             }
+            break;
         }
-
-        /*
-         *                      Generic Actions (ProcEvents, Combat-Log, Kill Rewards, Stop Combat)
-         */
-        // call kill spell proc event (before real die and combat stop to triggering auras removed at death/combat stop)
-        if (player_tap && player_tap != pVictim)
-        {
-            player_tap->ProcDamageAndSpell(pVictim, PROC_FLAG_KILL, PROC_FLAG_KILLED, PROC_EX_NONE, 0);
-
-            WorldPacket data(SMSG_PARTYKILLLOG, (8 + 8));   // send event PARTY_KILL
-            data << player_tap->GetObjectGuid();            // player with killing blow
-            data << pVictim->GetObjectGuid();               // victim
-
-            if (group_tap)
-                group_tap->BroadcastPacket(data, false, group_tap->GetMemberGroup(player_tap->GetObjectGuid()), player_tap->GetObjectGuid());
-
-            player_tap->SendDirectMessage(data);
-        }
-        else if (GetTypeId() == TYPEID_UNIT && this != pVictim)
-            ProcDamageAndSpell(pVictim, PROC_FLAG_KILL, PROC_FLAG_KILLED, PROC_EX_NONE, 0);
-
-        // Reward player, his pets, and group/raid members
-        if (player_tap != pVictim)
-        {
-            if (group_tap)
-                group_tap->RewardGroupAtKill(pVictim, player_tap);
-            else if (player_tap)
-                player_tap->RewardSinglePlayerAtKill(pVictim);
-        }
-
-        /*
-         *                      Actions for the killer
-         */
-        if (spiritOfRedemtionTalentReady)
-        {
-            DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamage: Spirit of Redemtion ready");
-
-            // save value before aura remove
-            uint32 ressSpellId = pVictim->GetUInt32Value(PLAYER_SELF_RES_SPELL);
-            if (!ressSpellId)
-                ressSpellId = ((Player*)pVictim)->GetResurrectionSpellId();
-
-            // Remove all expected to remove at death auras (most important negative case like DoT or periodic triggers)
-            pVictim->RemoveAllAurasOnDeath();
-
-            // restore for use at real death
-            pVictim->SetUInt32Value(PLAYER_SELF_RES_SPELL, ressSpellId);
-
-            // FORM_SPIRITOFREDEMPTION and related auras
-            pVictim->CastSpell(pVictim, 27827, TRIGGERED_OLD_TRIGGERED, nullptr, spiritOfRedemtionTalentReady);
-        }
-        else
-            pVictim->SetHealth(0);
-
-        // Call KilledUnit for creatures
-        if (AI())
-            AI()->KilledUnit(pVictim);
-
-        // Call AI OwnerKilledUnit (for any current summoned minipet/guardian/protector)
-        PetOwnerKilledUnit(pVictim);
-
-        /*
-         *                      Actions for the victim
-         */
-        if (pVictim->GetTypeId() == TYPEID_PLAYER)          // Killed player
-        {
-            Player* playerVictim = (Player*)pVictim;
-
-            // remember victim PvP death for corpse type and corpse reclaim delay
-            // at original death (not at SpiritOfRedemtionTalent timeout)
-            if (!damageFromSpiritOfRedemtionTalent)
-                playerVictim->SetPvPDeath(player_tap != nullptr);
-
-            // 10% durability loss on death
-            // only if not player and not controlled by player pet. And not at BG
-            if (durabilityLoss && !player_tap && !playerVictim->InBattleGround())
-            {
-                DEBUG_LOG("DealDamage: Killed %s, looing 10 percents durability", pVictim->GetGuidStr().c_str());
-                playerVictim->DurabilityLossAll(0.10f, false);
-                // durability lost message
-                WorldPacket data(SMSG_DURABILITY_DAMAGE_DEATH, 0);
-                playerVictim->GetSession()->SendPacket(data);
-            }
-
-            if (!spiritOfRedemtionTalentReady)              // Before informing Battleground
-            {
-                DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "SET JUST_DIED");
-                pVictim->SetDeathState(JUST_DIED);
-            }
-
-            // playerVictim was in duel, duel must be interrupted
-            // last damage from non duel opponent or non opponent controlled creature
-            if (duel_hasEnded)
-            {
-                playerVictim->duel->opponent->CombatStopWithPets(true);
-                playerVictim->CombatStopWithPets(true);
-
-                playerVictim->DuelComplete(DUEL_INTERRUPTED);
-            }
-
-            if (player_tap)                                 // PvP kill
-            {
-                if (BattleGround* bg = playerVictim->GetBattleGround())
-                {
-                    bg->HandleKillPlayer(playerVictim, player_tap);
-                }
-                else if (pVictim != this)
-                {
-                    // selfkills are not handled in outdoor pvp scripts
-                    if (OutdoorPvP* outdoorPvP = sOutdoorPvPMgr.GetScript(playerVictim->GetCachedZoneId()))
-                        outdoorPvP->HandlePlayerKill(player_tap, playerVictim);
-                }
-            }
-        }
-        else                                                // Killed creature
-            JustKilledCreature((Creature*)pVictim, player_tap);
-
-        // stop combat
-        DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamageAttackStop");
-        pVictim->CombatStop();
-        pVictim->getHostileRefManager().deleteReferences();
     }
-    else                                                    // if (health <= damage)
+
+    // processed charge only counting case
+    if (!triggered_spell_id)
+        return SPELL_AURA_PROC_OK;
+
+    SpellEntry const* triggerEntry = sSpellTemplate.LookupEntry<SpellEntry>(triggered_spell_id);
+
+    if (!triggerEntry)
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamageAlive");
+        sLog.outError("Unit::HandleHasteAuraProc: Spell %u have nonexistent triggered spell %u", hasteSpell->Id, triggered_spell_id);
+        return SPELL_AURA_PROC_FAILED;
+    }
 
-        pVictim->ModifyHealth(- (int32)damage);
+    // default case
+    if (!target || (target != this && !target->isAlive()))
+        return SPELL_AURA_PROC_FAILED;
 
-        if (damagetype != DOT)
+    if (cooldown && GetTypeId() == TYPEID_PLAYER && ((Player*)this)->HasSpellCooldown(triggered_spell_id))
+        return SPELL_AURA_PROC_FAILED;
+
+    if (basepoints0)
+        CastCustomSpell(target, triggered_spell_id, &basepoints0, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+    else
+        CastSpell(target, triggered_spell_id, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+
+    if (cooldown && GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->AddSpellCooldown(triggered_spell_id, 0, time(nullptr) + cooldown);
+
+    return SPELL_AURA_PROC_OK;
+}
+
+SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 procFlag, uint32 procEx, uint32 cooldown)
+{
+    SpellEntry const* dummySpell = triggeredByAura->GetSpellProto();
+    SpellEffectIndex effIndex = triggeredByAura->GetEffIndex();
+    int32  triggerAmount = triggeredByAura->GetModifier()->m_amount;
+
+    Item* castItem = triggeredByAura->GetCastItemGuid() && GetTypeId() == TYPEID_PLAYER
+                     ? ((Player*)this)->GetItemByGuid(triggeredByAura->GetCastItemGuid()) : nullptr;
+
+    uint32 triggered_spell_id = 0;
+    Unit* target = pVictim;
+    int32  basepoints[MAX_EFFECT_INDEX] = {0, 0, 0};
+
+    sLog.outErrorDb("HandleDummyAuraProc : %u", dummySpell->Id);
+
+    switch (dummySpell->SpellFamilyName)
+    {
+        case SPELLFAMILY_GENERIC:
         {
-            if (!getVictim())
+            switch (dummySpell->Id)
             {
-                // if not have main target then attack state with target (including AI call)
-                // start melee attacks only after melee hit
-                Attack(pVictim, (damagetype == DIRECT_DAMAGE));
-            }
-
-            // if damage pVictim call AI reaction
-            pVictim->AttackedBy(this);
-        }
-
-        if (damagetype == DIRECT_DAMAGE || damagetype == SPELL_DIRECT_DAMAGE)
-        {
-            if (!spellProto || !(spellProto->AuraInterruptFlags & AURA_INTERRUPT_FLAG_DIRECT_DAMAGE))
-                pVictim->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_DIRECT_DAMAGE);
-        }
-        if (pVictim->GetTypeId() != TYPEID_PLAYER)
-        {
-            float threat = damage * sSpellMgr.GetSpellThreatMultiplier(spellProto);
-            pVictim->AddThreat(this, threat, (cleanDamage && cleanDamage->hitOutCome == MELEE_HIT_CRIT), damageSchoolMask, spellProto);
-        }
-        else                                                // victim is a player
-        {
-            // Rage from damage received
-            if (this != pVictim && pVictim->GetPowerType() == POWER_RAGE)
-            {
-                uint32 rage_damage = damage + (cleanDamage ? cleanDamage->damage : 0);
-                ((Player*)pVictim)->RewardRage(rage_damage, 0, false);
-            }
-
-            // random durability for items (HIT TAKEN)
-            if (roll_chance_f(sWorld.getConfig(CONFIG_FLOAT_RATE_DURABILITY_LOSS_DAMAGE)))
-            {
-                EquipmentSlots slot = EquipmentSlots(urand(0, EQUIPMENT_SLOT_END - 1));
-                ((Player*)pVictim)->DurabilityPointLossForEquipSlot(slot);
-            }
-        }
-
-        if (GetTypeId() == TYPEID_PLAYER)
-        {
-            // random durability for items (HIT DONE)
-            if (roll_chance_f(sWorld.getConfig(CONFIG_FLOAT_RATE_DURABILITY_LOSS_DAMAGE)))
-            {
-                EquipmentSlots slot = EquipmentSlots(urand(0, EQUIPMENT_SLOT_END - 1));
-                ((Player*)this)->DurabilityPointLossForEquipSlot(slot);
-            }
-        }
-
-        if ((damagetype == DIRECT_DAMAGE || damagetype == SPELL_DIRECT_DAMAGE || damagetype == DOT)
-            && !(spellProto && spellProto->HasAttribute(SPELL_ATTR_EX4_DAMAGE_DOESNT_BREAK_AURAS)))
-        {
-            int32 auraInterruptFlags = AURA_INTERRUPT_FLAG_DAMAGE;
-            if (damagetype != DOT)
-                auraInterruptFlags = (auraInterruptFlags | AURA_INTERRUPT_FLAG_DIRECT_DAMAGE);
-
-            SpellAuraHolderMap& vInterrupts = pVictim->GetSpellAuraHolderMap();
-            std::vector<uint32> cleanupHolder;
-
-            for (auto aura : vInterrupts)
-            {
-                if (spellProto && spellProto->Id == aura.second->GetId()) // Not drop auras added by self
-                    continue;
-
-                const SpellEntry* se = aura.second->GetSpellProto();
-
-                if (!se)
-                    continue;
-
-                if (se->AuraInterruptFlags & auraInterruptFlags)
-                    cleanupHolder.push_back(aura.second->GetId());
-            }
-
-            for (auto aura : cleanupHolder)
-                pVictim->RemoveAurasDueToSpell(aura);
-        }
-
-        if (damagetype != NODAMAGE && damage && pVictim->GetTypeId() == TYPEID_PLAYER)
-        {
-            if (damagetype != DOT)
-            {
-                for (uint32 i = CURRENT_FIRST_NON_MELEE_SPELL; i < CURRENT_MAX_SPELL; ++i)
+                // Eye for an Eye
+                case 9799:
+                case 25988:
                 {
-                    // skip channeled spell (processed differently below)
-                    if (i == CURRENT_CHANNELED_SPELL)
-                        continue;
+                    // prevent damage back from weapon special attacks
+                    if (!procSpell || procSpell->DmgClass != SPELL_DAMAGE_CLASS_MAGIC)
+                        return SPELL_AURA_PROC_FAILED;
 
-                    if (Spell* spell = pVictim->GetCurrentSpell(CurrentSpellTypes(i)))
+                    // return damage % to attacker but < 50% own total health
+                    basepoints[0] = triggerAmount * int32(damage) / 100;
+                    if (basepoints[0] > (int32)GetMaxHealth() / 2)
+                        basepoints[0] = (int32)GetMaxHealth() / 2;
+
+                    triggered_spell_id = 25997;
+                    break;
+                }
+                // Sweeping Strikes
+                case 12328:
+                case 18765:
+                case 35429:
+                {
+                    // prevent chain of triggered spell from same triggered spell
+                    if (procSpell && procSpell->Id == 26654)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    target = SelectRandomUnfriendlyTarget(pVictim);
+                    if (!target)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    triggered_spell_id = 26654;
+                    break;
+                }
+                // Twisted Reflection (boss spell)
+                case 21063:
+                    triggered_spell_id = 21064;
+                    break;
+                // Unstable Power
+                case 24658:
+                {
+                    if (!procSpell || procSpell->Id == 24659)
+                        return SPELL_AURA_PROC_FAILED;
+                    // Need remove one 24659 aura
+                    RemoveAuraHolderFromStack(24659);
+                    return SPELL_AURA_PROC_OK;
+                }
+                // Restless Strength
+                case 24661:
+                {
+                    // Need remove one 24662 aura
+                    RemoveAuraHolderFromStack(24662);
+                    return SPELL_AURA_PROC_OK;
+                }
+                // Adaptive Warding (Frostfire Regalia set)
+                case 28764:
+                {
+                    if (!procSpell)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // find Mage Armor
+                    bool found = false;
+                    AuraList const& mRegenInterrupt = GetAurasByType(SPELL_AURA_MOD_MANA_REGEN_INTERRUPT);
+                    for (AuraList::const_iterator iter = mRegenInterrupt.begin(); iter != mRegenInterrupt.end(); ++iter)
                     {
-                        if (spell->getState() == SPELL_STATE_PREPARING)
+                        if (SpellEntry const* iterSpellProto = (*iter)->GetSpellProto())
                         {
-                            if (spell->m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_ABORT_ON_DMG)
-                                pVictim->InterruptSpell(CurrentSpellTypes(i));
-                            else
-                                spell->Delayed();
+                            if (iterSpellProto->SpellFamilyName == SPELLFAMILY_MAGE && (iterSpellProto->SpellFamilyFlags & uint64(0x10000000)))
+                            {
+                                found = true;
+                                break;
+                            }
                         }
                     }
-                }
-            }
+                    if (!found)
+                        return SPELL_AURA_PROC_FAILED;
 
-            if (Spell* spell = pVictim->m_currentSpells[CURRENT_CHANNELED_SPELL])
-            {
-                if (spell->getState() == SPELL_STATE_CASTING)
-                {
-                    uint32 channelInterruptFlags = spell->m_spellInfo->ChannelInterruptFlags;
-                    if (channelInterruptFlags & CHANNEL_FLAG_DELAY)
+                    switch (GetFirstSchoolInMask(GetSpellSchoolMask(procSpell)))
                     {
-                        if (pVictim != this)                // don't shorten the duration of channeling if you damage yourself
-                            spell->DelayedChannel();
+                        case SPELL_SCHOOL_NORMAL:
+                        case SPELL_SCHOOL_HOLY:
+                            return SPELL_AURA_PROC_FAILED;  // ignored
+                        case SPELL_SCHOOL_FIRE:   triggered_spell_id = 28765; break;
+                        case SPELL_SCHOOL_NATURE: triggered_spell_id = 28768; break;
+                        case SPELL_SCHOOL_FROST:  triggered_spell_id = 28766; break;
+                        case SPELL_SCHOOL_SHADOW: triggered_spell_id = 28769; break;
+                        case SPELL_SCHOOL_ARCANE: triggered_spell_id = 28770; break;
+                        default:
+                            return SPELL_AURA_PROC_FAILED;
                     }
-                    else if ((channelInterruptFlags & (CHANNEL_FLAG_DAMAGE | CHANNEL_FLAG_DAMAGE2)))
-                    {
-                        DETAIL_LOG("Spell %u canceled at damage!", spell->m_spellInfo->Id);
-                        pVictim->InterruptSpell(CURRENT_CHANNELED_SPELL);
-                    }
+
+                    target = this;
+                    break;
                 }
-                else if (spell->getState() == SPELL_STATE_DELAYED)
-                    // break channeled spell in delayed state on damage
+                // Obsidian Armor (Justice Bearer`s Pauldrons shoulder)
+                case 27539:
                 {
-                    DETAIL_LOG("Spell %u canceled at damage!", spell->m_spellInfo->Id);
-                    pVictim->InterruptSpell(CURRENT_CHANNELED_SPELL);
+                    if (!procSpell)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    switch (GetFirstSchoolInMask(GetSpellSchoolMask(procSpell)))
+                    {
+                        case SPELL_SCHOOL_NORMAL:
+                            return SPELL_AURA_PROC_FAILED;  // ignore
+                        case SPELL_SCHOOL_HOLY:   triggered_spell_id = 27536; break;
+                        case SPELL_SCHOOL_FIRE:   triggered_spell_id = 27533; break;
+                        case SPELL_SCHOOL_NATURE: triggered_spell_id = 27538; break;
+                        case SPELL_SCHOOL_FROST:  triggered_spell_id = 27534; break;
+                        case SPELL_SCHOOL_SHADOW: triggered_spell_id = 27535; break;
+                        case SPELL_SCHOOL_ARCANE: triggered_spell_id = 27540; break;
+                        default:
+                            return SPELL_AURA_PROC_FAILED;
+                    }
+
+                    target = this;
+                    break;
+                }
+                // Mana Leech (Passive) (Priest Pet Aura)
+                case 28305:
+                {
+                    // Cast on owner
+                    target = GetOwner();
+                    if (!target)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    basepoints[0] = int32(damage * 2.5f);   // manaregen
+                    triggered_spell_id = 34650;
+                    break;
+                }
+                // Mark of Malice
+                case 33493:
+                {
+                    // Cast finish spell at last charge
+                    if (triggeredByAura->GetHolder()->GetAuraCharges() > 1)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    target = this;
+                    triggered_spell_id = 33494;
+                    break;
+                }
+                // Vampiric Aura (boss spell)
+                case 38196:
+                {
+                    basepoints[0] = 3 * damage;             // 300%
+                    if (basepoints[0] < 0)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    triggered_spell_id = 31285;
+                    target = this;
+                    break;
+                }
+                // Aura of Madness (Darkmoon Card: Madness trinket)
+                //=====================================================
+                // 39511 Sociopath: +35 strength (Paladin, Rogue, Druid, Warrior)
+                // 40997 Delusional: +70 attack power (Rogue, Hunter, Paladin, Warrior, Druid)
+                // 40998 Kleptomania: +35 agility (Warrior, Rogue, Paladin, Hunter, Druid)
+                // 40999 Megalomania: +41 damage/healing (Druid, Shaman, Priest, Warlock, Mage, Paladin)
+                // 41002 Paranoia: +35 spell/melee/ranged crit strike rating (All classes)
+                // 41005 Manic: +35 haste (spell, melee and ranged) (All classes)
+                // 41009 Narcissism: +35 intellect (Druid, Shaman, Priest, Warlock, Mage, Paladin, Hunter)
+                // 41011 Martyr Complex: +35 stamina (All classes)
+                // 41406 Dementia: Every 5 seconds either gives you +5% damage/healing. (Druid, Shaman, Priest, Warlock, Mage, Paladin)
+                // 41409 Dementia: Every 5 seconds either gives you -5% damage/healing. (Druid, Shaman, Priest, Warlock, Mage, Paladin)
+                case 39446:
+                {
+                    if (GetTypeId() != TYPEID_PLAYER)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // Select class defined buff
+                    switch (getClass())
+                    {
+                        case CLASS_PALADIN:                 // 39511,40997,40998,40999,41002,41005,41009,41011,41409
+                        case CLASS_DRUID:                   // 39511,40997,40998,40999,41002,41005,41009,41011,41409
+                        {
+                            uint32 RandomSpell[] = {39511, 40997, 40998, 40999, 41002, 41005, 41009, 41011, 41409};
+                            triggered_spell_id = RandomSpell[urand(0, countof(RandomSpell) - 1)];
+                            break;
+                        }
+                        case CLASS_ROGUE:                   // 39511,40997,40998,41002,41005,41011
+                        case CLASS_WARRIOR:                 // 39511,40997,40998,41002,41005,41011
+                        {
+                            uint32 RandomSpell[] = {39511, 40997, 40998, 41002, 41005, 41011};
+                            triggered_spell_id = RandomSpell[urand(0, countof(RandomSpell) - 1)];
+                            break;
+                        }
+                        case CLASS_PRIEST:                  // 40999,41002,41005,41009,41011,41406,41409
+                        case CLASS_SHAMAN:                  // 40999,41002,41005,41009,41011,41406,41409
+                        case CLASS_MAGE:                    // 40999,41002,41005,41009,41011,41406,41409
+                        case CLASS_WARLOCK:                 // 40999,41002,41005,41009,41011,41406,41409
+                        {
+                            uint32 RandomSpell[] = {40999, 41002, 41005, 41009, 41011, 41406, 41409};
+                            triggered_spell_id = RandomSpell[urand(0, countof(RandomSpell) - 1)];
+                            break;
+                        }
+                        case CLASS_HUNTER:                  // 40997,40999,41002,41005,41009,41011,41406,41409
+                        {
+                            uint32 RandomSpell[] = {40997, 40999, 41002, 41005, 41009, 41011, 41406, 41409};
+                            triggered_spell_id = RandomSpell[urand(0, countof(RandomSpell) - 1)];
+                            break;
+                        }
+                        default:
+                            return SPELL_AURA_PROC_FAILED;
+                    }
+
+                    target = this;
+                    if (roll_chance_i(10))
+                        ((Player*)this)->Say("This is Madness!", LANG_UNIVERSAL);
+                    break;
+                }
+                // Sunwell Exalted Caster Neck (Shattered Sun Pendant of Acumen neck)
+                // cast 45479 Light's Wrath if Exalted by Aldor
+                // cast 45429 Arcane Bolt if Exalted by Scryers
+                case 45481:
+                {
+                    if (GetTypeId() != TYPEID_PLAYER)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // Get Aldor reputation rank
+                    if (((Player*)this)->GetReputationRank(932) == REP_EXALTED)
+                    {
+                        target = this;
+                        triggered_spell_id = 45479;
+                        break;
+                    }
+                    // Get Scryers reputation rank
+                    if (((Player*)this)->GetReputationRank(934) == REP_EXALTED)
+                    {
+                        // triggered at positive/self casts also, current attack target used then
+                        if (IsFriendlyTo(target))
+                        {
+                            target = getVictim();
+                            if (!target)
+                            {
+                                target = ObjectAccessor::GetUnit(*this, ((Player*)this)->GetSelectionGuid());
+                                if (!target)
+                                    return SPELL_AURA_PROC_FAILED;
+                            }
+                            if (IsFriendlyTo(target))
+                                return SPELL_AURA_PROC_FAILED;
+                        }
+
+                        triggered_spell_id = 45429;
+                        break;
+                    }
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                // Sunwell Exalted Melee Neck (Shattered Sun Pendant of Might neck)
+                // cast 45480 Light's Strength if Exalted by Aldor
+                // cast 45428 Arcane Strike if Exalted by Scryers
+                case 45482:
+                {
+                    if (GetTypeId() != TYPEID_PLAYER)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // Get Aldor reputation rank
+                    if (((Player*)this)->GetReputationRank(932) == REP_EXALTED)
+                    {
+                        target = this;
+                        triggered_spell_id = 45480;
+                        break;
+                    }
+                    // Get Scryers reputation rank
+                    if (((Player*)this)->GetReputationRank(934) == REP_EXALTED)
+                    {
+                        triggered_spell_id = 45428;
+                        break;
+                    }
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                // Sunwell Exalted Tank Neck (Shattered Sun Pendant of Resolve neck)
+                // cast 45431 Arcane Insight if Exalted by Aldor
+                // cast 45432 Light's Ward if Exalted by Scryers
+                case 45483:
+                {
+                    if (GetTypeId() != TYPEID_PLAYER)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // Get Aldor reputation rank
+                    if (((Player*)this)->GetReputationRank(932) == REP_EXALTED)
+                    {
+                        target = this;
+                        triggered_spell_id = 45432;
+                        break;
+                    }
+                    // Get Scryers reputation rank
+                    if (((Player*)this)->GetReputationRank(934) == REP_EXALTED)
+                    {
+                        target = this;
+                        triggered_spell_id = 45431;
+                        break;
+                    }
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                // Sunwell Exalted Healer Neck (Shattered Sun Pendant of Restoration neck)
+                // cast 45478 Light's Salvation if Exalted by Aldor
+                // cast 45430 Arcane Surge if Exalted by Scryers
+                case 45484:
+                {
+                    if (GetTypeId() != TYPEID_PLAYER)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // Get Aldor reputation rank
+                    if (((Player*)this)->GetReputationRank(932) == REP_EXALTED)
+                    {
+                        target = this;
+                        triggered_spell_id = 45478;
+                        break;
+                    }
+                    // Get Scryers reputation rank
+                    if (((Player*)this)->GetReputationRank(934) == REP_EXALTED)
+                    {
+                        triggered_spell_id = 45430;
+                        break;
+                    }
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                /*
+                // Sunwell Exalted Caster Neck (??? neck)
+                // cast ??? Light's Wrath if Exalted by Aldor
+                // cast ??? Arcane Bolt if Exalted by Scryers*/
+                case 46569:
+                    return SPELL_AURA_PROC_FAILED;          // old unused version
+            }
+            break;
+        }
+        case SPELLFAMILY_MAGE:
+        {
+            // Magic Absorption
+            if (dummySpell->SpellIconID == 459)             // only this spell have SpellIconID == 459 and dummy aura
+            {
+                if (GetPowerType() != POWER_MANA)
+                    return SPELL_AURA_PROC_FAILED;
+
+                // mana reward
+                basepoints[0] = (triggerAmount * GetMaxPower(POWER_MANA) / 100);
+                target = this;
+                triggered_spell_id = 29442;
+                break;
+            }
+            // Master of Elements
+            if (dummySpell->SpellIconID == 1920)
+            {
+                if (!procSpell)
+                    return SPELL_AURA_PROC_FAILED;
+
+                // mana cost save
+                int32 cost = procSpell->manaCost + procSpell->ManaCostPercentage * GetCreateMana() / 100;
+                basepoints[0] = cost * triggerAmount / 100;
+                if (basepoints[0] <= 0)
+                    return SPELL_AURA_PROC_FAILED;
+
+                target = this;
+                triggered_spell_id = 29077;
+                break;
+            }
+
+            switch (dummySpell->Id)
+            {
+                // Ignite
+                case 11119:
+                case 11120:
+                case 12846:
+                case 12847:
+                case 12848:
+                {
+                    switch (dummySpell->Id)
+                    {
+                        case 11119: basepoints[0] = int32(0.04f * damage); break;
+                        case 11120: basepoints[0] = int32(0.08f * damage); break;
+                        case 12846: basepoints[0] = int32(0.12f * damage); break;
+                        case 12847: basepoints[0] = int32(0.16f * damage); break;
+                        case 12848: basepoints[0] = int32(0.20f * damage); break;
+                        default:
+                            sLog.outError("Unit::HandleDummyAuraProc: non handled spell id: %u (IG)", dummySpell->Id);
+                            return SPELL_AURA_PROC_FAILED;
+                    }
+
+                    triggered_spell_id = 12654;
+                    break;
+                }
+                // Combustion
+                case 11129:
+                {
+                    // last charge and crit
+                    if (triggeredByAura->GetHolder()->GetAuraCharges() <= 1 && (procEx & PROC_EX_CRITICAL_HIT))
+                    {
+                        RemoveAurasDueToSpell(28682);       //-> remove Combustion auras
+                        return SPELL_AURA_PROC_OK;          // charge counting (will removed)
+                    }
+
+                    CastSpell(this, 28682, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+                    return (procEx & PROC_EX_CRITICAL_HIT) ? SPELL_AURA_PROC_OK : SPELL_AURA_PROC_FAILED; // charge update only at crit hits, no hidden cooldowns
                 }
             }
+            break;
         }
-
-        // last damage from duel opponent
-        if (duel_hasEnded)
+        case SPELLFAMILY_WARRIOR:
         {
-            MANGOS_ASSERT(pVictim->GetTypeId() == TYPEID_PLAYER);
-            Player* he = (Player*)pVictim;
-
-            MANGOS_ASSERT(he->duel);
-
-            he->SetHealth(1);
-
-            he->duel->opponent->CombatStopWithPets(true);
-            he->CombatStopWithPets(true);
-
-            he->CastSpell(he, 7267, TRIGGERED_OLD_TRIGGERED);                  // beg
-            he->DuelComplete(DUEL_WON);
-        }
-    }
-
-    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamageEnd returned %d damage", damage);
-
-    return damage;
-}
-
-struct PetOwnerKilledUnitHelper
-{
-    explicit PetOwnerKilledUnitHelper(Unit* pVictim) : m_victim(pVictim) {}
-    void operator()(Unit* pTarget) const
-    {
-        if (pTarget->GetTypeId() == TYPEID_UNIT)
-        {
-            if (pTarget->AI())
-                pTarget->AI()->OwnerKilledUnit(m_victim);
-        }
-    }
-
-    Unit* m_victim;
-};
-
-void Unit::JustKilledCreature(Creature* victim, Player* responsiblePlayer)
-{
-    victim->m_deathState = DEAD;                            // so that isAlive, isDead return expected results in the called hooks of JustKilledCreature
-    // must be used only shortly before SetDeathState(JUST_DIED) and only for Creatures or Pets
-
-    // some critters required for quests (need normal entry instead possible heroic in any cases)
-    if (victim->GetCreatureType() == CREATURE_TYPE_CRITTER && GetTypeId() == TYPEID_PLAYER)
-    {
-        if (CreatureInfo const* normalInfo = ObjectMgr::GetCreatureTemplate(victim->GetEntry()))
-            ((Player*)this)->KilledMonster(normalInfo, victim->GetObjectGuid());
-    }
-
-    // Interrupt channeling spell when a Possessed Summoned is killed
-    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(victim->GetUInt32Value(UNIT_CREATED_BY_SPELL));
-    if (spellInfo && spellInfo->HasAttribute(SPELL_ATTR_EX_FARSIGHT) && spellInfo->HasAttribute(SPELL_ATTR_EX_CHANNELED_1))
-    {
-        Unit* creator = GetMap()->GetUnit(victim->GetCreatorGuid());
-        if (creator && creator->GetCharmGuid() == victim->GetObjectGuid())
-        {
-            Spell* channeledSpell = creator->GetCurrentSpell(CURRENT_CHANNELED_SPELL);
-            if (channeledSpell && channeledSpell->m_spellInfo->Id == spellInfo->Id)
-                creator->InterruptNonMeleeSpells(false);
-        }
-    }
-
-    /* ******************************* Inform various hooks ************************************ */
-    // Inform victim's AI
-    if (victim->AI())
-        victim->AI()->JustDied(this);
-
-    // Inform Owner
-    Unit* pOwner = victim->GetCharmerOrOwner();
-    if (victim->IsTemporarySummon())
-    {
-        TemporarySummon* pSummon = (TemporarySummon*)victim;
-        if (pSummon->GetSummonerGuid().IsCreature())
-            if (Creature* pSummoner = victim->GetMap()->GetCreature(pSummon->GetSummonerGuid()))
-                if (pSummoner->AI())
-                    pSummoner->AI()->SummonedCreatureJustDied(victim);
-    }
-    else if (pOwner && pOwner->AI())
-        pOwner->AI()->SummonedCreatureJustDied(victim);
-
-    // Inform Instance Data and Linking
-    if (InstanceData* mapInstance = victim->GetInstanceData())
-        mapInstance->OnCreatureDeath(victim);
-
-    if (responsiblePlayer)                                  // killedby Player, inform BG
-        if (BattleGround* bg = responsiblePlayer->GetBattleGround())
-            bg->HandleKillUnit(victim, responsiblePlayer);
-
-    // Notify the outdoor pvp script
-    if (OutdoorPvP* outdoorPvP = sOutdoorPvPMgr.GetScript(responsiblePlayer ? responsiblePlayer->GetCachedZoneId() : GetZoneId()))
-        outdoorPvP->HandleCreatureDeath(victim);
-
-    // Start creature death script
-    GetMap()->ScriptsStart(sCreatureDeathScripts, victim->GetEntry(), victim, responsiblePlayer ? responsiblePlayer : this);
-
-    if (victim->IsLinkingEventTrigger())
-        victim->GetMap()->GetCreatureLinkingHolder()->DoCreatureLinkingEvent(LINKING_EVENT_DIE, victim);
-
-    // Dungeon specific stuff
-    if (victim->GetInstanceId())
-    {
-        Map* m = victim->GetMap();
-        Player* creditedPlayer = GetCharmerOrOwnerPlayerOrPlayerItself();
-        // TODO: do instance binding anyway if the charmer/owner is offline
-
-        if (m->IsDungeon() && creditedPlayer)
-        {
-            if (m->IsRaidOrHeroicDungeon())
+            // Retaliation
+            if (dummySpell->IsFitToFamilyMask(uint64(0x0000000800000000)))
             {
-                if (victim->GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_INSTANCE_BIND)
-                    ((DungeonMap*)m)->PermBindAllPlayers(creditedPlayer);
+                // check attack comes not from behind
+                if (pVictim->IsFacingTargetsBack(this))
+                    return SPELL_AURA_PROC_FAILED;
+
+                triggered_spell_id = 22858;
+                break;
             }
-            else
+            // Second Wind
+            if (dummySpell->SpellIconID == 1697)
             {
-                DungeonPersistentState* save = ((DungeonMap*)m)->GetPersistanceState();
-                // the reset time is set but not added to the scheduler
-                // until the players leave the instance
-                time_t resettime = victim->GetRespawnTimeEx() + 2 * HOUR;
-                if (save->GetResetTime() < resettime)
-                    save->SetResetTime(resettime);
+                // only for spells and hit/crit (trigger start always) and not start from self casted spells (5530 Mace Stun Effect for example)
+                if (!procSpell || !(procEx & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)) || this == pVictim)
+                    return SPELL_AURA_PROC_FAILED;
+                // Need stun or root mechanic
+                if (!(GetAllSpellMechanicMask(procSpell) & IMMUNE_TO_ROOT_AND_STUN_MASK))
+                    return SPELL_AURA_PROC_FAILED;
+
+                switch (dummySpell->Id)
+                {
+                    case 29838: triggered_spell_id = 29842; break;
+                    case 29834: triggered_spell_id = 29841; break;
+                    default:
+                        sLog.outError("Unit::HandleDummyAuraProc: non handled spell id: %u (SW)", dummySpell->Id);
+                        return SPELL_AURA_PROC_FAILED;
+                }
+
+                target = this;
+                break;
             }
+            break;
+        }
+        case SPELLFAMILY_WARLOCK:
+        {
+            // Seed of Corruption
+            if (dummySpell->SpellFamilyFlags & uint64(0x0000001000000000))
+            {
+                Modifier* mod = triggeredByAura->GetModifier();
+                // if damage is more than need or target die from damage deal finish spell
+                if (mod->m_amount <= (int32)damage || GetHealth() <= damage)
+                {
+                    // remember guid before aura delete
+                    ObjectGuid casterGuid = triggeredByAura->GetCasterGuid();
+
+                    // Remove aura (before cast for prevent infinite loop handlers)
+                    RemoveAurasDueToSpell(triggeredByAura->GetId());
+
+                    // Cast finish spell (triggeredByAura already not exist!)
+                    CastSpell(this, 27285, TRIGGERED_OLD_TRIGGERED, castItem, nullptr, casterGuid);
+                    return SPELL_AURA_PROC_OK;              // no hidden cooldown
+                }
+
+                // Damage counting
+                mod->m_amount -= damage;
+                return SPELL_AURA_PROC_OK;
+            }
+            // Seed of Corruption (Mobs cast) - no die req
+            if (!dummySpell->SpellFamilyFlags && dummySpell->SpellIconID == 1932)
+            {
+                Modifier* mod = triggeredByAura->GetModifier();
+                // if damage is more than need deal finish spell
+                if (mod->m_amount <= (int32)damage)
+                {
+                    // remember guid before aura delete
+                    ObjectGuid casterGuid = triggeredByAura->GetCasterGuid();
+
+                    // Remove aura (before cast for prevent infinite loop handlers)
+                    RemoveAurasDueToSpell(triggeredByAura->GetId());
+
+                    // Cast finish spell (triggeredByAura already not exist!)
+                    CastSpell(this, 32865, TRIGGERED_OLD_TRIGGERED, castItem, nullptr, casterGuid);
+                    return SPELL_AURA_PROC_OK;              // no hidden cooldown
+                }
+                // Damage counting
+                mod->m_amount -= damage;
+                return SPELL_AURA_PROC_OK;
+            }
+            switch (dummySpell->Id)
+            {
+                // Nightfall
+                case 18094:
+                case 18095:
+                {
+                    target = this;
+                    triggered_spell_id = 17941;
+                    break;
+                }
+                // Soul Leech
+                case 30293:
+                case 30295:
+                case 30296:
+                {
+                    // health
+                    basepoints[0] = int32(damage * triggerAmount / 100);
+                    target = this;
+                    triggered_spell_id = 30294;
+                    break;
+                }
+                // Shadowflame (Voidheart Raiment set bonus)
+                case 37377:
+                {
+                    triggered_spell_id = 37379;
+                    break;
+                }
+                // Pet Healing (Corruptor Raiment or Rift Stalker Armor)
+                case 37381:
+                {
+                    target = GetPet();
+                    if (!target)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // heal amount
+                    basepoints[0] = damage * triggerAmount / 100;
+                    triggered_spell_id = 37382;
+                    break;
+                }
+                // Shadowflame Hellfire (Voidheart Raiment set bonus)
+                case 39437:
+                {
+                    triggered_spell_id = 37378;
+                    break;
+                }
+            }
+            break;
+        }
+        case SPELLFAMILY_PRIEST:
+        {
+            // Vampiric Touch
+            if (dummySpell->SpellFamilyFlags & uint64(0x0000040000000000))
+            {
+                if (!pVictim || !pVictim->isAlive())
+                    return SPELL_AURA_PROC_FAILED;
+
+                // pVictim is caster of aura
+                if (triggeredByAura->GetCasterGuid() != pVictim->GetObjectGuid())
+                    return SPELL_AURA_PROC_FAILED;
+
+                // energize amount
+                basepoints[0] = triggerAmount * damage / 100;
+                pVictim->CastCustomSpell(pVictim, 34919, &basepoints[0], nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+                return SPELL_AURA_PROC_OK;                  // no hidden cooldown
+            }
+            switch (dummySpell->Id)
+            {
+                // Vampiric Embrace
+                case 15286:
+                {
+                    if (!pVictim || !pVictim->isAlive())
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // pVictim is caster of aura
+                    if (triggeredByAura->GetCasterGuid() != pVictim->GetObjectGuid())
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // heal amount
+                    basepoints[0] = triggerAmount * damage / 100;
+                    pVictim->CastCustomSpell(pVictim, 15290, &basepoints[0], nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+                    return SPELL_AURA_PROC_OK;              // no hidden cooldown
+                }
+                // Priest Tier 6 Trinket (Ashtongue Talisman of Acumen)
+                case 40438:
+                {
+                    // Shadow Word: Pain
+                    if (procSpell->SpellFamilyFlags & uint64(0x0000000000008000))
+                        triggered_spell_id = 40441;
+                    // Renew
+                    else if (procSpell->SpellFamilyFlags & uint64(0x0000000000000010))
+                        triggered_spell_id = 40440;
+                    else
+                        return SPELL_AURA_PROC_FAILED;
+
+                    target = this;
+                    break;
+                }
+                // Oracle Healing Bonus ("Garments of the Oracle" set)
+                case 26169:
+                {
+                    // heal amount
+                    basepoints[0] = int32(damage * 10 / 100);
+                    target = this;
+                    triggered_spell_id = 26170;
+                    break;
+                }
+                // Frozen Shadoweave (Shadow's Embrace set) warning! its not only priest set
+                case 39372:
+                {
+                    if (!procSpell || (GetSpellSchoolMask(procSpell) & (SPELL_SCHOOL_MASK_FROST | SPELL_SCHOOL_MASK_SHADOW)) == 0)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // heal amount
+                    basepoints[0] = damage * triggerAmount / 100;
+                    target = this;
+                    triggered_spell_id = 39373;
+                    break;
+                }
+                // Greater Heal (Vestments of Faith (Priest Tier 3) - 4 pieces bonus)
+                case 28809:
+                {
+                    triggered_spell_id = 28810;
+                    break;
+                }
+            }
+            break;
+        }
+        case SPELLFAMILY_DRUID:
+        {
+            switch (dummySpell->Id)
+            {
+                // Healing Touch (Dreamwalker Raiment set)
+                case 28719:
+                {
+                    // mana back
+                    basepoints[0] = int32(procSpell->manaCost * 30 / 100);
+                    target = this;
+                    triggered_spell_id = 28742;
+                    break;
+                }
+                // Healing Touch Refund (Idol of Longevity trinket)
+                case 28847:
+                {
+                    target = this;
+                    triggered_spell_id = 28848;
+                    break;
+                }
+                // Mana Restore (Malorne Raiment set / Malorne Regalia set)
+                case 37288:
+                case 37295:
+                {
+                    target = this;
+                    triggered_spell_id = 37238;
+                    break;
+                }
+                // Druid Tier 6 Trinket
+                case 40442:
+                {
+                    float  chance;
+
+                    // Starfire
+                    if (procSpell->SpellFamilyFlags & uint64(0x0000000000000004))
+                    {
+                        triggered_spell_id = 40445;
+                        chance = 25.0f;
+                    }
+                    // Rejuvenation
+                    else if (procSpell->SpellFamilyFlags & uint64(0x0000000000000010))
+                    {
+                        triggered_spell_id = 40446;
+                        chance = 25.0f;
+                    }
+                    // Mangle (Bear) and Mangle (Cat)
+                    else if (procSpell->SpellFamilyFlags & uint64(0x0000044000000000))
+                    {
+                        triggered_spell_id = 40452;
+                        chance = 40.0f;
+                    }
+                    else
+                        return SPELL_AURA_PROC_FAILED;
+
+                    if (!roll_chance_f(chance))
+                        return SPELL_AURA_PROC_FAILED;
+
+                    target = this;
+                    break;
+                }
+                // Maim Interrupt
+                case 44835:
+                {
+                    // Deadly Interrupt Effect
+                    triggered_spell_id = 32747;
+                    break;
+                }
+            }
+            break;
+        }
+        case SPELLFAMILY_ROGUE:
+        {
+            switch (dummySpell->Id)
+            {
+                // Clean Escape
+                case 23582:
+                    // triggered spell have same masks and etc with main Vanish spell
+                    if (!procSpell || procSpell->Effect[EFFECT_INDEX_0] == SPELL_EFFECT_NONE)
+                        return SPELL_AURA_PROC_FAILED;
+                    triggered_spell_id = 23583;
+                    break;
+                // Deadly Throw Interrupt
+                case 32748:
+                {
+                    // Prevent cast Deadly Throw Interrupt on self from last effect (apply dummy) of Deadly Throw
+                    if (this == pVictim)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    triggered_spell_id = 32747;
+                    break;
+                }
+            }
+            // Quick Recovery
+            if (dummySpell->SpellIconID == 2116)
+            {
+                if (!procSpell)
+                    return SPELL_AURA_PROC_FAILED;
+
+                // energy cost save
+                basepoints[0] = procSpell->manaCost * triggerAmount / 100;
+                if (basepoints[0] <= 0)
+                    return SPELL_AURA_PROC_FAILED;
+
+                target = this;
+                triggered_spell_id = 31663;
+                break;
+            }
+            break;
+        }
+        case SPELLFAMILY_HUNTER:
+        {
+            // Thrill of the Hunt
+            if (dummySpell->SpellIconID == 2236)
+            {
+                if (!procSpell)
+                    return SPELL_AURA_PROC_FAILED;
+
+                // mana cost save
+                basepoints[0] = procSpell->manaCost * 40 / 100;
+                if (basepoints[0] <= 0)
+                    return SPELL_AURA_PROC_FAILED;
+
+                target = this;
+                triggered_spell_id = 34720;
+                break;
+            }
+            break;
+        }
+        case SPELLFAMILY_PALADIN:
+        {
+            // Seal of Righteousness - melee proc dummy
+            if ((dummySpell->SpellFamilyFlags & uint64(0x000000008000000)) && triggeredByAura->GetEffIndex() == EFFECT_INDEX_0)
+            {
+                if (GetTypeId() != TYPEID_PLAYER)
+                    return SPELL_AURA_PROC_FAILED;
+
+                uint32 spellId;
+                switch (triggeredByAura->GetId())
+                {
+                    case 21084: spellId = 25742; break;     // Rank 1
+                    case 20287: spellId = 25740; break;     // Rank 2
+                    case 20288: spellId = 25739; break;     // Rank 3
+                    case 20289: spellId = 25738; break;     // Rank 4
+                    case 20290: spellId = 25737; break;     // Rank 5
+                    case 20291: spellId = 25736; break;     // Rank 6
+                    case 20292: spellId = 25735; break;     // Rank 7
+                    case 20293: spellId = 25713; break;     // Rank 8
+                    case 27155: spellId = 27156; break;     // Rank 9
+                    default:
+                        sLog.outError("Unit::HandleDummyAuraProc: non handled possibly SoR (Id = %u)", triggeredByAura->GetId());
+                        return SPELL_AURA_PROC_FAILED;
+                }
+                Item* item = ((Player*)this)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+                float speed = (item ? item->GetProto()->Delay : BASE_ATTACK_TIME) / 1000.0f;
+
+                float damageBasePoints;
+                if (item && item->GetProto()->InventoryType == INVTYPE_2HWEAPON)
+                    // two hand weapon
+                    damageBasePoints = 1.20f * triggerAmount * 1.2f * 1.03f * speed / 100.0f + 1;
+                else
+                    // one hand weapon/no weapon
+                    damageBasePoints = 0.85f * ceil(triggerAmount * 1.2f * 1.03f * speed / 100.0f) - 1;
+
+                int32 damagePoint = int32(damageBasePoints + 0.03f * (GetWeaponDamageRange(BASE_ATTACK, MINDAMAGE) + GetWeaponDamageRange(BASE_ATTACK, MAXDAMAGE)) / 2.0f) + 1;
+
+                // apply damage bonuses manually
+                if (damagePoint >= 0)
+                {
+                    damagePoint = SpellDamageBonusDone(pVictim, dummySpell, damagePoint, SPELL_DIRECT_DAMAGE);
+                    damagePoint = pVictim->SpellDamageBonusTaken(this, dummySpell, damagePoint, SPELL_DIRECT_DAMAGE);
+                }
+
+                CastCustomSpell(pVictim, spellId, &damagePoint, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, nullptr, triggeredByAura);
+                return SPELL_AURA_PROC_OK;                  // no hidden cooldown
+            }
+            // Seal of Blood do damage trigger
+            if (dummySpell->SpellFamilyFlags & uint64(0x0000040000000000))
+            {
+                switch (triggeredByAura->GetEffIndex())
+                {
+                    case 0:
+                        triggered_spell_id = 31893;
+                        break;
+                    case 1:
+                    {
+                        // damage
+                        basepoints[0] = triggerAmount * damage / 100;
+                        target = this;
+                        triggered_spell_id = 32221;
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+
+            switch (dummySpell->Id)
+            {
+                // Holy Power (Redemption Armor set)
+                case 28789:
+                {
+                    if (!pVictim)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // Set class defined buff
+                    switch (pVictim->getClass())
+                    {
+                        case CLASS_PALADIN:
+                        case CLASS_PRIEST:
+                        case CLASS_SHAMAN:
+                        case CLASS_DRUID:
+                            triggered_spell_id = 28795;     // Increases the friendly target's mana regeneration by $s1 per 5 sec. for $d.
+                            break;
+                        case CLASS_MAGE:
+                        case CLASS_WARLOCK:
+                            triggered_spell_id = 28793;     // Increases the friendly target's spell damage and healing by up to $s1 for $d.
+                            break;
+                        case CLASS_HUNTER:
+                        case CLASS_ROGUE:
+                            triggered_spell_id = 28791;     // Increases the friendly target's attack power by $s1 for $d.
+                            break;
+                        case CLASS_WARRIOR:
+                            triggered_spell_id = 28790;     // Increases the friendly target's armor
+                            break;
+                        default:
+                            return SPELL_AURA_PROC_FAILED;
+                    }
+                    break;
+                }
+                // Spiritual Attunement
+                case 31785:
+                case 33776:
+                {
+                    // if healed by another unit (pVictim)
+                    if (this == pVictim)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // dont count overhealing
+                    uint32 diff = GetMaxHealth() - GetHealth();
+                    if (!diff)
+                        return SPELL_AURA_PROC_FAILED;
+                    basepoints[0] = triggerAmount * (damage > diff ? diff : damage) / 100;
+                    target = this;
+                    triggered_spell_id = 31786;
+                    break;
+                }
+                // Seal of Vengeance (damage calc on apply aura)
+                case 31801:
+                {
+                    if (effIndex != EFFECT_INDEX_0)         // effect 1,2 used by seal unleashing code
+                        return SPELL_AURA_PROC_FAILED;
+
+                    triggered_spell_id = 31803;
+
+                    // Since Patch 2.2.0 Seal of Vengeance does additional damage against fully stacked targets
+                    // Add 5-stack effect from Holy Vengeance
+                    const SpellAuraHolder* existing = target->GetSpellAuraHolder(31803, GetObjectGuid());
+                    if (existing && existing->GetStackAmount() >= 5)
+                        CastSpell(target, 42463, TRIGGERED_OLD_TRIGGERED, nullptr, triggeredByAura);
+                    break;
+                }
+                // Paladin Tier 6 Trinket (Ashtongue Talisman of Zeal)
+                case 40470:
+                {
+                    if (!procSpell)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    float  chance;
+
+                    // Flash of light/Holy light
+                    if (procSpell->SpellFamilyFlags & uint64(0x00000000C0000000))
+                    {
+                        triggered_spell_id = 40471;
+                        chance = 15.0f;
+                    }
+                    // Judgement
+                    else if (procSpell->SpellFamilyFlags & uint64(0x0000000000800000))
+                    {
+                        triggered_spell_id = 40472;
+                        chance = 50.0f;
+                    }
+                    else
+                        return SPELL_AURA_PROC_FAILED;
+
+                    if (!roll_chance_f(chance))
+                        return SPELL_AURA_PROC_FAILED;
+
+                    break;
+                }
+            }
+            break;
+        }
+        case SPELLFAMILY_SHAMAN:
+        {
+            switch (dummySpell->Id)
+            {
+                // Totemic Power (The Earthshatterer set)
+                case 28823:
+                {
+                    if (!pVictim)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // Set class defined buff
+                    switch (pVictim->getClass())
+                    {
+                        case CLASS_PALADIN:
+                        case CLASS_PRIEST:
+                        case CLASS_SHAMAN:
+                        case CLASS_DRUID:
+                            triggered_spell_id = 28824;     // Increases the friendly target's mana regeneration by $s1 per 5 sec. for $d.
+                            break;
+                        case CLASS_MAGE:
+                        case CLASS_WARLOCK:
+                            triggered_spell_id = 28825;     // Increases the friendly target's spell damage and healing by up to $s1 for $d.
+                            break;
+                        case CLASS_HUNTER:
+                        case CLASS_ROGUE:
+                            triggered_spell_id = 28826;     // Increases the friendly target's attack power by $s1 for $d.
+                            break;
+                        case CLASS_WARRIOR:
+                            triggered_spell_id = 28827;     // Increases the friendly target's armor
+                            break;
+                        default:
+                            return SPELL_AURA_PROC_FAILED;
+                    }
+                    break;
+                }
+                // Lesser Healing Wave (Totem of Flowing Water Relic)
+                case 28849:
+                {
+                    target = this;
+                    triggered_spell_id = 28850;
+                    break;
+                }
+                // Windfury Weapon (Passive) 1-5 Ranks
+                case 33757:
+                {
+                    if (GetTypeId() != TYPEID_PLAYER)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    if (!castItem || !castItem->IsEquipped())
+                        return SPELL_AURA_PROC_FAILED;
+
+                    // custom cooldown processing case
+                    if (cooldown && ((Player*)this)->HasSpellCooldown(dummySpell->Id))
+                        return SPELL_AURA_PROC_FAILED;
+
+                    uint32 spellId;
+                    switch (castItem->GetEnchantmentId(EnchantmentSlot(TEMP_ENCHANTMENT_SLOT)))
+                    {
+                        case 283: spellId = 33757; break;   // 1 Rank
+                        case 284: spellId = 33756; break;   // 2 Rank
+                        case 525: spellId = 33755; break;   // 3 Rank
+                        case 1669: spellId = 33754; break;  // 4 Rank
+                        case 2636: spellId = 33727; break;  // 5 Rank
+                        default:
+                        {
+                            sLog.outError("Unit::HandleDummyAuraProc: non handled item enchantment (rank?) %u for spell id: %u (Windfury)",
+                                          castItem->GetEnchantmentId(EnchantmentSlot(TEMP_ENCHANTMENT_SLOT)), dummySpell->Id);
+                            return SPELL_AURA_PROC_FAILED;
+                        }
+                    }
+
+                    SpellEntry const* windfurySpellEntry = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
+                    if (!windfurySpellEntry)
+                    {
+                        sLog.outError("Unit::HandleDummyAuraProc: nonexistent spell id: %u (Windfury)", spellId);
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+
+                    int32 extra_attack_power = CalculateSpellDamage(pVictim, windfurySpellEntry, EFFECT_INDEX_0);
+
+                    // Off-Hand case
+                    if (castItem->GetSlot() == EQUIPMENT_SLOT_OFFHAND)
+                    {
+                        // Value gained from additional AP
+                        basepoints[0] = int32(extra_attack_power / 14.0f * GetAttackTime(OFF_ATTACK) / 1000 / 2);
+                        triggered_spell_id = 33750;
+                    }
+                    // Main-Hand case
+                    else
+                    {
+                        // Value gained from additional AP
+                        basepoints[0] = int32(extra_attack_power / 14.0f * GetAttackTime(BASE_ATTACK) / 1000);
+                        triggered_spell_id = 25504;
+                    }
+
+                    // apply cooldown before cast to prevent processing itself
+                    if (cooldown)
+                        ((Player*)this)->AddSpellCooldown(dummySpell->Id, 0, time(nullptr) + cooldown);
+
+                    // Attack Twice
+                    for (uint32 i = 0; i < 2; ++i)
+                        CastCustomSpell(pVictim, triggered_spell_id, &basepoints[0], nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+
+                    return SPELL_AURA_PROC_OK;
+                }
+                // Shaman Tier 6 Trinket
+                case 40463:
+                {
+                    if (!procSpell)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    float  chance;
+                    if (procSpell->SpellFamilyFlags & uint64(0x0000000000000001))
+                    {
+                        triggered_spell_id = 40465;         // Lightning Bolt
+                        chance = 15.0f;
+                    }
+                    else if (procSpell->SpellFamilyFlags & uint64(0x0000000000000080))
+                    {
+                        triggered_spell_id = 40465;         // Lesser Healing Wave
+                        chance = 10.0f;
+                    }
+                    else if (procSpell->SpellFamilyFlags & uint64(0x0000001000000000))
+                    {
+                        triggered_spell_id = 40466;         // Stormstrike
+                        chance = 50.0f;
+                    }
+                    else
+                        return SPELL_AURA_PROC_FAILED;
+
+                    if (!roll_chance_f(chance))
+                        return SPELL_AURA_PROC_FAILED;
+
+                    target = this;
+                    break;
+                }
+            }
+
+            // Earth Shield
+            if (dummySpell->SpellFamilyFlags & uint64(0x0000040000000000))
+            {
+                if (GetTypeId() != TYPEID_PLAYER)
+                    return SPELL_AURA_PROC_FAILED;
+
+                // heal
+                basepoints[0] = triggerAmount;
+                target = this;
+                triggered_spell_id = 379;
+                break;
+            }
+            // Lightning Overload
+            if (dummySpell->SpellIconID == 2018)            // only this spell have SpellFamily Shaman SpellIconID == 2018 and dummy aura
+            {
+                if (!procSpell || GetTypeId() != TYPEID_PLAYER || !pVictim)
+                    return SPELL_AURA_PROC_FAILED;
+
+                // custom cooldown processing case
+                if (cooldown && GetTypeId() == TYPEID_PLAYER && ((Player*)this)->HasSpellCooldown(dummySpell->Id))
+                    return SPELL_AURA_PROC_FAILED;
+
+                uint32 spellId;
+                // Every Lightning Bolt and Chain Lightning spell have duplicate vs half damage and zero cost
+                switch (procSpell->Id)
+                {
+                    // Lightning Bolt
+                    case   403: spellId = 45284; break;     // Rank  1
+                    case   529: spellId = 45286; break;     // Rank  2
+                    case   548: spellId = 45287; break;     // Rank  3
+                    case   915: spellId = 45288; break;     // Rank  4
+                    case   943: spellId = 45289; break;     // Rank  5
+                    case  6041: spellId = 45290; break;     // Rank  6
+                    case 10391: spellId = 45291; break;     // Rank  7
+                    case 10392: spellId = 45292; break;     // Rank  8
+                    case 15207: spellId = 45293; break;     // Rank  9
+                    case 15208: spellId = 45294; break;     // Rank 10
+                    case 25448: spellId = 45295; break;     // Rank 11
+                    case 25449: spellId = 45296; break;     // Rank 12
+                    // Chain Lightning
+                    case   421: spellId = 45297; break;     // Rank  1
+                    case   930: spellId = 45298; break;     // Rank  2
+                    case  2860: spellId = 45299; break;     // Rank  3
+                    case 10605: spellId = 45300; break;     // Rank  4
+                    case 25439: spellId = 45301; break;     // Rank  5
+                    case 25442: spellId = 45302; break;     // Rank  6
+                    default:
+                        sLog.outError("Unit::HandleDummyAuraProc: non handled spell id: %u (LO)", procSpell->Id);
+                        return SPELL_AURA_PROC_FAILED;
+                }
+
+                // Remove cooldown (Chain Lightning - have Category Recovery time)
+                if (procSpell->SpellFamilyFlags & uint64(0x0000000000000002))
+                    ((Player*)this)->RemoveSpellCooldown(spellId);
+
+                CastSpell(pVictim, spellId, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+
+                if (cooldown && GetTypeId() == TYPEID_PLAYER)
+                    ((Player*)this)->AddSpellCooldown(dummySpell->Id, 0, time(nullptr) + cooldown);
+
+                return SPELL_AURA_PROC_OK;
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    // processed charge only counting case
+    if (!triggered_spell_id)
+        return SPELL_AURA_PROC_OK;
+
+    SpellEntry const* triggerEntry = sSpellTemplate.LookupEntry<SpellEntry>(triggered_spell_id);
+
+    if (!triggerEntry)
+    {
+        sLog.outError("Unit::HandleDummyAuraProc: Spell %u have nonexistent triggered spell %u", dummySpell->Id, triggered_spell_id);
+        return SPELL_AURA_PROC_FAILED;
+    }
+
+    // default case
+    if (!target || (target != this && !target->isAlive()))
+        return SPELL_AURA_PROC_FAILED;
+
+    if (cooldown && GetTypeId() == TYPEID_PLAYER && ((Player*)this)->HasSpellCooldown(triggered_spell_id))
+        return SPELL_AURA_PROC_FAILED;
+
+    if (basepoints[EFFECT_INDEX_0] || basepoints[EFFECT_INDEX_1] || basepoints[EFFECT_INDEX_2])
+        CastCustomSpell(target, triggered_spell_id,
+                        basepoints[EFFECT_INDEX_0] ? &basepoints[EFFECT_INDEX_0] : nullptr,
+                        basepoints[EFFECT_INDEX_1] ? &basepoints[EFFECT_INDEX_1] : nullptr,
+                        basepoints[EFFECT_INDEX_2] ? &basepoints[EFFECT_INDEX_2] : nullptr,
+                        TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+    else
+        CastSpell(target, triggered_spell_id, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+
+    if (cooldown && GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->AddSpellCooldown(triggered_spell_id, 0, time(nullptr) + cooldown);
+
+    return SPELL_AURA_PROC_OK;
+}
+
+SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(Unit* pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 procFlags, uint32 procEx, uint32 cooldown)
+{
+    // Get triggered aura spell info
+    SpellEntry const* auraSpellInfo = triggeredByAura->GetSpellProto();
+
+    // Basepoints of trigger aura
+    int32 triggerAmount = triggeredByAura->GetModifier()->m_amount;
+
+    // Set trigger spell id, target, custom basepoints
+    uint32 trigger_spell_id = auraSpellInfo->EffectTriggerSpell[triggeredByAura->GetEffIndex()];
+    Unit*  target = nullptr;
+    int32  basepoints[MAX_EFFECT_INDEX] = {0, 0, 0};
+
+    if (triggeredByAura->GetModifier()->m_auraname == SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE)
+        basepoints[0] = triggerAmount;
+
+    Item* castItem = triggeredByAura->GetCastItemGuid() && GetTypeId() == TYPEID_PLAYER
+                     ? ((Player*)this)->GetItemByGuid(triggeredByAura->GetCastItemGuid()) : nullptr;
+
+
+    // Try handle unknown trigger spells
+    // Custom requirements (not listed in procEx) Warning! damage dealing after this
+    // Custom triggered spells
+    switch (auraSpellInfo->SpellFamilyName)
+    {
+        case SPELLFAMILY_GENERIC:
+            switch (auraSpellInfo->Id)
+            {
+                // case 191:                            // Elemental Response
+                //    switch (procSpell->School)
+                //    {
+                //        case SPELL_SCHOOL_FIRE:  trigger_spell_id = 34192; break;
+                //        case SPELL_SCHOOL_FROST: trigger_spell_id = 34193; break;
+                //        case SPELL_SCHOOL_ARCANE:trigger_spell_id = 34194; break;
+                //        case SPELL_SCHOOL_NATURE:trigger_spell_id = 34195; break;
+                //        case SPELL_SCHOOL_SHADOW:trigger_spell_id = 34196; break;
+                //        case SPELL_SCHOOL_HOLY:  trigger_spell_id = 34197; break;
+                //        case SPELL_SCHOOL_NORMAL:trigger_spell_id = 34198; break;
+                //    }
+                //    break;
+                // case 5301:  break;                   // Defensive State (DND)
+                // case 7137:  break:                   // Shadow Charge (Rank 1)
+                // case 7377:  break:                   // Take Immune Periodic Damage <Not Working>
+                // case 13358: break;                   // Defensive State (DND)
+                // case 16092: break;                   // Defensive State (DND)
+                // case 18943: break;                   // Double Attack
+                // case 19194: break;                   // Double Attack
+                // case 19817: break;                   // Double Attack
+                // case 19818: break;                   // Double Attack
+                // case 22835: break;                   // Drunken Rage
+                //    trigger_spell_id = 14822; break;
+                case 23780:                                 // Aegis of Preservation (Aegis of Preservation trinket)
+                    trigger_spell_id = 23781;
+                    break;
+                case 24905:                                 // Moonkin Form (Passive)
+                {
+                    // Elune's Touch (instead non-existed triggered spell) 30% from AP
+                    trigger_spell_id = 33926;
+                    basepoints[0] = GetTotalAttackPowerValue(BASE_ATTACK) * 30 / 100;
+                    target = this;
+                    break;
+                }
+                // case 24949: break;                       // Defensive State 2 (DND)
+                case 27522:                                 // Mana Drain Trigger
+                case 40336:                                 // Mana Drain Trigger
+                case 46939:                                 // Black Bow of the Betrayer
+                    // On successful melee or ranged attack gain 8 mana and if possible drain 8 mana from the target.
+                    if (isAlive())
+                        CastSpell(this, 29471, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+                    if (pVictim && pVictim->isAlive())
+                        CastSpell(pVictim, 27526, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+                    return SPELL_AURA_PROC_OK;
+                case 31255:                                 // Deadly Swiftness (Rank 1)
+                {
+                    // whenever you deal damage to a target who is below 20% health.
+                    if (pVictim->GetHealth() > pVictim->GetMaxHealth() / 5)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    target = this;
+                    trigger_spell_id = 22588;
+                    break;
+                }
+                // case 33207: break;                       // Gossip NPC Periodic - Fidget
+                case 33896:                                 // Desperate Defense (Stonescythe Whelp, Stonescythe Alpha, Stonescythe Ambusher)
+                    trigger_spell_id = 33898;
+                    break;
+                // case 34082: break;                   // Advantaged State (DND)
+                // case 34783: break:                   // Spell Reflection
+                // case 35205: break:                   // Vanish
+                // case 35321: break;                   // Gushing Wound
+                // case 36096: break:                   // Spell Reflection
+                // case 36207: break:                   // Steal Weapon
+                // case 36576: break:                   // Shaleskin (Shaleskin Flayer, Shaleskin Ripper) 30023 trigger
+                // case 37030: break;                   // Chaotic Temperament
+                // case 38363: break;                   // Gushing Wound
+                // case 39215: break;                   // Gushing Wound
+                // case 40250: break;                   // Improved Duration
+                // case 40329: break;                   // Demo Shout Sensor
+                // case 40364: break;                   // Entangling Roots Sensor
+                // case 41054: break;                   // Copy Weapon
+                //    trigger_spell_id = 41055; break;
+                // case 41248: break;                   // Consuming Strikes
+                //    trigger_spell_id = 41249; break;
+                // case 43453: break:                   // Rune Ward
+                // case 43504: break;                   // Alterac Valley OnKill Proc Aura
+                case 43820:                                 // Charm of the Witch Doctor (Amani Charm of the Witch Doctor trinket)
+                {
+                    // Pct value stored in dummy
+                    basepoints[0] = pVictim->GetCreateHealth() * auraSpellInfo->CalculateSimpleValue(EFFECT_INDEX_1) / 100;
+                    target = pVictim;
+                    break;
+                }
+                // case 44326: break:                       // Pure Energy Passive
+                // case 44526: break;                       // Hate Monster (Spar) (30 sec)
+                // case 44527: break;                       // Hate Monster (Spar Buddy) (30 sec)
+                // case 44819: break;                       // Hate Monster (Spar Buddy) (>30% Health)
+                // case 44820: break;                       // Hate Monster (Spar) (<30%)
+                case 45057:                                 // Evasive Maneuvers (Commendation of Kael`thas trinket)
+                    // reduce you below $s1% health (in fact in this specific case can proc from any attack while health in result less $s1%)
+                    if (int32(GetHealth()) - int32(damage) >= int32(GetMaxHealth() * triggerAmount / 100))
+                        return SPELL_AURA_PROC_FAILED;
+                    break;
+                    // case 45205: break;                   // Copy Offhand Weapon
+
+
+                case 47300: // Dark Flame Aura              procs from alythess
+
+                    if(!procSpell)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    if (this->HasAura(45345))                   // SPELL_DARK_FLAME on player
+                        return SPELL_AURA_PROC_FAILED;
+
+                    if (procSpell->Id == 46771                  // flame sear
+                            || procSpell->Id == 45342           // or conflag
+                            || procSpell->Id == 45235)          // or blaze
+                    {
+                        cooldown = 1;
+                        target = this;
+                        if (this->HasAura(45347))
+                        {
+                            this->RemoveAurasDueToSpell(45347);
+                            trigger_spell_id = 45345;
+                        }
+                        else
+                            trigger_spell_id = 45348;
+                    }
+
+                    break;
+
+                case 45343:                          // Dark Flame Aura proc from scarolash
+
+                    if(!procSpell)
+                        return SPELL_AURA_PROC_FAILED;
+
+                    if (this->HasAura(45345))       // SPELL_DARK_FLAME on player
+                        return SPELL_AURA_PROC_FAILED;
+
+                    if (procSpell->Id == 45256      // confunding blow
+                        || procSpell->Id == 45248    // shadow blades
+                        || procSpell->Id == 45329)   // shadow nova
+                    {
+                        cooldown = 1;
+                        target = this;
+                        if (this->HasAura(45348))
+                        {
+                            this->RemoveAurasDueToSpell(45348);
+                            trigger_spell_id = 45345;
+                        }
+                        else
+                            trigger_spell_id = 45347;
+                    }
+
+                    break;
+
+                    // case 45903: break:                   // Offensive State
+                    // case 46146: break:                   // [PH] Ahune  Spanky Hands
+                    // case 46146: break;                   // [PH] Ahune  Spanky Hands
+                    // case 50051: break;                   // Ethereal Pet Aura
+                    break;
+            }
+            break;
+        case SPELLFAMILY_MAGE:
+            if (auraSpellInfo->SpellIconID == 2127)         // Blazing Speed
+            {
+                switch (auraSpellInfo->Id)
+                {
+                    case 31641:  // Rank 1
+                    case 31642:  // Rank 2
+                        trigger_spell_id = 31643;
+                        break;
+                    default:
+                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u miss possibly Blazing Speed", auraSpellInfo->Id);
+                        return SPELL_AURA_PROC_FAILED;
+                }
+            }
+            else if (auraSpellInfo->Id == 26467)            // Persistent Shield (Scarab Brooch trinket)
+            {
+                // This spell originally trigger 13567 - Dummy Trigger (vs dummy effect)
+                basepoints[0] = damage * 15 / 100;
+                target = pVictim;
+                trigger_spell_id = 26470;
+            }
+            break;
+        case SPELLFAMILY_WARRIOR:
+            // Deep Wounds (replace triggered spells to directly apply DoT), dot spell have familyflags
+            if (!auraSpellInfo->SpellFamilyFlags && auraSpellInfo->SpellIconID == 243)
+            {
+                float weaponDamage;
+                // DW should benefit of attack power, damage percent mods etc.
+                // TODO: check if using offhand damage is correct and if it should be divided by 2
+                if (haveOffhandWeapon() && getAttackTimer(BASE_ATTACK) > getAttackTimer(OFF_ATTACK))
+                    weaponDamage = (GetFloatValue(UNIT_FIELD_MINOFFHANDDAMAGE) + GetFloatValue(UNIT_FIELD_MAXOFFHANDDAMAGE)) / 2;
+                else
+                    weaponDamage = (GetFloatValue(UNIT_FIELD_MINDAMAGE) + GetFloatValue(UNIT_FIELD_MAXDAMAGE)) / 2;
+
+                switch (auraSpellInfo->Id)
+                {
+                    case 12834: basepoints[0] = int32(weaponDamage * 0.2f); break;
+                    case 12849: basepoints[0] = int32(weaponDamage * 0.4f); break;
+                    case 12867: basepoints[0] = int32(weaponDamage * 0.6f); break;
+                    // Impossible case
+                    default:
+                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: DW unknown spell rank %u", auraSpellInfo->Id);
+                        return SPELL_AURA_PROC_FAILED;
+                }
+
+                // 1 tick/sec * 6 sec = 6 ticks
+                basepoints[0] /= 6;
+
+                trigger_spell_id = 12721;
+                break;
+            }
+            // Rampage
+            else if (auraSpellInfo->SpellIconID == 2006 && auraSpellInfo->IsFitToFamilyMask(uint64(0x0000000000100000)))
+            {
+                switch (auraSpellInfo->Id)
+                {
+                    case 29801: trigger_spell_id = 30029; break;       // Rank 1
+                    case 30030: trigger_spell_id = 30031; break;       // Rank 2
+                    case 30033: trigger_spell_id = 30032; break;       // Rank 3
+                    default:
+                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u not handled in Rampage", auraSpellInfo->Id);
+                        return SPELL_AURA_PROC_FAILED;
+                }
+            }
+            break;
+        case SPELLFAMILY_WARLOCK:
+        {
+            // Pyroclasm
+            if (auraSpellInfo->SpellIconID == 1137)
+            {
+                if (!pVictim || !pVictim->isAlive() || pVictim == this || procSpell == nullptr)
+                    return SPELL_AURA_PROC_FAILED;
+                // Calculate spell tick count for spells
+                uint32 tick = 1; // Default tick = 1
+
+                // Hellfire have 15 tick
+                if (procSpell->SpellFamilyFlags & uint64(0x0000000000000040))
+                    tick = 15;
+                // Rain of Fire have 4 tick
+                else if (procSpell->SpellFamilyFlags & uint64(0x0000000000000020))
+                    tick = 4;
+
+                // Calculate chance = baseChance / tick
+                float chance = 0;
+                switch (auraSpellInfo->Id)
+                {
+                    case 18096: chance = 13.0f / tick; break;
+                    case 18073: chance = 26.0f / tick; break;
+                }
+                // Roll chance
+                if (!roll_chance_f(chance))
+                    return SPELL_AURA_PROC_FAILED;
+
+                trigger_spell_id = 18093;
+            }
+            // Drain Soul
+            else if (auraSpellInfo->SpellFamilyFlags & uint64(0x0000000000004000))
+            {
+                Unit::AuraList const& mAddFlatModifier = GetAurasByType(SPELL_AURA_ADD_FLAT_MODIFIER);
+                for (Unit::AuraList::const_iterator i = mAddFlatModifier.begin(); i != mAddFlatModifier.end(); ++i)
+                {
+                    if ((*i)->GetModifier()->m_miscvalue == SPELLMOD_CHANCE_OF_SUCCESS && (*i)->GetSpellProto()->SpellIconID == 113)
+                    {
+                        // basepoints of trigger spell stored in dummyeffect of spellProto
+                        int32 basepoints2 = GetMaxPower(POWER_MANA) * (*i)->GetSpellProto()->CalculateSimpleValue(EFFECT_INDEX_2) / 100;
+                        CastCustomSpell(this, 18371, &basepoints2, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+                        break;
+                    }
+                }
+                // Not remove charge (aura removed on death in any cases)
+                // Need for correct work Drain Soul SPELL_AURA_CHANNEL_DEATH_ITEM aura
+                return SPELL_AURA_PROC_FAILED;
+            }
+            // Cheat Death
+            else if (auraSpellInfo->Id == 28845)
+            {
+                // When your health drops below 20% ....
+                int32 health20 = int32(GetMaxHealth()) / 5;
+                if (int32(GetHealth()) - int32(damage) >= health20 || int32(GetHealth()) < health20)
+                    return SPELL_AURA_PROC_FAILED;
+            }
+            break;
+        }
+        case SPELLFAMILY_PRIEST:
+        {
+            // Greater Heal Refund (Avatar Raiment set)
+            if (auraSpellInfo->Id == 37594)
+            {
+                // Not give if target already have full health
+                if (pVictim->GetHealth() == pVictim->GetMaxHealth())
+                    return SPELL_AURA_PROC_FAILED;
+                // If your Greater Heal brings the target to full health, you gain $37595s1 mana.
+                if (pVictim->GetHealth() + damage < pVictim->GetMaxHealth())
+                    return SPELL_AURA_PROC_FAILED;
+                trigger_spell_id = 37595;
+            }
+            // Shadowguard
+            else if (auraSpellInfo->SpellIconID == 19)
+            {
+                switch (auraSpellInfo->Id)
+                {
+                    case 18137: trigger_spell_id = 28377; break;   // Rank 1
+                    case 19308: trigger_spell_id = 28378; break;   // Rank 2
+                    case 19309: trigger_spell_id = 28379; break;   // Rank 3
+                    case 19310: trigger_spell_id = 28380; break;   // Rank 4
+                    case 19311: trigger_spell_id = 28381; break;   // Rank 5
+                    case 19312: trigger_spell_id = 28382; break;   // Rank 6
+                    case 25477: trigger_spell_id = 28385; break;   // Rank 7
+                    default:
+                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u not handled in SG", auraSpellInfo->Id);
+                        return SPELL_AURA_PROC_FAILED;
+                }
+            }
+            // Blessed Recovery
+            else if (auraSpellInfo->SpellIconID == 1875)
+            {
+                switch (auraSpellInfo->Id)
+                {
+                    case 27811: trigger_spell_id = 27813; break;
+                    case 27815: trigger_spell_id = 27817; break;
+                    case 27816: trigger_spell_id = 27818; break;
+                    default:
+                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u not handled in BR", auraSpellInfo->Id);
+                        return SPELL_AURA_PROC_FAILED;
+                }
+                basepoints[0] = damage * triggerAmount / 100 / 3;
+                target = this;
+            }
+            break;
+        }
+        case SPELLFAMILY_DRUID:
+        {
+            // Leader of the Pack
+            if (auraSpellInfo->Id == 24932)
+            {
+                if (triggerAmount == 0)
+                    return SPELL_AURA_PROC_FAILED;
+                basepoints[0] = triggerAmount * GetMaxHealth() / 100;
+                trigger_spell_id = 34299;
+            }
+            // Druid Forms Trinket
+            else if (auraSpellInfo->Id == 37336)
+            {
+                switch (GetShapeshiftForm())
+                {
+                    case FORM_NONE:     trigger_spell_id = 37344; break;
+                    case FORM_CAT:      trigger_spell_id = 37341; break;
+                    case FORM_BEAR:
+                    case FORM_DIREBEAR: trigger_spell_id = 37340; break;
+                    case FORM_TREE:     trigger_spell_id = 37342; break;
+                    case FORM_MOONKIN:  trigger_spell_id = 37343; break;
+                    default:
+                        return SPELL_AURA_PROC_FAILED;
+                }
+            }
+            break;
+        }
+        case SPELLFAMILY_ROGUE:
+        {
+            if (auraSpellInfo->SpellIconID == 2260)         // Combat Potency
+            {
+                if (!(procFlags & PROC_FLAG_SUCCESSFUL_OFFHAND_HIT))
+                    return SPELL_AURA_PROC_FAILED;
+            }
+
+            break;
+        }
+        case SPELLFAMILY_HUNTER:
+            break;
+        case SPELLFAMILY_PALADIN:
+        {
+            /*
+            // Blessed Life
+            if (auraSpellInfo->SpellIconID == 2137)
+            {
+                switch (auraSpellInfo->Id)
+                {
+                    case 31828:                         // Rank 1
+                    case 31829:                         // Rank 2
+                    case 31830:                         // Rank 3
+                        break;
+                    default:
+                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u miss posibly Blessed Life", auraSpellInfo->Id);
+                        return SPELL_AURA_PROC_FAILED;
+                }
+            }
+            */
+            // Healing Discount
+            if (auraSpellInfo->Id == 37705)
+            {
+                trigger_spell_id = 37706;
+                target = this;
+            }
+            // Judgement of Light and Judgement of Wisdom
+            else if (auraSpellInfo->SpellFamilyFlags & uint64(0x0000000000080000))
+            {
+                switch (auraSpellInfo->Id)
+                {
+                    // Judgement of Light
+                    case 20185: trigger_spell_id = 20267; break; // Rank 1
+                    case 20344: trigger_spell_id = 20341; break; // Rank 2
+                    case 20345: trigger_spell_id = 20342; break; // Rank 3
+                    case 20346: trigger_spell_id = 20343; break; // Rank 4
+                    case 27162: trigger_spell_id = 27163; break; // Rank 5
+                    // Judgement of Wisdom
+                    case 20186: trigger_spell_id = 20268; break; // Rank 1
+                    case 20354: trigger_spell_id = 20352; break; // Rank 2
+                    case 20355: trigger_spell_id = 20353; break; // Rank 3
+                    case 27164: trigger_spell_id = 27165; break; // Rank 4
+                    default:
+                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u miss posibly Judgement of Light/Wisdom", auraSpellInfo->Id);
+                        return SPELL_AURA_PROC_FAILED;
+                }
+                pVictim->CastSpell(pVictim, trigger_spell_id, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+                return SPELL_AURA_PROC_OK;                  // no hidden cooldown
+            }
+            // Illumination
+            else if (auraSpellInfo->SpellIconID == 241)
+            {
+                if (!procSpell)
+                    return SPELL_AURA_PROC_FAILED;
+                // procspell is triggered spell but we need mana cost of original casted spell
+                uint32 originalSpellId = procSpell->Id;
+                // Holy Shock heal
+                if (procSpell->SpellFamilyFlags & uint64(0x0001000000000000))
+                {
+                    switch (procSpell->Id)
+                    {
+                        case 25914: originalSpellId = 20473; break;
+                        case 25913: originalSpellId = 20929; break;
+                        case 25903: originalSpellId = 20930; break;
+                        case 27175: originalSpellId = 27174; break;
+                        case 33074: originalSpellId = 33072; break;
+                        default:
+                            sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u not handled in HShock", procSpell->Id);
+                            return SPELL_AURA_PROC_FAILED;
+                    }
+                }
+                SpellEntry const* originalSpell = sSpellTemplate.LookupEntry<SpellEntry>(originalSpellId);
+                if (!originalSpell)
+                {
+                    sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u unknown but selected as original in Illu", originalSpellId);
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                // percent stored in effect 1 (class scripts) base points
+                int32 cost = originalSpell->manaCost;
+                basepoints[0] = cost * auraSpellInfo->CalculateSimpleValue(EFFECT_INDEX_1) / 100;
+                trigger_spell_id = 20272;
+                target = this;
+            }
+            // Lightning Capacitor
+            else if (auraSpellInfo->Id == 37657)
+            {
+                if (!pVictim || !pVictim->isAlive())
+                    return SPELL_AURA_PROC_FAILED;
+                // stacking
+                CastSpell(this, 37658, TRIGGERED_OLD_TRIGGERED, nullptr, triggeredByAura);
+
+                Aura* dummy = GetDummyAura(37658);
+                // release at 3 aura in stack (cont contain in basepoint of trigger aura)
+                if (!dummy || dummy->GetStackAmount() < uint32(triggerAmount))
+                    return SPELL_AURA_PROC_FAILED;
+
+                RemoveAurasDueToSpell(37658);
+                trigger_spell_id = 37661;
+                target = pVictim;
+            }
+            // Bonus Healing (Crystal Spire of Karabor mace)
+            else if (auraSpellInfo->Id == 40971)
+            {
+                // If your target is below $s1% health
+                if (pVictim->GetHealth() > pVictim->GetMaxHealth() * triggerAmount / 100)
+                    return SPELL_AURA_PROC_FAILED;
+            }
+            break;
+        }
+        case SPELLFAMILY_SHAMAN:
+        {
+            // Lightning Shield (overwrite non existing triggered spell call in spell.dbc
+            if (auraSpellInfo->IsFitToFamilyMask(uint64(0x0000000000000400)) && auraSpellInfo->SpellVisual == 37)
+            {
+                switch (auraSpellInfo->Id)
+                {
+                    case 324:                           // Rank 1
+                        trigger_spell_id = 26364; break;
+                    case 325:                           // Rank 2
+                        trigger_spell_id = 26365; break;
+                    case 905:                           // Rank 3
+                        trigger_spell_id = 26366; break;
+                    case 945:                           // Rank 4
+                        trigger_spell_id = 26367; break;
+                    case 8134:                          // Rank 5
+                        trigger_spell_id = 26369; break;
+                    case 10431:                         // Rank 6
+                        trigger_spell_id = 26370; break;
+                    case 10432:                         // Rank 7
+                        trigger_spell_id = 26363; break;
+                    case 25469:                         // Rank 8
+                        trigger_spell_id = 26371; break;
+                    case 25472:                         // Rank 9
+                        trigger_spell_id = 26372; break;
+                    default:
+                        sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u not handled in LShield", auraSpellInfo->Id);
+                        return SPELL_AURA_PROC_FAILED;
+                }
+            }
+            // Lightning Shield (The Ten Storms set)
+            else if (auraSpellInfo->Id == 23551)
+            {
+                trigger_spell_id = 23552;
+                target = pVictim;
+            }
+            // Damage from Lightning Shield (The Ten Storms set)
+            else if (auraSpellInfo->Id == 23552)
+                trigger_spell_id = 27635;
+            // Mana Surge (The Earthfury set)
+            else if (auraSpellInfo->Id == 23572)
+            {
+                if (!procSpell)
+                    return SPELL_AURA_PROC_FAILED;
+                basepoints[0] = procSpell->manaCost * 35 / 100;
+                trigger_spell_id = 23571;
+                target = this;
+            }
+            // Nature's Guardian
+            else if (auraSpellInfo->SpellIconID == 2013)
+            {
+                // Check health condition - should drop to less 30% (trigger at any attack with result health less 30%, independent original health state)
+                int32 health30 = int32(GetMaxHealth()) * 3 / 10;
+                if (int32(GetHealth()) - int32(damage) >= health30)
+                    return SPELL_AURA_PROC_FAILED;
+
+                if (pVictim && pVictim->isAlive())
+                    pVictim->getThreatManager().modifyThreatPercent(this, -10);
+
+                basepoints[0] = triggerAmount * GetMaxHealth() / 100;
+                trigger_spell_id = 31616;
+                target = this;
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    // All ok. Check current trigger spell
+    SpellEntry const* triggerEntry = sSpellTemplate.LookupEntry<SpellEntry>(trigger_spell_id);
+    if (!triggerEntry)
+    {
+        // Not cast unknown spell
+        // sLog.outError("Unit::HandleProcTriggerSpellAuraProc: Spell %u have 0 in EffectTriggered[%d], not handled custom case?",auraSpellInfo->Id,triggeredByAura->GetEffIndex());
+        return SPELL_AURA_PROC_FAILED;
+    }
+
+    // not allow proc extra attack spell at extra attack
+    if (m_extraAttacks && IsSpellHaveEffect(triggerEntry, SPELL_EFFECT_ADD_EXTRA_ATTACKS))
+        return SPELL_AURA_PROC_FAILED;
+
+    // Custom basepoints/target for exist spell
+    // dummy basepoints or other customs
+    switch (trigger_spell_id)
+    {
+        // Cast positive spell on enemy target
+        case 7099:  // Curse of Mending
+        case 39647: // Curse of Mending
+        case 29494: // Temptation
+        case 20233: // Improved Lay on Hands (cast on target)
+        {
+            target = pVictim;
+            break;
+        }
+        // Combo points add triggers (need add combopoint only for main target, and after possible combopoints reset)
+        case 15250: // Rogue Setup
+        {
+            if (!pVictim || pVictim != getVictim())  // applied only for main target
+                return SPELL_AURA_PROC_FAILED;
+            break;                                   // continue normal case
+        }
+        // Finishing moves that add combo points
+        case 14189: // Seal Fate (Netherblade set)
+        case 14157: // Ruthlessness
+        {
+            // Need add combopoint AFTER finishing move (or they get dropped in finish phase)
+            if (Spell* spell = GetCurrentSpell(CURRENT_GENERIC_SPELL))
+            {
+                spell->AddTriggeredSpell(trigger_spell_id);
+                return SPELL_AURA_PROC_OK;
+            }
+            return SPELL_AURA_PROC_FAILED;
+        }
+        // Shamanistic Rage triggered spell
+        case 30824:
+        {
+            basepoints[0] = int32(GetTotalAttackPowerValue(BASE_ATTACK) * triggerAmount / 100);
+            break;
+        }
+        // Enlightenment (trigger only from mana cost spells)
+        case 35095:
+        {
+            if (!procSpell || procSpell->powerType != POWER_MANA || (procSpell->manaCost == 0 && procSpell->ManaCostPercentage == 0 && procSpell->manaCostPerlevel == 0))
+                return SPELL_AURA_PROC_FAILED;
+            break;
         }
     }
 
-    bool isPet = victim->IsPet();
+    if (cooldown && GetTypeId() == TYPEID_PLAYER && ((Player*)this)->HasSpellCooldown(trigger_spell_id))
+        return SPELL_AURA_PROC_FAILED;
 
-    /* ********************************* Set Death finally ************************************* */
-    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "SET JUST_DIED");
-    victim->SetDeathState(JUST_DIED);                       // if !spiritOfRedemtionTalentReady always true for unit
+    // try detect target manually if not set
+    if (target == nullptr)
+        target = !(procFlags & (PROC_FLAG_DONE_SPELL_MAGIC_DMG_CLASS_POS | PROC_FLAG_DONE_SPELL_NONE_DMG_CLASS_POS)) && IsPositiveSpellTargetMode(triggerEntry, this, pVictim) ? this : pVictim;
 
-    if (isPet)
-        return;                                             // Pets might have been unsummoned at this place, do not handle them further!
-
-    /* ******************************** Prepare loot if can ************************************ */
-    victim->DeleteThreatList();
-
-    // only lootable if it has loot or can drop gold
-    victim->PrepareBodyLootState();
-}
-
-void Unit::PetOwnerKilledUnit(Unit* pVictim)
-{
-    // for minipet and guardians (including protector)
-    CallForAllControlledUnits(PetOwnerKilledUnitHelper(pVictim), CONTROLLED_MINIPET | CONTROLLED_GUARDIANS);
-}
-
-void Unit::CastStop(uint32 except_spellid)
-{
-    for (uint32 i = CURRENT_FIRST_NON_MELEE_SPELL; i < CURRENT_MAX_SPELL; ++i)
-        if (m_currentSpells[i] && m_currentSpells[i]->m_spellInfo->Id != except_spellid)
-            InterruptSpell(CurrentSpellTypes(i), false);
-}
-
-SpellCastResult Unit::CastSpell(Unit* Victim, uint32 spellId, uint32 triggeredFlags, Item* castItem, Aura* triggeredByAura, ObjectGuid originalCaster, SpellEntry const* triggeredBy)
-{
-    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
-
-    if (!spellInfo)
+    // default case
+    if (!target || (target != this && !target->isAlive()))
+        return SPELL_AURA_PROC_FAILED;
+    // Quick check for target modes for procs: do not cast offensive procs on friendly targets and in reverse
+    else if (!(procEx & PROC_EX_REFLECT))
     {
-        if (triggeredByAura)
-            sLog.outError("CastSpell: unknown spell id %i by caster: %s triggered by aura %u (eff %u)", spellId, GetGuidStr().c_str(), triggeredByAura->GetId(), triggeredByAura->GetEffIndex());
-        else
-            sLog.outError("CastSpell: unknown spell id %i by caster: %s", spellId, GetGuidStr().c_str());
-        return SPELL_NOT_FOUND;
+        if (IsPositiveSpellTargetMode(triggerEntry, this, target) != IsFriendlyTo(target))
+            return SPELL_AURA_PROC_FAILED;
     }
 
-    return CastSpell(Victim, spellInfo, triggeredFlags, castItem, triggeredByAura, originalCaster, triggeredBy);
+    if (basepoints[EFFECT_INDEX_0] || basepoints[EFFECT_INDEX_1] || basepoints[EFFECT_INDEX_2])
+        CastCustomSpell(target, trigger_spell_id,
+                        basepoints[EFFECT_INDEX_0] ? &basepoints[EFFECT_INDEX_0] : nullptr,
+                        basepoints[EFFECT_INDEX_1] ? &basepoints[EFFECT_INDEX_1] : nullptr,
+                        basepoints[EFFECT_INDEX_2] ? &basepoints[EFFECT_INDEX_2] : nullptr,
+                        TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+    else
+        CastSpell(target, trigger_spell_id, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+
+    if (cooldown && GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->AddSpellCooldown(trigger_spell_id, 0, time(nullptr) + cooldown);
+
+    return SPELL_AURA_PROC_OK;
 }
 
-SpellCastResult Unit::CastSpell(Unit* Victim, SpellEntry const* spellInfo, uint32 triggeredFlags, Item* castItem, Aura* triggeredByAura, ObjectGuid originalCaster, SpellEntry const* triggeredBy)
+SpellAuraProcResult Unit::HandleProcTriggerDamageAuraProc(Unit* pVictim, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* /*procSpell*/, uint32 /*procFlags*/, uint32 /*procEx*/, uint32 /*cooldown*/)
 {
-    if (!spellInfo)
-    {
-        if (triggeredByAura)
-            sLog.outError("CastSpell: unknown spell by caster: %s triggered by aura %u (eff %u)", GetGuidStr().c_str(), triggeredByAura->GetId(), triggeredByAura->GetEffIndex());
-        else
-            sLog.outError("CastSpell: unknown spell by caster: %s", GetGuidStr().c_str());
-
-        return SPELL_NOT_FOUND;
-    }
-
-    if (castItem)
-        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: cast Item spellId - %i", spellInfo->Id);
-
-    if (triggeredByAura)
-    {
-        if (!originalCaster)
-            originalCaster = triggeredByAura->GetCasterGuid();
-
-        triggeredBy = triggeredByAura->GetSpellProto();
-    }
-
-    Spell* spell = new Spell(this, spellInfo, triggeredFlags, originalCaster, triggeredBy);
-
-    SpellCastTargets targets;
-    targets.setUnitTarget(Victim);
-
-    if (spellInfo->Targets & TARGET_FLAG_DEST_LOCATION)
-        targets.setDestination(Victim->GetPositionX(), Victim->GetPositionY(), Victim->GetPositionZ());
-    if (spellInfo->Targets & TARGET_FLAG_SOURCE_LOCATION)
-        if (WorldObject* caster = spell->GetCastingObject())
-            targets.setSource(caster->GetPositionX(), caster->GetPositionY(), caster->GetPositionZ());
-
-    spell->m_CastItem = castItem;
-    return spell->SpellStart(&targets, triggeredByAura);
-}
-
-SpellCastResult Unit::CastCustomSpell(Unit* Victim, uint32 spellId, int32 const* bp0, int32 const* bp1, int32 const* bp2, uint32 triggeredFlags, Item* castItem, Aura* triggeredByAura, ObjectGuid originalCaster, SpellEntry const* triggeredBy)
-{
-    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
-
-    if (!spellInfo)
-    {
-        if (triggeredByAura)
-            sLog.outError("CastCustomSpell: unknown spell id %i by caster: %s triggered by aura %u (eff %u)", spellId, GetGuidStr().c_str(), triggeredByAura->GetId(), triggeredByAura->GetEffIndex());
-        else
-            sLog.outError("CastCustomSpell: unknown spell id %i by caster: %s", spellId, GetGuidStr().c_str());
-        return SPELL_NOT_FOUND;
-    }
-
-    return CastCustomSpell(Victim, spellInfo, bp0, bp1, bp2, triggeredFlags, castItem, triggeredByAura, originalCaster, triggeredBy);
-}
-
-SpellCastResult Unit::CastCustomSpell(Unit* Victim, SpellEntry const* spellInfo, int32 const* bp0, int32 const* bp1, int32 const* bp2, uint32 triggeredFlags, Item* castItem, Aura* triggeredByAura, ObjectGuid originalCaster, SpellEntry const* triggeredBy)
-{
-    if (!spellInfo)
-    {
-        if (triggeredByAura)
-            sLog.outError("CastCustomSpell: unknown spell by caster: %s triggered by aura %u (eff %u)", GetGuidStr().c_str(), triggeredByAura->GetId(), triggeredByAura->GetEffIndex());
-        else
-            sLog.outError("CastCustomSpell: unknown spell by caster: %s", GetGuidStr().c_str());
-        return SPELL_NOT_FOUND;
-    }
-
-    if (castItem)
-        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: cast Item spellId - %i", spellInfo->Id);
-
-    if (triggeredByAura)
-    {
-        if (!originalCaster)
-            originalCaster = triggeredByAura->GetCasterGuid();
-
-        triggeredBy = triggeredByAura->GetSpellProto();
-    }
-
-    Spell* spell = new Spell(this, spellInfo, triggeredFlags, originalCaster, triggeredBy);
-
-    if (bp0)
-        spell->m_currentBasePoints[EFFECT_INDEX_0] = *bp0;
-
-    if (bp1)
-        spell->m_currentBasePoints[EFFECT_INDEX_1] = *bp1;
-
-    if (bp2)
-        spell->m_currentBasePoints[EFFECT_INDEX_2] = *bp2;
-
-    SpellCastTargets targets;
-    targets.setUnitTarget(Victim);
-    spell->m_CastItem = castItem;
-
-    if (spellInfo->Targets & TARGET_FLAG_DEST_LOCATION)
-        targets.setDestination(Victim->GetPositionX(), Victim->GetPositionY(), Victim->GetPositionZ());
-    if (spellInfo->Targets & TARGET_FLAG_SOURCE_LOCATION)
-        if (WorldObject* caster = spell->GetCastingObject())
-            targets.setSource(caster->GetPositionX(), caster->GetPositionY(), caster->GetPositionZ());
-
-    return spell->SpellStart(&targets, triggeredByAura);
-}
-
-// used for scripting
-SpellCastResult Unit::CastSpell(float x, float y, float z, uint32 spellId, uint32 triggeredFlags, Item* castItem, Aura* triggeredByAura, ObjectGuid originalCaster, SpellEntry const* triggeredBy)
-{
-    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
-
-    if (!spellInfo)
-    {
-        if (triggeredByAura)
-            sLog.outError("CastSpell(x,y,z): unknown spell id %i by caster: %s triggered by aura %u (eff %u)", spellId, GetGuidStr().c_str(), triggeredByAura->GetId(), triggeredByAura->GetEffIndex());
-        else
-            sLog.outError("CastSpell(x,y,z): unknown spell id %i by caster: %s", spellId, GetGuidStr().c_str());
-        return SPELL_NOT_FOUND;
-    }
-
-    return CastSpell(x, y, z, spellInfo, triggeredFlags, castItem, triggeredByAura, originalCaster, triggeredBy);
-}
-
-// used for scripting
-SpellCastResult Unit::CastSpell(float x, float y, float z, SpellEntry const* spellInfo, uint32 triggeredFlags, Item* castItem, Aura* triggeredByAura, ObjectGuid originalCaster, SpellEntry const* triggeredBy)
-{
-    if (!spellInfo)
-    {
-        if (triggeredByAura)
-            sLog.outError("CastSpell(x,y,z): unknown spell by caster: %s triggered by aura %u (eff %u)", GetGuidStr().c_str(), triggeredByAura->GetId(), triggeredByAura->GetEffIndex());
-        else
-            sLog.outError("CastSpell(x,y,z): unknown spell by caster: %s", GetGuidStr().c_str());
-        return SPELL_NOT_FOUND;
-    }
-
-    if (castItem)
-        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: cast Item spellId - %i", spellInfo->Id);
-
-    if (triggeredByAura)
-    {
-        if (!originalCaster)
-            originalCaster = triggeredByAura->GetCasterGuid();
-
-        triggeredBy = triggeredByAura->GetSpellProto();
-    }
-
-    Spell* spell = new Spell(this, spellInfo, triggeredFlags, originalCaster, triggeredBy);
-
-    SpellCastTargets targets;
-
-    if (spellInfo->Targets & TARGET_FLAG_DEST_LOCATION)
-        targets.setDestination(x, y, z);
-    if (spellInfo->Targets & TARGET_FLAG_SOURCE_LOCATION)
-        targets.setSource(x, y, z);
-
-    // Spell cast with x,y,z but without dbc target-mask, set destination
-    if (!(targets.m_targetMask & (TARGET_FLAG_DEST_LOCATION | TARGET_FLAG_SOURCE_LOCATION)))
-        targets.setDestination(x, y, z);
-
-    spell->m_CastItem = castItem;
-    return spell->SpellStart(&targets, triggeredByAura);
-}
-
-// Obsolete func need remove, here only for comotability vs another patches
-uint32 Unit::SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage)
-{
-    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellID);
+    SpellEntry const* spellInfo = triggeredByAura->GetSpellProto();
+    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "ProcDamageAndSpell: doing %u damage from spell id %u (triggered by auratype %u of spell %u)",
+                     triggeredByAura->GetModifier()->m_amount, spellInfo->Id, triggeredByAura->GetModifier()->m_auraname, triggeredByAura->GetId());
     SpellNonMeleeDamage damageInfo(this, pVictim, spellInfo->Id, SpellSchoolMask(spellInfo->SchoolMask));
-    CalculateSpellDamage(&damageInfo, damage, spellInfo);
+    CalculateSpellDamage(&damageInfo, triggeredByAura->GetModifier()->m_amount, spellInfo);
     damageInfo.target->CalculateAbsorbResistBlock(this, &damageInfo, spellInfo);
     DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb, SPELL_DIRECT_DAMAGE, spellInfo);
     SendSpellNonMeleeDamageLog(&damageInfo);
     DealSpellDamage(&damageInfo, true);
-    return damageInfo.damage;
+
+    sLog.outErrorDb("Unit::HandleProcTriggerDamageAuraProc: %u",spellInfo->Id);
+
+    return SPELL_AURA_PROC_OK;
 }
 
-void Unit::CalculateSpellDamage(SpellNonMeleeDamage* damageInfo, int32 damage, SpellEntry const* spellInfo, WeaponAttackType attackType)
+SpellAuraProcResult Unit::HandleOverrideClassScriptAuraProc(Unit* pVictim, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procEx*/ , uint32 cooldown)
 {
-    SpellSchoolMask damageSchoolMask = damageInfo->schoolMask;
-    Unit* pVictim = damageInfo->target;
+    int32 scriptId = triggeredByAura->GetModifier()->m_miscvalue;
 
-    if (damage < 0)
-        return;
+    if (!pVictim || !pVictim->isAlive())
+        return SPELL_AURA_PROC_FAILED;
 
-    if (!this || !pVictim)
-        return;
+    Item* castItem = triggeredByAura->GetCastItemGuid() && GetTypeId() == TYPEID_PLAYER
+                     ? ((Player*)this)->GetItemByGuid(triggeredByAura->GetCastItemGuid()) : nullptr;
 
-    // units which are not alive cannot deal damage except for dying creatures
-    if ((!this->isAlive() || !pVictim->isAlive()) && (this->GetTypeId() != TYPEID_UNIT || this->getDeathState() != DEAD))
-        return;
+    // Basepoints of trigger aura
+    int32 triggerAmount = triggeredByAura->GetModifier()->m_amount;
 
-    // Check spell crit chance
-    bool crit = IsSpellCrit(pVictim, spellInfo, damageSchoolMask, attackType);
+    uint32 triggered_spell_id = 0;
 
-    // damage bonus (per damage class)
-    switch (spellInfo->DmgClass)
+    switch (scriptId)
     {
-        // Melee and Ranged Spells
-        case SPELL_DAMAGE_CLASS_RANGED:
-        case SPELL_DAMAGE_CLASS_MELEE:
+        case 836:                                           // Improved Blizzard (Rank 1)
         {
-            // Calculate damage bonus
-            damage = MeleeDamageBonusDone(pVictim, damage, attackType, spellInfo, SPELL_DIRECT_DAMAGE);
-            damage = pVictim->MeleeDamageBonusTaken(this, damage, attackType, spellInfo, SPELL_DIRECT_DAMAGE);
-        }
-        break;
-        // Magical Attacks
-        case SPELL_DAMAGE_CLASS_NONE:
-        case SPELL_DAMAGE_CLASS_MAGIC:
-        {
-            // Calculate damage bonus
-            damage = SpellDamageBonusDone(pVictim, spellInfo, damage, SPELL_DIRECT_DAMAGE);
-            damage = pVictim->SpellDamageBonusTaken(this, spellInfo, damage, SPELL_DIRECT_DAMAGE);
-        }
-        break;
-    }
-
-    // if crit add critical bonus
-    if (crit)
-    {
-        damageInfo->HitInfo |= SPELL_HIT_TYPE_CRIT;
-        damage = CalculateCritAmount(pVictim, damage, spellInfo);
-    }
-
-    // damage mitigation
-    if (damage > 0)
-    {
-        // physical damage => armor
-        if (damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL)
-            damage = CalcArmorReducedDamage(pVictim, damage);
-    }
-    else
-        damage = 0;
-    damageInfo->damage = damage;
-}
-
-void Unit::DealSpellDamage(SpellNonMeleeDamage* damageInfo, bool durabilityLoss)
-{
-    if (!damageInfo)
-        return;
-
-    Unit* pVictim = damageInfo->target;
-
-    if (!this || !pVictim)
-        return;
-
-    if (!pVictim->isAlive() || pVictim->IsTaxiFlying() || (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode()))
-        return;
-
-    SpellEntry const* spellProto = sSpellTemplate.LookupEntry<SpellEntry>(damageInfo->SpellID);
-    if (spellProto == nullptr)
-    {
-        sLog.outError("Unit::DealSpellDamage have wrong damageInfo->SpellID: %u", damageInfo->SpellID);
-        return;
-    }
-
-    // You don't lose health from damage taken from another player while in a sanctuary
-    // You still see it in the combat log though
-    if (!IsAllowedDamageInArea(pVictim))
-        return;
-
-    // update at damage Judgement aura duration that applied by attacker at victim
-    if (damageInfo->damage && spellProto->Id == 35395)
-    {
-        SpellAuraHolderMap const& vAuras = pVictim->GetSpellAuraHolderMap();
-        for (SpellAuraHolderMap::const_iterator itr = vAuras.begin(); itr != vAuras.end(); ++itr)
-        {
-            SpellEntry const* spellInfo = (*itr).second->GetSpellProto();
-            if (spellInfo->HasAttribute(SPELL_ATTR_EX3_CANT_MISS) && spellInfo->SpellFamilyName == SPELLFAMILY_PALADIN && ((*itr).second->GetCasterGuid() == GetObjectGuid()))
-                (*itr).second->RefreshHolder();
-        }
-    }
-
-    // Call default DealDamage (send critical in hit info for threat calculation)
-    CleanDamage cleanDamage(0, BASE_ATTACK, damageInfo->HitInfo & SPELL_HIT_TYPE_CRIT ? MELEE_HIT_CRIT : MELEE_HIT_NORMAL);
-    DealDamage(pVictim, damageInfo->damage, &cleanDamage, SPELL_DIRECT_DAMAGE, damageInfo->schoolMask, spellProto, durabilityLoss);
-}
-
-// TODO for melee need create structure as in
-void Unit::CalculateMeleeDamage(Unit* pVictim, CalcDamageInfo* damageInfo, WeaponAttackType attackType /*= BASE_ATTACK*/)
-{
-    damageInfo->attacker         = this;
-    damageInfo->target           = pVictim;
-    damageInfo->damageSchoolMask = GetMeleeDamageSchoolMask();
-    damageInfo->attackType       = attackType;
-    damageInfo->damage           = 0;
-    damageInfo->cleanDamage      = 0;
-    damageInfo->absorb           = 0;
-    damageInfo->resist           = 0;
-    damageInfo->blocked_amount   = 0;
-
-    damageInfo->TargetState      = VICTIMSTATE_UNAFFECTED;
-    damageInfo->HitInfo          = HITINFO_NORMALSWING;
-    damageInfo->procAttacker     = PROC_FLAG_NONE;
-    damageInfo->procVictim       = PROC_FLAG_NONE;
-    damageInfo->procEx           = PROC_EX_NONE;
-    damageInfo->hitOutCome       = MELEE_HIT_EVADE;
-
-    if (!this || !pVictim)
-        return;
-    if (!this->isAlive() || !pVictim->isAlive())
-        return;
-
-    // Select HitInfo/procAttacker/procVictim flag based on attack type
-    switch (attackType)
-    {
-        case BASE_ATTACK:
-            damageInfo->procAttacker = PROC_FLAG_SUCCESSFUL_MELEE_HIT;
-            damageInfo->procVictim   = PROC_FLAG_TAKEN_MELEE_HIT;
-            damageInfo->HitInfo      = HITINFO_NORMALSWING2;
-            break;
-        case OFF_ATTACK:
-            damageInfo->procAttacker = PROC_FLAG_SUCCESSFUL_MELEE_HIT | PROC_FLAG_SUCCESSFUL_OFFHAND_HIT;
-            damageInfo->procVictim   = PROC_FLAG_TAKEN_MELEE_HIT;//|PROC_FLAG_TAKEN_OFFHAND_HIT // not used
-            damageInfo->HitInfo = HITINFO_LEFTSWING;
-            break;
-        case RANGED_ATTACK:
-            damageInfo->procAttacker = PROC_FLAG_SUCCESSFUL_RANGED_HIT;
-            damageInfo->procVictim   = PROC_FLAG_TAKEN_RANGED_HIT;
-            damageInfo->HitInfo = HITINFO_UNK3;             // test (dev note: test what? HitInfo flag possibly not confirmed.)
-            break;
-        default:
-            break;
-    }
-
-    // Physical Immune check
-    if (damageInfo->target->IsImmuneToDamage(damageInfo->damageSchoolMask))
-    {
-        damageInfo->HitInfo       |= HITINFO_NORMALSWING;
-        damageInfo->TargetState    = VICTIMSTATE_IS_IMMUNE;
-
-        damageInfo->procEx |= PROC_EX_IMMUNE;
-        damageInfo->damage         = 0;
-        damageInfo->cleanDamage    = 0;
-        return;
-    }
-    uint32 damage = CalculateDamage(damageInfo->attackType, false);
-    // Add melee damage bonus
-    damage = MeleeDamageBonusDone(damageInfo->target, damage, damageInfo->attackType);
-    damage = damageInfo->target->MeleeDamageBonusTaken(this, damage, damageInfo->attackType);
-
-    // Calculate armor reduction
-    damageInfo->damage = CalcArmorReducedDamage(damageInfo->target, damage);
-    damageInfo->cleanDamage += damage - damageInfo->damage;
-
-    damageInfo->hitOutCome = RollMeleeOutcomeAgainst(damageInfo->target, damageInfo->attackType, damageInfo->damageSchoolMask);
-
-    // Disable parry or dodge for ranged attack
-    if (damageInfo->attackType == RANGED_ATTACK)
-    {
-        if (damageInfo->hitOutCome == MELEE_HIT_PARRY) damageInfo->hitOutCome = MELEE_HIT_NORMAL;
-        if (damageInfo->hitOutCome == MELEE_HIT_DODGE) damageInfo->hitOutCome = MELEE_HIT_MISS;
-    }
-
-    switch (damageInfo->hitOutCome)
-    {
-        case MELEE_HIT_EVADE:
-        {
-            damageInfo->HitInfo    |= HITINFO_MISS | HITINFO_SWINGNOHITSOUND;
-            damageInfo->TargetState = VICTIMSTATE_EVADES;
-
-            damageInfo->procEx |= PROC_EX_EVADE;
-            damageInfo->damage = 0;
-            damageInfo->cleanDamage = 0;
-            return;
-        }
-        case MELEE_HIT_MISS:
-        {
-            damageInfo->HitInfo    |= HITINFO_MISS;
-            damageInfo->TargetState = VICTIMSTATE_UNAFFECTED;
-
-            damageInfo->procEx |= PROC_EX_MISS;
-            damageInfo->damage = 0;
-            damageInfo->cleanDamage = 0;
+            if (!procSpell || procSpell->SpellVisual != 9487)
+                return SPELL_AURA_PROC_FAILED;
+            triggered_spell_id = 12484;
             break;
         }
-        case MELEE_HIT_NORMAL:
-            damageInfo->TargetState = VICTIMSTATE_NORMAL;
-            damageInfo->procEx |= PROC_EX_NORMAL_HIT;
-            break;
-        case MELEE_HIT_CRIT:
+        case 988:                                           // Improved Blizzard (Rank 2)
         {
-            damageInfo->HitInfo     |= HITINFO_CRITICALHIT;
-            damageInfo->TargetState  = VICTIMSTATE_NORMAL;
-            damageInfo->procEx |= PROC_EX_CRITICAL_HIT;
-            CalculateCritAmount(damageInfo);
+            if (!procSpell || procSpell->SpellVisual != 9487)
+                return SPELL_AURA_PROC_FAILED;
+            triggered_spell_id = 12485;
             break;
         }
-        case MELEE_HIT_PARRY:
-            damageInfo->TargetState  = VICTIMSTATE_PARRY;
-            damageInfo->procEx      |= PROC_EX_PARRY;
-            damageInfo->cleanDamage += damageInfo->damage;
-            damageInfo->damage = 0;
-            break;
-
-        case MELEE_HIT_DODGE:
-            damageInfo->TargetState  = VICTIMSTATE_DODGE;
-            damageInfo->procEx      |= PROC_EX_DODGE;
-            damageInfo->cleanDamage += damageInfo->damage;
-            damageInfo->damage = 0;
-            break;
-        case MELEE_HIT_BLOCK:
+        case 989:                                           // Improved Blizzard (Rank 3)
         {
-            damageInfo->TargetState = VICTIMSTATE_NORMAL;
-            damageInfo->procEx     |= PROC_EX_BLOCK;
-            damageInfo->blocked_amount = damageInfo->target->GetShieldBlockValue();
-            if (damageInfo->blocked_amount >= damageInfo->damage)
+            if (!procSpell || procSpell->SpellVisual != 9487)
+                return SPELL_AURA_PROC_FAILED;
+            triggered_spell_id = 12486;
+            break;
+        }
+        case 4086:                                          // Improved Mend Pet (Rank 1)
+        case 4087:                                          // Improved Mend Pet (Rank 2)
+        {
+            if (!roll_chance_i(triggerAmount))
+                return SPELL_AURA_PROC_FAILED;
+
+            triggered_spell_id = 24406;
+            break;
+        }
+        case 4533:                                          // Dreamwalker Raiment 2 pieces bonus
+        {
+            // Chance 50%
+            if (!roll_chance_i(50))
+                return SPELL_AURA_PROC_FAILED;
+
+            switch (pVictim->GetPowerType())
             {
-                damageInfo->TargetState = VICTIMSTATE_BLOCKS;
-                damageInfo->blocked_amount = damageInfo->damage;
-            }
-            else
-                damageInfo->procEx |= PROC_EX_NORMAL_HIT;   // Partial blocks can still cause attacker procs
-
-            damageInfo->damage      -= damageInfo->blocked_amount;
-            damageInfo->cleanDamage += damageInfo->blocked_amount;
-            break;
-        }
-        case MELEE_HIT_GLANCING:
-        {
-            damageInfo->HitInfo |= HITINFO_GLANCING;
-            damageInfo->TargetState = VICTIMSTATE_NORMAL;
-            damageInfo->procEx |= PROC_EX_NORMAL_HIT;
-            // calculate base values and mods
-            float baseLowEnd = 1.3f;
-            float baseHighEnd = 1.2f;
-            switch (getClass())                             // lowering base values for casters
-            {
-                case CLASS_SHAMAN:
-                case CLASS_PRIEST:
-                case CLASS_MAGE:
-                case CLASS_WARLOCK:
-                case CLASS_DRUID:
-                    baseLowEnd  -= 0.7f;
-                    baseHighEnd -= 0.3f;
-                    break;
-            }
-
-            float maxLowEnd = 0.6f;
-            switch (getClass())                             // upper for melee classes
-            {
-                case CLASS_WARRIOR:
-                case CLASS_ROGUE:
-                    maxLowEnd = 0.91f;                      // If the attacker is a melee class then instead the lower value of 0.91
-            }
-
-            // calculate values
-            int32 attackerRating = GetWeaponSkillValue(damageInfo->attackType);
-            attackerRating = static_cast<std::uint32_t>(attackerRating) > getLevel() * 5 ? getLevel() * 5 : attackerRating; // cap rating at level * 5, done in 2.0.1
-            int32 diff = damageInfo->target->GetDefenseSkillValue() - attackerRating;
-            float lowEnd  = baseLowEnd - (0.05f * diff);
-            float highEnd = baseHighEnd - (0.03f * diff);
-
-            // apply max/min bounds
-            if (lowEnd < 0.01f)                             // the low end must not go bellow 0.01f
-                lowEnd = 0.01f;
-            else if (lowEnd > maxLowEnd)                    // the smaller value of this and 0.6 is kept as the low end
-                lowEnd = maxLowEnd;
-
-            if (highEnd < 0.2f)                             // high end limits
-                highEnd = 0.2f;
-            if (highEnd > 0.99f)
-                highEnd = 0.99f;
-
-            if (lowEnd > highEnd)                           // prevent negative range size
-                lowEnd = highEnd;
-
-            float reducePercent = lowEnd + rand_norm_f() * (highEnd - lowEnd);
-
-            damageInfo->cleanDamage += damageInfo->damage - uint32(reducePercent *  damageInfo->damage);
-            damageInfo->damage   = uint32(reducePercent *  damageInfo->damage);
-            break;
-        }
-        case MELEE_HIT_CRUSHING:
-        {
-            damageInfo->HitInfo     |= HITINFO_CRUSHING;
-            damageInfo->TargetState  = VICTIMSTATE_NORMAL;
-            damageInfo->procEx |= PROC_EX_NORMAL_HIT;
-            // 150% normal damage
-            damageInfo->damage += (damageInfo->damage / 2);
-            break;
-        }
-        default:
-
-            break;
-    }
-
-    // Calculate absorb resist
-    if (int32(damageInfo->damage) > 0)
-    {
-        damageInfo->procVictim |= PROC_FLAG_TAKEN_ANY_DAMAGE;
-
-        // Calculate absorb & resists
-        damageInfo->target->CalculateDamageAbsorbAndResist(this, damageInfo->damageSchoolMask, DIRECT_DAMAGE, damageInfo->damage, &damageInfo->absorb, &damageInfo->resist, true);
-        damageInfo->damage -= damageInfo->absorb + damageInfo->resist;
-        if (damageInfo->absorb)
-        {
-            damageInfo->HitInfo |= HITINFO_ABSORB;
-            damageInfo->procEx |= PROC_EX_ABSORB;
-        }
-        if (damageInfo->resist)
-            damageInfo->HitInfo |= HITINFO_RESIST;
-    }
-    else // Umpossible get negative result but....
-        damageInfo->damage = 0;
-}
-
-void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
-{
-    if (!damageInfo)
-        return;
-
-    Unit* pVictim = damageInfo->target;
-
-    if (!this || !pVictim)
-        return;
-
-    if (!pVictim->isAlive() || pVictim->IsTaxiFlying() || (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode()))
-        return;
-
-    // You don't lose health from damage taken from another player while in a sanctuary
-    // You still see it in the combat log though
-    if (!IsAllowedDamageInArea(pVictim))
-        return;
-
-    // Hmmmm dont like this emotes client must by self do all animations
-    if (damageInfo->HitInfo & HITINFO_CRITICALHIT)
-        pVictim->HandleEmoteCommand(EMOTE_ONESHOT_WOUNDCRITICAL);
-    if (damageInfo->blocked_amount && damageInfo->TargetState != VICTIMSTATE_BLOCKS)
-        pVictim->HandleEmoteCommand(EMOTE_ONESHOT_PARRYSHIELD);
-
-    if (damageInfo->TargetState == VICTIMSTATE_PARRY)
-    {
-        if (pVictim->GetTypeId() != TYPEID_UNIT ||
-            !(((Creature*)pVictim)->GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_NO_PARRY_HASTEN))
-        {
-            // Get attack timers
-            float offtime = float(pVictim->getAttackTimer(OFF_ATTACK));
-            float basetime = float(pVictim->getAttackTimer(BASE_ATTACK));
-            // Reduce attack time
-            if (pVictim->haveOffhandWeapon() && offtime < basetime)
-            {
-                float percent20 = pVictim->GetAttackTime(OFF_ATTACK) * 0.20f;
-                float percent60 = 3.0f * percent20;
-                if (offtime > percent20 && offtime <= percent60)
-                {
-                    pVictim->setAttackTimer(OFF_ATTACK, uint32(percent20));
-                }
-                else if (offtime > percent60)
-                {
-                    offtime -= 2.0f * percent20;
-                    pVictim->setAttackTimer(OFF_ATTACK, uint32(offtime));
-                }
-            }
-            else
-            {
-                float percent20 = pVictim->GetAttackTime(BASE_ATTACK) * 0.20f;
-                float percent60 = 3.0f * percent20;
-                if (basetime > percent20 && basetime <= percent60)
-                {
-                    pVictim->setAttackTimer(BASE_ATTACK, uint32(percent20));
-                }
-                else if (basetime > percent60)
-                {
-                    basetime -= 2.0f * percent20;
-                    pVictim->setAttackTimer(BASE_ATTACK, uint32(basetime));
-                }
-            }
-        }
-    }
-
-    // Call default DealDamage
-    CleanDamage cleanDamage(damageInfo->cleanDamage, damageInfo->attackType, damageInfo->hitOutCome);
-    DealDamage(pVictim, damageInfo->damage, &cleanDamage, DIRECT_DAMAGE, damageInfo->damageSchoolMask, nullptr, durabilityLoss);
-
-    // If this attack by an NPC dealt some damage from behind to a player, it has a chance to daze victim
-    if (damageInfo->damage && CanDazeInCombat(pVictim) && roll_chance_f(CalculateEffectiveDazeChance(pVictim, damageInfo->attackType)))
-        CastSpell(pVictim, 1604, TRIGGERED_OLD_TRIGGERED);
-
-    // update at damage Judgement aura duration that applied by attacker at victim
-    if (damageInfo->damage)
-    {
-        SpellAuraHolderMap const& vAuras = pVictim->GetSpellAuraHolderMap();
-        for (SpellAuraHolderMap::const_iterator itr = vAuras.begin(); itr != vAuras.end(); ++itr)
-        {
-            SpellEntry const* spellInfo = (*itr).second->GetSpellProto();
-            if (spellInfo->HasAttribute(SPELL_ATTR_EX3_CANT_MISS) && spellInfo->SpellFamilyName == SPELLFAMILY_PALADIN && ((*itr).second->GetCasterGuid() == GetObjectGuid()))
-                (*itr).second->RefreshHolder();
-        }
-    }
-
-    // If not miss
-    if (!(damageInfo->HitInfo & HITINFO_MISS))
-    {
-        // on weapon hit casts
-        if (GetTypeId() == TYPEID_PLAYER && pVictim->isAlive())
-            ((Player*)this)->CastItemCombatSpell(pVictim, damageInfo->attackType);
-
-        // If not immune
-        if (damageInfo->TargetState != VICTIMSTATE_IS_IMMUNE)
-        {
-            // victim's damage shield
-            std::set<Aura*> alreadyDone;
-            AuraList const& vDamageShields = pVictim->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
-            for (AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)
-            {
-                if (alreadyDone.find(*i) == alreadyDone.end())
-                {
-                    alreadyDone.insert(*i);
-                    uint32 damage = (*i)->GetModifier()->m_amount;
-                    SpellEntry const* i_spellProto = (*i)->GetSpellProto();
-                    // Calculate absorb resist ??? no data in opcode for this possibly unable to absorb or resist?
-                    // uint32 absorb;
-                    // uint32 resist;
-                    // CalcAbsorbResist(pVictim, SpellSchools(spellProto->School), SPELL_DIRECT_DAMAGE, damage, &absorb, &resist);
-                    // damage-=absorb + resist;
-
-                    pVictim->DealDamageMods(this, damage, nullptr, SPELL_DIRECT_DAMAGE, i_spellProto);
-
-                    WorldPacket data(SMSG_SPELLDAMAGESHIELD, (8 + 8 + 4 + 4 + 4));
-                    data << pVictim->GetObjectGuid();
-                    data << GetObjectGuid();
-                    data << uint32(i_spellProto->Id);
-                    data << uint32(damage);                  // Damage
-                    data << uint32(i_spellProto->SchoolMask);
-                    pVictim->SendMessageToSet(data, true);
-
-                    pVictim->DealDamage(this, damage, nullptr, SPELL_DIRECT_DAMAGE, GetSpellSchoolMask(i_spellProto), i_spellProto, true);
-
-                    i = vDamageShields.begin();
-                }
-                else
-                    ++i;
-            }
-        }
-    }
-}
-
-
-void Unit::HandleEmoteCommand(uint32 emote_id)
-{
-    WorldPacket data(SMSG_EMOTE, 4 + 8);
-    data << uint32(emote_id);
-    data << GetObjectGuid();
-    SendMessageToSet(data, true);
-}
-
-void Unit::HandleEmoteState(uint32 emote_id)
-{
-    SetUInt32Value(UNIT_NPC_EMOTESTATE, emote_id);
-}
-
-void Unit::HandleEmote(uint32 emote_id)
-{
-    if (!emote_id)
-        HandleEmoteState(0);
-    else if (EmotesEntry const* emoteEntry = sEmotesStore.LookupEntry(emote_id))
-    {
-        if (emoteEntry->EmoteType)                          // 1,2 states, 0 command
-            HandleEmoteState(emote_id);
-        else
-            HandleEmoteCommand(emote_id);
-    }
-}
-
-uint32 Unit::CalcArmorReducedDamage(Unit* pVictim, const uint32 damage)
-{
-    float armor = (float)pVictim->GetArmor();
-
-    // Ignore enemy armor by armor penetration
-    armor -= GetResistancePenetration(SPELL_SCHOOL_NORMAL);
-
-    if (armor < 0.0f)
-        armor = 0.0f;
-
-    float levelModifier = (float)getLevel();
-    if (levelModifier > 59)
-        levelModifier = levelModifier + (4.5f * (levelModifier - 59));
-
-    float tmpvalue = 0.1f * armor / (8.5f * levelModifier + 40);
-    tmpvalue = tmpvalue / (1.0f + tmpvalue);
-
-    if (tmpvalue < 0.0f)
-        tmpvalue = 0.0f;
-    if (tmpvalue > 0.75f)
-        tmpvalue = 0.75f;
-
-    uint32 newdamage = uint32(damage - (damage * tmpvalue));
-
-    return (newdamage > 1) ? newdamage : 1;
-}
-
-void Unit::CalculateDamageAbsorbAndResist(Unit* pCaster, SpellSchoolMask schoolMask, DamageEffectType damagetype, const uint32 damage, uint32* absorb, uint32* resist, bool canReflect, bool ignoreResists, bool binary)
-{
-    if (!pCaster || !isAlive() || !damage)
-        return;
-
-    // Magic damage, check for resists
-    if (!ignoreResists && (schoolMask & SPELL_SCHOOL_MASK_MAGIC) && (!binary || damagetype == DOT))
-    {
-        const float percent = CalculateEffectiveMagicResistancePercent(pCaster, schoolMask);
-        const SpellPartialResistChanceEntry &chances = SPELL_PARTIAL_RESIST_DISTRIBUTION.at(uint32(percent * 100));
-        // We choose which portion of damage is resisted below, none by default
-        uint8 portion = SPELL_PARTIAL_RESIST_NONE;
-        // If we got to this point, we already rolled for full resist on hit
-        // We do a roll between remaining chances
-        const uint8 outcomes = (NUM_SPELL_PARTIAL_RESISTS - 1);
-        const uint32 roll = urand(1, (10000 - chances.at(SPELL_PARTIAL_RESIST_PCT_100)));
-        Die<SpellPartialResist, SPELL_PARTIAL_RESIST_NONE, outcomes> die;
-        for (uint8 outcome = SPELL_PARTIAL_RESIST_NONE; outcome < outcomes; ++outcome)
-            die.chance[outcome] = chances.at(outcome);
-        portion = die.roll(roll);
-        const uint32 amount = uint32(damage * (portion * (1.0f / float(outcomes))));
-        // We already rolled for full resist on hit, so we need to deal at least *some* amount of damage...
-        *resist = (amount >= damage) ? (damage - 1) : amount;
-    }
-    else
-        *resist = 0;
-
-    int32 RemainingDamage = damage - *resist;
-
-    // Reflect damage spells (not cast any damage spell in aura lookup)
-    uint32 reflectSpell = 0;
-    int32  reflectDamage = 0;
-    Aura*  reflectTriggeredBy = nullptr;                       // expected as not expired at reflect as in current cases
-    // Death Prevention Aura
-    SpellEntry const*  preventDeathSpell = nullptr;
-
-    // full absorb cases (by chance)
-    /* none cases, but preserve for better backporting conflict resolve
-    AuraList const& vAbsorb = GetAurasByType(SPELL_AURA_SCHOOL_ABSORB);
-    for(AuraList::const_iterator i = vAbsorb.begin(); i != vAbsorb.end() && RemainingDamage > 0; ++i)
-    {
-        // only work with proper school mask damage
-        Modifier* i_mod = (*i)->GetModifier();
-        if (!(i_mod->m_miscvalue & schoolMask))
-            continue;
-
-        SpellEntry const* i_spellProto = (*i)->GetSpellProto();
-    }
-    */
-
-    // Need remove expired auras after
-    bool existExpired = false;
-
-    // absorb without mana cost
-    AuraList const& vSchoolAbsorb = GetAurasByType(SPELL_AURA_SCHOOL_ABSORB);
-    for (AuraList::const_iterator i = vSchoolAbsorb.begin(); i != vSchoolAbsorb.end() && RemainingDamage > 0; ++i)
-    {
-        Modifier* mod = (*i)->GetModifier();
-        if (!(mod->m_miscvalue & schoolMask))
-            continue;
-
-        SpellEntry const* spellProto = (*i)->GetSpellProto();
-
-        // Max Amount can be absorbed by this aura
-        int32  currentAbsorb = mod->m_amount;
-
-        // Found empty aura (impossible but..)
-        if (currentAbsorb <= 0)
-        {
-            existExpired = true;
-            continue;
-        }
-
-        // Handle custom absorb auras
-        // TODO: try find better way
-
-        switch (spellProto->SpellFamilyName)
-        {
-            case SPELLFAMILY_GENERIC:
-            {
-                // Reflective Shield (Lady Malande boss)
-                if (spellProto->Id == 41475 && canReflect)
-                {
-                    if (RemainingDamage < currentAbsorb)
-                        reflectDamage = RemainingDamage / 2;
-                    else
-                        reflectDamage = currentAbsorb / 2;
-                    reflectSpell = 33619;
-                    reflectTriggeredBy = *i;
-                    reflectTriggeredBy->SetInUse(true);     // lock aura from final deletion until processing
-                    break;
-                }
-                if (spellProto->Id == 39228)                // Argussian Compass
-                {
-                    // Max absorb stored in 1 dummy effect
-                    int32 max_absorb = spellProto->CalculateSimpleValue(EFFECT_INDEX_1);
-                    if (max_absorb < currentAbsorb)
-                        currentAbsorb = max_absorb;
-                    break;
-                }
-                break;
-            }
-            case SPELLFAMILY_ROGUE:
-            {
-                // Cheat Death
-                if (spellProto->SpellIconID == 2109)
-                {
-                    if (!preventDeathSpell &&
-                            GetTypeId() == TYPEID_PLAYER && // Only players
-                            !((Player*)this)->HasSpellCooldown(31231) &&
-                            // Only if no cooldown
-                            roll_chance_i((*i)->GetModifier()->m_amount))
-                        // Only if roll
-                    {
-                        preventDeathSpell = (*i)->GetSpellProto();
-                    }
-                    // always skip this spell in charge dropping, absorb amount calculation since it has chance as m_amount and doesn't need to absorb any damage
-                    continue;
-                }
-                break;
-            }
-            case SPELLFAMILY_PRIEST:
-            {
-                // Reflective Shield
-                if (spellProto->IsFitToFamilyMask(uint64(0x0000000000000001)) && canReflect)
-                {
-                    if (pCaster == this)
-                        break;
-                    Unit* caster = (*i)->GetCaster();
-                    if (!caster)
-                        break;
-                    AuraList const& vOverRideCS = caster->GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
-                    for (AuraList::const_iterator k = vOverRideCS.begin(); k != vOverRideCS.end(); ++k)
-                    {
-                        switch ((*k)->GetModifier()->m_miscvalue)
-                        {
-                            case 5065:                      // Rank 1
-                            case 5064:                      // Rank 2
-                            case 5063:                      // Rank 3
-                            case 5062:                      // Rank 4
-                            case 5061:                      // Rank 5
-                            {
-                                if (RemainingDamage >= currentAbsorb)
-                                    reflectDamage = (*k)->GetModifier()->m_amount * currentAbsorb / 100;
-                                else
-                                    reflectDamage = (*k)->GetModifier()->m_amount * RemainingDamage / 100;
-                                reflectSpell = 33619;
-                                reflectTriggeredBy = *i;
-                                reflectTriggeredBy->SetInUse(true);// lock aura from final deletion until processing
-                            } break;
-                            default: break;
-                        }
-                    }
-                    break;
-                }
-                break;
-            }
-            default:
-                break;
-        }
-
-        // currentAbsorb - damage can be absorbed by shield
-        // If need absorb less damage
-        if (RemainingDamage < currentAbsorb)
-            currentAbsorb = RemainingDamage;
-
-        RemainingDamage -= currentAbsorb;
-
-        // Reduce shield amount
-        mod->m_amount -= currentAbsorb;
-        if ((*i)->GetHolder()->DropAuraCharge())
-            mod->m_amount = 0;
-        // Need remove it later
-        if (mod->m_amount <= 0)
-            existExpired = true;
-    }
-
-    // Remove all expired absorb auras
-    if (existExpired)
-    {
-        for (AuraList::const_iterator i = vSchoolAbsorb.begin(); i != vSchoolAbsorb.end();)
-        {
-            if ((*i)->GetModifier()->m_amount <= 0)
-            {
-                RemoveAurasDueToSpell((*i)->GetId(), nullptr, AURA_REMOVE_BY_SHIELD_BREAK);
-                i = vSchoolAbsorb.begin();
-            }
-            else
-                ++i;
-        }
-    }
-
-    // Cast back reflect damage spell
-    if (canReflect && reflectSpell)
-    {
-        CastCustomSpell(pCaster, reflectSpell, &reflectDamage, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, nullptr, reflectTriggeredBy);
-        reflectTriggeredBy->SetInUse(false);                // free lock from deletion
-    }
-
-    // absorb by mana cost
-    AuraList const& vManaShield = GetAurasByType(SPELL_AURA_MANA_SHIELD);
-    for (AuraList::const_iterator i = vManaShield.begin(), next; i != vManaShield.end() && RemainingDamage > 0; i = next)
-    {
-        next = i; ++next;
-
-        // check damage school mask
-        if (((*i)->GetModifier()->m_miscvalue & schoolMask) == 0)
-            continue;
-
-        int32 currentAbsorb;
-        if (RemainingDamage >= (*i)->GetModifier()->m_amount)
-            currentAbsorb = (*i)->GetModifier()->m_amount;
-        else
-            currentAbsorb = RemainingDamage;
-
-        if (float manaMultiplier = (*i)->GetSpellProto()->EffectMultipleValue[(*i)->GetEffIndex()])
-        {
-            if (Player* modOwner = GetSpellModOwner())
-                modOwner->ApplySpellMod((*i)->GetId(), SPELLMOD_MULTIPLE_VALUE, manaMultiplier);
-
-            int32 maxAbsorb = int32(GetPower(POWER_MANA) / manaMultiplier);
-            if (currentAbsorb > maxAbsorb)
-                currentAbsorb = maxAbsorb;
-
-            int32 manaReduction = int32(currentAbsorb * manaMultiplier);
-            ApplyPowerMod(POWER_MANA, manaReduction, false);
-        }
-
-        (*i)->GetModifier()->m_amount -= currentAbsorb;
-        if ((*i)->GetModifier()->m_amount <= 0)
-        {
-            RemoveAurasDueToSpell((*i)->GetId());
-            next = vManaShield.begin();
-        }
-
-        RemainingDamage -= currentAbsorb;
-    }
-
-    // only split damage if not damaging yourself
-    if (pCaster != this)
-    {
-        AuraList const& vSplitDamageFlat = GetAurasByType(SPELL_AURA_SPLIT_DAMAGE_FLAT);
-        for (AuraList::const_iterator i = vSplitDamageFlat.begin(), next; i != vSplitDamageFlat.end() && RemainingDamage >= 0; i = next)
-        {
-            next = i; ++next;
-
-            // check damage school mask
-            if (((*i)->GetModifier()->m_miscvalue & schoolMask) == 0)
-                continue;
-
-            // Damage can be splitted only if aura has an alive caster
-            Unit* caster = (*i)->GetCaster();
-            if (!caster || caster == this || !caster->IsInWorld() || !caster->isAlive())
-                continue;
-
-            int32 currentAbsorb;
-            if (RemainingDamage >= (*i)->GetModifier()->m_amount)
-                currentAbsorb = (*i)->GetModifier()->m_amount;
-            else
-                currentAbsorb = RemainingDamage;
-
-            RemainingDamage -= currentAbsorb;
-
-            if (caster->IsImmuneToDamage(schoolMask))
-            {
-                SendSpellMiss(caster, (*i)->GetSpellProto()->Id, SPELL_MISS_IMMUNE);
-                return;
-            }
-
-            uint32 splitted = currentAbsorb;
-            uint32 splitted_absorb = 0;
-            pCaster->DealDamageMods(caster, splitted, &splitted_absorb, DIRECT_DAMAGE, (*i)->GetSpellProto());
-
-            pCaster->SendSpellNonMeleeDamageLog(caster, (*i)->GetSpellProto()->Id, splitted, schoolMask, splitted_absorb, 0, false, 0, false);
-
-            CleanDamage cleanDamage = CleanDamage(splitted, BASE_ATTACK, MELEE_HIT_NORMAL);
-            pCaster->DealDamage(caster, splitted, &cleanDamage, DIRECT_DAMAGE, schoolMask, (*i)->GetSpellProto(), false);
-        }
-
-        AuraList const& vSplitDamagePct = GetAurasByType(SPELL_AURA_SPLIT_DAMAGE_PCT);
-        for (AuraList::const_iterator i = vSplitDamagePct.begin(), next; i != vSplitDamagePct.end() && RemainingDamage >= 0; i = next)
-        {
-            next = i; ++next;
-
-            // check damage school mask
-            if (((*i)->GetModifier()->m_miscvalue & schoolMask) == 0)
-                continue;
-
-            // Damage can be splitted only if aura has an alive caster
-            Unit* caster = (*i)->GetCaster();
-            if (!caster || caster == this || !caster->IsInWorld() || !caster->isAlive())
-                continue;
-
-            uint32 splitted = uint32(RemainingDamage * (*i)->GetModifier()->m_amount / 100.0f);
-
-            RemainingDamage -=  int32(splitted);
-
-            if (caster->IsImmuneToDamage(schoolMask))
-            {
-                SendSpellMiss(caster, (*i)->GetSpellProto()->Id, SPELL_MISS_IMMUNE);
-                return;
-            }
-
-            uint32 split_absorb = 0;
-            pCaster->DealDamageMods(caster, splitted, &split_absorb, DIRECT_DAMAGE, (*i)->GetSpellProto());
-
-            pCaster->SendSpellNonMeleeDamageLog(caster, (*i)->GetSpellProto()->Id, splitted, schoolMask, split_absorb, 0, false, 0, false);
-
-            CleanDamage cleanDamage = CleanDamage(splitted, BASE_ATTACK, MELEE_HIT_NORMAL);
-            pCaster->DealDamage(caster, splitted, &cleanDamage, DIRECT_DAMAGE, schoolMask, (*i)->GetSpellProto(), false);
-        }
-    }
-
-    // Apply death prevention spells effects
-    if (preventDeathSpell && RemainingDamage >= (int32)GetHealth())
-    {
-        switch (preventDeathSpell->SpellFamilyName)
-        {
-            // Cheat Death
-            case SPELLFAMILY_ROGUE:
-            {
-                // Cheat Death
-                if (preventDeathSpell->SpellIconID == 2109)
-                {
-                    CastSpell(this, 31231, TRIGGERED_OLD_TRIGGERED);
-                    ((Player*)this)->AddSpellCooldown(31231, 0, time(nullptr) + 60);
-                    // with health > 10% lost health until health==10%, in other case no losses
-                    uint32 health10 = GetMaxHealth() / 10;
-                    RemainingDamage = GetHealth() > health10 ? GetHealth() - health10 : 0;
-                }
-                break;
-            }
-        }
-    }
-
-    *absorb = damage - RemainingDamage - *resist;
-}
-
-void Unit::CalculateAbsorbResistBlock(Unit* pCaster, SpellNonMeleeDamage* damageInfo, SpellEntry const* spellProto, WeaponAttackType attType)
-{
-    if (CanBlockAbility(pCaster, spellProto) && roll_chance_f(CalculateEffectiveBlockChance(pCaster, attType, spellProto)))
-    {
-        damageInfo->blocked = GetShieldBlockValue();
-        if (damageInfo->damage < damageInfo->blocked)
-            damageInfo->blocked = damageInfo->damage;
-        damageInfo->damage -= damageInfo->blocked;
-    }
-
-    CalculateDamageAbsorbAndResist(pCaster, GetSpellSchoolMask(spellProto), SPELL_DIRECT_DAMAGE, damageInfo->damage, &damageInfo->absorb, &damageInfo->resist, IsReflectableSpell(spellProto), spellProto->HasAttribute(SPELL_ATTR_EX4_IGNORE_RESISTANCES), IsBinarySpell(spellProto));
-    damageInfo->damage -= damageInfo->absorb + damageInfo->resist;
-}
-
-void Unit::AttackerStateUpdate(Unit* pVictim, WeaponAttackType attType, bool extra)
-{
-    if (hasUnitState(UNIT_STAT_CAN_NOT_REACT) || HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED))
-        return;
-
-    if (!pVictim->isAlive())
-        return;
-
-    if (IsNonMeleeSpellCasted(false))
-        return;
-
-    if (attType == RANGED_ATTACK)
-        return;                                             // ignore ranged case
-
-    uint32 extraAttacks = m_extraAttacks;
-
-    // melee attack spell casted at main hand attack only
-    if (attType == BASE_ATTACK && m_currentSpells[CURRENT_MELEE_SPELL])
-    {
-        m_currentSpells[CURRENT_MELEE_SPELL]->cast();
-        return;
-    }
-
-    RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_MELEE_ATTACK);
-
-    // attack can be redirected to another target
-    if (Unit* magnetTarget = SelectMagnetTarget(pVictim))
-         pVictim = magnetTarget;
-
-    CalcDamageInfo damageInfo;
-    CalculateMeleeDamage(pVictim, &damageInfo, attType);
-    // Send log damage message to client
-    DealDamageMods(pVictim, damageInfo.damage, &damageInfo.absorb, DIRECT_DAMAGE);
-    SendAttackStateUpdate(&damageInfo);
-    ProcDamageAndSpell(damageInfo.target, damageInfo.procAttacker, damageInfo.procVictim, damageInfo.procEx, damageInfo.damage, damageInfo.attackType);
-    DealMeleeDamage(&damageInfo, true);
-
-    if (GetTypeId() == TYPEID_PLAYER)
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "AttackerStateUpdate: (Player) %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",
-                         GetGUIDLow(), pVictim->GetGUIDLow(), pVictim->GetTypeId(), damageInfo.damage, damageInfo.absorb, damageInfo.blocked_amount, damageInfo.resist);
-    else
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "AttackerStateUpdate: (NPC)    %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",
-                         GetGUIDLow(), pVictim->GetGUIDLow(), pVictim->GetTypeId(), damageInfo.damage, damageInfo.absorb, damageInfo.blocked_amount, damageInfo.resist);
-
-    if (Unit* owner = GetOwner())
-        if (owner->GetTypeId() == TYPEID_UNIT)
-        {
-            owner->SetInCombatWith(pVictim);
-            owner->AddThreat(pVictim);
-            pVictim->SetInCombatWith(owner);
-        }
-
-    for (GuidSet::const_iterator itr = m_guardianPets.begin(); itr != m_guardianPets.end(); ++itr)
-        if (Unit* pet = (Unit*)GetMap()->GetPet(*itr))
-        {
-            pet->SetInCombatWith(pVictim);
-            pet->AddThreat(pVictim);
-            pVictim->SetInCombatWith(pet);
-        }
-
-    // if damage pVictim call AI reaction
-    pVictim->AttackedBy(this);
-}
-
-void Unit::DoExtraAttacks(Unit* pVictim)
-{
-    while (m_extraAttacks)
-    {
-        AttackerStateUpdate(pVictim, BASE_ATTACK, true);
-        if (m_extraAttacks > 0)
-            --m_extraAttacks;
-    }
-}
-
-MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackType attType, SpellSchoolMask schoolMask) const
-{
-    if (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode())
-        return MELEE_HIT_EVADE;
-
-    Die<UnitCombatDieSide, UNIT_COMBAT_DIE_HIT, NUM_UNIT_COMBAT_DIE_SIDES> die;
-    die.chance[UNIT_COMBAT_DIE_MISS] = uint32(CalculateEffectiveMissChance(pVictim, attType) * 100);
-    if (pVictim->GetTypeId() == TYPEID_PLAYER && !pVictim->IsStandState() && CanCrit(attType))
-    {
-        die.chance[UNIT_COMBAT_DIE_CRIT] = 10000;
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: New attack die: [MISS:%u, CRIT:%u] (target is sitting)",
-                         die.chance[UNIT_COMBAT_DIE_MISS], die.chance[UNIT_COMBAT_DIE_CRIT]);
-    }
-    else
-    {
-        if (pVictim->CanReactInCombat())
-        {
-            if (pVictim->CanDodgeInCombat(this))
-                die.chance[UNIT_COMBAT_DIE_DODGE] = uint32(pVictim->CalculateEffectiveDodgeChance(this, attType) * 100);
-            if (pVictim->CanParryInCombat(this))
-                die.chance[UNIT_COMBAT_DIE_PARRY] = uint32(pVictim->CalculateEffectiveParryChance(this, attType) * 100);
-            if (pVictim->CanBlockInCombat(this, schoolMask))
-                die.chance[UNIT_COMBAT_DIE_BLOCK] = uint32(pVictim->CalculateEffectiveBlockChance(this, attType) * 100);
-        }
-        if (CanGlanceInCombat(pVictim))
-            die.chance[UNIT_COMBAT_DIE_GLANCE] = uint32(CalculateEffectiveGlanceChance(pVictim, attType) * 100);
-        die.chance[UNIT_COMBAT_DIE_CRIT] = uint32(CalculateEffectiveCritChance(pVictim, attType) * 100);
-        if (CanCrushInCombat(pVictim))
-            die.chance[UNIT_COMBAT_DIE_CRUSH] = uint32(CalculateEffectiveCrushChance(pVictim, attType) * 100);
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: New attack die: [MISS:%u, DODGE:%u, PARRY:%u, BLOCK:%u, GLANCE:%u, CRIT:%u, CRUSH:%u]",
-                         die.chance[UNIT_COMBAT_DIE_MISS], die.chance[UNIT_COMBAT_DIE_DODGE], die.chance[UNIT_COMBAT_DIE_PARRY], die.chance[UNIT_COMBAT_DIE_BLOCK],
-                         die.chance[UNIT_COMBAT_DIE_GLANCE], die.chance[UNIT_COMBAT_DIE_CRIT], die.chance[UNIT_COMBAT_DIE_CRUSH]);
-    }
-
-    const uint32 random = urand(1, 10000);
-    const UnitCombatDieSide side = die.roll(random);
-    if (side != UNIT_COMBAT_DIE_HIT)
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: Rolled %u, result: %s (chance %u)", random, UnitCombatDieSideText(side), die.chance[side]);
-    switch (uint32(side))
-    {
-        case UNIT_COMBAT_DIE_MISS:   return MELEE_HIT_MISS;
-        case UNIT_COMBAT_DIE_DODGE:  return MELEE_HIT_DODGE;
-        case UNIT_COMBAT_DIE_PARRY:  return MELEE_HIT_PARRY;
-        case UNIT_COMBAT_DIE_BLOCK:  return MELEE_HIT_BLOCK;
-        case UNIT_COMBAT_DIE_GLANCE: return MELEE_HIT_GLANCING;
-        case UNIT_COMBAT_DIE_CRIT:   return MELEE_HIT_CRIT;
-        case UNIT_COMBAT_DIE_CRUSH:  return MELEE_HIT_CRUSHING;
-    }
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: Rolled %u, result: HIT", random);
-    return MELEE_HIT_NORMAL;
-}
-
-uint32 Unit::CalculateDamage(WeaponAttackType attType, bool normalized)
-{
-    float min_damage, max_damage;
-
-    if (normalized && GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->CalculateMinMaxDamage(attType, normalized, min_damage, max_damage);
-    else
-    {
-        switch (attType)
-        {
-            case RANGED_ATTACK:
-                min_damage = GetFloatValue(UNIT_FIELD_MINRANGEDDAMAGE);
-                max_damage = GetFloatValue(UNIT_FIELD_MAXRANGEDDAMAGE);
-                break;
-            case BASE_ATTACK:
-                min_damage = GetFloatValue(UNIT_FIELD_MINDAMAGE);
-                max_damage = GetFloatValue(UNIT_FIELD_MAXDAMAGE);
-                break;
-            case OFF_ATTACK:
-                min_damage = GetFloatValue(UNIT_FIELD_MINOFFHANDDAMAGE);
-                max_damage = GetFloatValue(UNIT_FIELD_MAXOFFHANDDAMAGE);
-                break;
-            // Just for good manner
-            default:
-                min_damage = 0.0f;
-                max_damage = 0.0f;
-                break;
-        }
-    }
-
-    if (min_damage > max_damage)
-    {
-        std::swap(min_damage, max_damage);
-    }
-
-    if (max_damage == 0.0f)
-        max_damage = 5.0f;
-
-    return urand((uint32)min_damage, (uint32)max_damage);
-}
-
-float Unit::CalculateLevelPenalty(SpellEntry const* spellProto) const
-{
-    uint32 spellLevel = spellProto->spellLevel;
-    if (spellLevel <= 0)
-        return 1.0f;
-
-    float LvlPenalty = 0.0f;
-
-    if (spellLevel < 20)
-        LvlPenalty = (20.0f - spellLevel) * 3.75f;
-    float LvlFactor = (float(spellLevel) + 6.0f) / float(getLevel());
-    if (LvlFactor > 1.0f)
-        LvlFactor = 1.0f;
-
-    return (100.0f - LvlPenalty) * LvlFactor / 100.0f;
-}
-
-void Unit::SendMeleeAttackStart(Unit* pVictim) const
-{
-    WorldPacket data(SMSG_ATTACKSTART, 8 + 8);
-    data << GetObjectGuid();
-    data << pVictim->GetObjectGuid();
-
-    SendMessageToSet(data, true);
-    DEBUG_LOG("WORLD: Sent SMSG_ATTACKSTART");
-}
-
-void Unit::SendMeleeAttackStop(Unit* victim) const
-{
-    if (!victim)
-        return;
-
-    WorldPacket data(SMSG_ATTACKSTOP, (4 + 16));            // we guess size
-    data << GetPackGUID();
-    data << victim->GetPackGUID();                          // can be 0x00...
-    data << uint32(0);                                      // can be 0x1
-    SendMessageToSet(data, true);
-    DETAIL_FILTER_LOG(LOG_FILTER_COMBAT, "%s %u stopped attacking %s %u", (GetTypeId() == TYPEID_PLAYER ? "player" : "creature"), GetGUIDLow(), (victim->GetTypeId() == TYPEID_PLAYER ? "player" : "creature"), victim->GetGUIDLow());
-
-    /*if(victim->GetTypeId() == TYPEID_UNIT)
-    ((Creature*)victim)->AI().EnterEvadeMode(this);*/
-}
-
-// Melee based spells hit result calculations
-SpellMissInfo Unit::MeleeSpellHitResult(Unit* pVictim, SpellEntry const* spell)
-{
-    Die<UnitCombatDieSide, UNIT_COMBAT_DIE_HIT, NUM_UNIT_COMBAT_DIE_SIDES> die;
-    die.chance[UNIT_COMBAT_DIE_MISS] = uint32(CalculateSpellMissChance(pVictim, SPELL_SCHOOL_MASK_NORMAL, spell) * 100);
-    die.chance[UNIT_COMBAT_DIE_RESIST] = uint32(CalculateSpellResistChance(pVictim, SPELL_SCHOOL_MASK_NORMAL, spell) * 100);
-    if (pVictim->CanReactOnAbility(spell))
-    {
-        const WeaponAttackType attackType = GetWeaponAttackType(spell);
-        if (pVictim->CanDodgeAbility(this, spell))
-           die.chance[UNIT_COMBAT_DIE_DODGE] = uint32(pVictim->CalculateEffectiveDodgeChance(this, attackType, spell) * 100);
-        if (pVictim->CanParryAbility(this, spell))
-           die.chance[UNIT_COMBAT_DIE_PARRY] = uint32(pVictim->CalculateEffectiveParryChance(this, attackType, spell) * 100);
-        if (pVictim->CanDeflectAbility(this, spell))
-           die.chance[UNIT_COMBAT_DIE_DEFLECT] = uint32(pVictim->CalculateAbilityDeflectChance(this, spell) * 100);
-        if (pVictim->CanBlockAbility(this, spell, true))
-           die.chance[UNIT_COMBAT_DIE_BLOCK] = uint32(pVictim->CalculateEffectiveBlockChance(this, attackType, spell) * 100);
-    }
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MeleeSpellHitResult: New ability hit die: %u [MISS:%u, RESIST:%u, DODGE:%u, PARRY:%u, DEFLECT:%u, BLOCK:%u]", spell->Id,
-                     die.chance[UNIT_COMBAT_DIE_MISS], die.chance[UNIT_COMBAT_DIE_RESIST], die.chance[UNIT_COMBAT_DIE_DODGE],
-                     die.chance[UNIT_COMBAT_DIE_PARRY], die.chance[UNIT_COMBAT_DIE_DEFLECT], die.chance[UNIT_COMBAT_DIE_BLOCK]);
-    const uint32 random = urand(1, 10000);
-    const UnitCombatDieSide side = die.roll(random);
-    if (side != UNIT_COMBAT_DIE_HIT)
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MeleeSpellHitResult: Rolled %u, result: %s (chance %u)", random, UnitCombatDieSideText(side), die.chance[side]);
-    switch (uint32(side))
-    {
-        case UNIT_COMBAT_DIE_MISS:      return SPELL_MISS_MISS;
-        case UNIT_COMBAT_DIE_RESIST:    return SPELL_MISS_RESIST;
-        case UNIT_COMBAT_DIE_DODGE:     return SPELL_MISS_DODGE;
-        case UNIT_COMBAT_DIE_PARRY:     return SPELL_MISS_PARRY;
-        case UNIT_COMBAT_DIE_DEFLECT:   return SPELL_MISS_DEFLECT;
-        case UNIT_COMBAT_DIE_BLOCK:     return SPELL_MISS_BLOCK;
-    }
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MeleeSpellHitResult: Rolled %u, result: HIT", random);
-    return SPELL_MISS_NONE;
-}
-
-SpellMissInfo Unit::MagicSpellHitResult(Unit* pVictim, SpellEntry const* spell)
-{
-    // Can`t miss on dead target (on skinning for example)
-    if (!pVictim->isAlive())
-        return SPELL_MISS_NONE;
-
-    const SpellSchoolMask schoolMask = GetSpellSchoolMask(spell);
-
-    Die<UnitCombatDieSide, UNIT_COMBAT_DIE_HIT, NUM_UNIT_COMBAT_DIE_SIDES> die;
-    die.chance[UNIT_COMBAT_DIE_MISS] = uint32(CalculateSpellMissChance(pVictim, schoolMask, spell) * 100);
-    die.chance[UNIT_COMBAT_DIE_RESIST] = uint32(CalculateSpellResistChance(pVictim, schoolMask, spell) * 100);
-    /* Deflect for spells is currently unused up until WotLK, commented out for performance
-    if (pVictim->CanDeflectAbility(this, spell))
-       die.chance[UNIT_COMBAT_DIE_DEFLECT] = uint32(pVictim->CalculateAbilityDeflectChance(this, spell) * 100);
-    */
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MagicSpellHitResult: New spell hit die: %u [MISS:%u, RESIST:%u, DEFLECT:%u]", spell->Id,
-                     die.chance[UNIT_COMBAT_DIE_MISS], die.chance[UNIT_COMBAT_DIE_RESIST], die.chance[UNIT_COMBAT_DIE_DEFLECT]);
-    const uint32 random = urand(1, 10000);
-    const UnitCombatDieSide side = die.roll(random);
-    if (side != UNIT_COMBAT_DIE_HIT)
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MagicSpellHitResult: Rolled %u, result: %s (chance %u)", random, UnitCombatDieSideText(side), die.chance[side]);
-    switch (uint32(side))
-    {
-        case UNIT_COMBAT_DIE_MISS:      // Shows up as "Resist" up until WotLK
-        case UNIT_COMBAT_DIE_RESIST:    return SPELL_MISS_RESIST;
-        case UNIT_COMBAT_DIE_DEFLECT:   return SPELL_MISS_DEFLECT;
-    }
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MagicSpellHitResult: Rolled %u, result: HIT", random);
-    return SPELL_MISS_NONE;
-}
-
-// Calculate spell hit result can be:
-// Every spell can: Evade/Immune/Reflect/Sucesful hit
-// For melee based spells:
-//   Miss
-//   Dodge
-//   Parry
-// For spells
-//   Resist
-SpellMissInfo Unit::SpellHitResult(Unit* pVictim, SpellEntry const* spell, bool CanReflect)
-{
-    // Return evade for units in evade mode
-    if (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode())
-        return SPELL_MISS_EVADE;
-
-    // All positive spells can`t miss
-    // TODO: client not show miss log for this spells - so need find info for this in dbc and use it!
-    if (IsPositiveSpell(spell->Id, this, pVictim))
-        return SPELL_MISS_NONE;
-
-    // Try victim reflect spell
-    if (CanReflect)
-    {
-        int32 reflectchance = pVictim->GetTotalAuraModifier(SPELL_AURA_REFLECT_SPELLS);
-        Unit::AuraList const& mReflectSpellsSchool = pVictim->GetAurasByType(SPELL_AURA_REFLECT_SPELLS_SCHOOL);
-        for (Unit::AuraList::const_iterator i = mReflectSpellsSchool.begin(); i != mReflectSpellsSchool.end(); ++i)
-            if ((*i)->GetModifier()->m_miscvalue & GetSpellSchoolMask(spell))
-                reflectchance += (*i)->GetModifier()->m_amount;
-        if (reflectchance > 0 && roll_chance_i(reflectchance))
-        {
-            // Start triggers for remove charges if need (trigger only for victim, and mark as active spell)
-            ProcDamageAndSpell(pVictim, PROC_FLAG_NONE, PROC_FLAG_TAKEN_SPELL_MAGIC_DMG_CLASS_NEG, PROC_EX_REFLECT, 1, BASE_ATTACK, spell);
-            return SPELL_MISS_REFLECT;
-        }
-    }
-
-    if (!spell->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY))
-    {
-        // Check for immune
-        if (pVictim->IsImmuneToSpell(spell, this == pVictim))
-            return SPELL_MISS_IMMUNE;
-
-        // Check for immune (use charges)
-        if (pVictim->IsImmuneToDamage(GetSpellSchoolMask(spell)))
-            return SPELL_MISS_IMMUNE;
-    }
-
-    switch (spell->DmgClass)
-    {
-        case SPELL_DAMAGE_CLASS_NONE:
-            return SPELL_MISS_NONE;
-        case SPELL_DAMAGE_CLASS_MAGIC:
-            return MagicSpellHitResult(pVictim, spell);
-        case SPELL_DAMAGE_CLASS_MELEE:
-        case SPELL_DAMAGE_CLASS_RANGED:
-            return MeleeSpellHitResult(pVictim, spell);
-    }
-    return SPELL_MISS_NONE;
-}
-
-uint32 Unit::GetDefenseSkillValue(Unit const* target) const
-{
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        // in PvP always use full skill (and bonuses on top of it if present)
-        uint32 value = (target && target->GetTypeId() == TYPEID_PLAYER)
-                       ? std::max(((Player*)this)->GetMaxSkillValue(SKILL_DEFENSE), ((Player*)this)->GetSkillValue(SKILL_DEFENSE))
-                       : ((Player*)this)->GetSkillValue(SKILL_DEFENSE);
-        value += uint32(((Player*)this)->GetRatingBonusValue(CR_DEFENSE_SKILL));
-        return value;
-    }
-    else
-        return GetUnitMeleeSkill(target);
-}
-
-void Unit::SetCanDodge(const bool flag)
-{
-    if (m_canDodge == flag)
-        return;
-
-    m_canDodge = flag;
-    if (GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->UpdateDodgePercentage();
-}
-
-void Unit::SetCanParry(const bool flag)
-{
-    if (m_canParry == flag)
-        return;
-
-    m_canParry = flag;
-    if (GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->UpdateParryPercentage();
-}
-
-void Unit::SetCanBlock(const bool flag)
-{
-    if (m_canBlock == flag)
-        return;
-
-    m_canBlock = flag;
-    if (GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->UpdateBlockPercentage();
-}
-
-bool Unit::CanDodgeInCombat() const
-{
-    if (!CanDodge() || !CanReactInCombat())
-        return false;
-    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): unit is incapable
-    if (GetDodgeChance() < 0.01f)
-        return false;
-     return true;
-}
-
-bool Unit::CanDodgeInCombat(const Unit *attacker) const
-{
-    if (!attacker || !CanDodgeInCombat())
-        return false;
-    // Players can't dodge attacks from behind
-    if (GetTypeId() == TYPEID_PLAYER)
-        return attacker->IsFacingTargetsFront(this);
-    return true;
-}
-
-bool Unit::CanParryInCombat() const
-{
-    if (!CanParry() || !CanReactInCombat() || HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_DISARMED) || IsNonMeleeSpellCasted(false))
-        return false;
-    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): unit is incapable
-    if (GetParryChance() < 0.01f)
-        return false;
-    // Players need a melee weapon they can use to parry an attack
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        const Player* player = (const Player*)this;
-        return (player->GetWeaponForAttack(BASE_ATTACK, true, true) || player->GetWeaponForAttack(OFF_ATTACK, true, true));
-    }
-    return true;
-}
-
-bool Unit::CanParryInCombat(const Unit *attacker) const
-{
-    return (attacker && CanParryInCombat() && attacker->IsFacingTargetsFront(this));
-}
-
-bool Unit::CanBlockInCombat(SpellSchoolMask weaponSchoolMask) const
-{
-    // Pre-WotLK: cannot block elemental and magic melee auto-attacks
-    if (weaponSchoolMask & SPELL_SCHOOL_MASK_MAGIC)
-        return false;
-    if (!CanBlock() || !CanReactInCombat() || IsNonMeleeSpellCasted(false))
-        return false;
-    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): unit is incapable
-    if (GetBlockChance() < 0.01f)
-        return false;
-    // Players need a shield equipped to block an attack
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        const Player* player = (const Player*)this;
-        if (player->CanUseEquippedWeapon(OFF_ATTACK))
-        {
-            const Item* offhand = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
-            return (offhand && !offhand->IsBroken() && offhand->GetProto()->Block);
-        }
-        return false;
-    }
-    return true;
-}
-
-bool Unit::CanBlockInCombat(const Unit *attacker, SpellSchoolMask weaponSchoolMask) const
-{
-    return (attacker && CanBlockInCombat(weaponSchoolMask) && attacker->IsFacingTargetsFront(this));
-}
-
-bool Unit::CanCrushInCombat() const
-{
-    if (!CanCrush())
-        return false;
-    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_NO_CRUSH)
-        return false;
-    return true;
-}
-
-bool Unit::CanCrushInCombat(const Unit *victim) const
-{
-    return (victim && CanCrushInCombat() && victim->GetCharmerOrOwnerOrOwnGuid().IsPlayer());
-}
-
-bool Unit::CanGlanceInCombat(const Unit *victim) const
-{
-    return (victim && CanGlanceInCombat() && victim->GetCharmerOrOwnerOrOwnGuid().IsCreature() && victim->GetLevelForTarget(this) > 10);
-}
-
-bool Unit::CanDazeInCombat(const Unit *victim) const
-{
-    return (victim && CanDazeInCombat() && (victim->GetTypeId() == TYPEID_PLAYER) && IsFacingTargetsBack(victim));
-}
-
-bool Unit::CanReactOnAbility(const SpellEntry *ability) const
-{
-    return (ability && !ability->HasAttribute(SPELL_ATTR_IMPOSSIBLE_DODGE_PARRY_BLOCK));
-}
-
-bool Unit::CanDodgeAbility(const Unit *attacker, const SpellEntry *ability) const
-{
-    // Can't dodge unavoidable and ranged attacks
-    if (!CanReactOnAbility(ability) || ability->DmgClass != SPELL_DAMAGE_CLASS_MELEE)
-        return false;
-    // Check if attacker can be dodged at the moment
-    if (!CanDodgeInCombat(attacker))
-        return false;
-    // Check if attacker cuts through dodge with this ability
-    const AuraList &ignore = attacker->GetAurasByType(SPELL_AURA_IGNORE_COMBAT_RESULT);
-    for (AuraList::const_iterator i = ignore.begin(); i != ignore.end(); ++i)
-    {
-        if ((*i)->isAffectedOnSpell(ability) && (*i)->GetModifier()->m_miscvalue == MELEE_HIT_DODGE)
-            return false;
-    }
-    return true;
-}
-
-bool Unit::CanParryAbility(const Unit *attacker, const SpellEntry *ability) const
-{
-    // Can't parry unavoidable attacks
-    if (!CanReactOnAbility(ability))
-        return false;
-    // Only physical melee attacks can be parried, deflect for magical and ranged
-    if (ability->DmgClass != SPELL_DAMAGE_CLASS_MELEE || (GetSpellSchoolMask(ability) & SPELL_SCHOOL_MASK_MAGIC))
-        return false;
-    // Only close range melee attacks can be parried, longer range abilities use deflect
-    if (ability->rangeIndex != SPELL_RANGE_IDX_COMBAT && ability->rangeIndex != SPELL_RANGE_IDX_SELF_ONLY)
-        return false;
-    // Check if attacker can be parried at the moment
-    if (!CanParryInCombat(attacker))
-        return false;
-    // Check if attacker cuts through parry with this ability
-    const AuraList &ignore = attacker->GetAurasByType(SPELL_AURA_IGNORE_COMBAT_RESULT);
-    for (AuraList::const_iterator i = ignore.begin(); i != ignore.end(); ++i)
-    {
-        if ((*i)->isAffectedOnSpell(ability) && (*i)->GetModifier()->m_miscvalue == MELEE_HIT_PARRY)
-            return false;
-    }
-    return true;
-}
-
-bool Unit::CanBlockAbility(const Unit *attacker, const SpellEntry *ability, bool miss) const
-{
-    // Can't block unavoidable attacks
-    if (!CanReactOnAbility(ability))
-        return false;
-    // Melee and ranged spells only
-    switch (ability->DmgClass)
-    {
-        case SPELL_DAMAGE_CLASS_MELEE:
-        case SPELL_DAMAGE_CLASS_RANGED:
-            break;
-        default:
-            return false;
-    }
-    // There are 2 types of ability blocks: partial and full
-    // Fully blockable spells have a specific attribute, which generates a miss instead of a partial block
-    // Spells with an attribute must be rolled for block once on spell hit die
-    // Spells without an attribute must be rolled for partial block only inside damage calculation
-    // This function can query both scenarios via an argument flag
-    if (miss != ability->HasAttribute(SPELL_ATTR_EX3_BLOCKABLE_SPELL))
-        return false;
-    // Check if attacker can be blocked at the moment
-    if (!CanBlockInCombat(attacker))
-        return false;
-    // Check if attacker cuts through block with this ability
-    const AuraList &ignore = attacker->GetAurasByType(SPELL_AURA_IGNORE_COMBAT_RESULT);
-    for (AuraList::const_iterator i = ignore.begin(); i != ignore.end(); ++i)
-    {
-        if ((*i)->isAffectedOnSpell(ability) && (*i)->GetModifier()->m_miscvalue == MELEE_HIT_BLOCK)
-            return false;
-    }
-    return true;
-}
-
-bool Unit::CanDeflectAbility(const Unit *attacker, const SpellEntry *ability) const
-{
-    // Can't deflect unavoidable attacks
-    if (!CanReactOnAbility(ability))
-        return false;
-    // Only magical melee attacks, ranged attacks and spells can be deflected, parry for the rest
-    switch (ability->DmgClass)
-    {
-        case SPELL_DAMAGE_CLASS_RANGED:
-        case SPELL_DAMAGE_CLASS_MAGIC:
-            break;
-        case SPELL_DAMAGE_CLASS_MELEE:
-            if (!(GetSpellSchoolMask(ability) & SPELL_SCHOOL_MASK_MAGIC))
-                return false;
-            if (ability->rangeIndex == SPELL_RANGE_IDX_COMBAT || ability->rangeIndex == SPELL_RANGE_IDX_SELF_ONLY)
-                return false;
-            break;
-        default:
-            return false;
-    }
-    // Check if attacker can be parried/deflected at the moment
-    if (!CanParryInCombat(attacker))
-        return false;
-    // Check if attacker cuts through parry/deflect with this ability
-    const AuraList &ignore = attacker->GetAurasByType(SPELL_AURA_IGNORE_COMBAT_RESULT);
-    for (AuraList::const_iterator i = ignore.begin(); i != ignore.end(); ++i)
-    {
-        if ((*i)->isAffectedOnSpell(ability) && (*i)->GetModifier()->m_miscvalue == MELEE_HIT_PARRY)
-            return false;
-    }
-    return true;
-}
-
-float Unit::CalculateEffectiveDodgeChance(const Unit *attacker, WeaponAttackType attType, const SpellEntry *ability) const
-{
-    float chance = 0.0f;
-
-    chance += GetDodgeChance();
-    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit is incapable
-    if (chance < 0.01f)
-        return 0.0f;
-    const bool weapon = (!ability || ability->EquippedItemClass == ITEM_CLASS_WEAPON);
-    // Skill difference can be negative (and reduce our chance to mitigate an attack), which means:
-    // a) Attacker's level is higher
-    // b) Attacker has +skill bonuses
-    const bool isPlayerOrPet = (GetTypeId() == TYPEID_PLAYER || GetOwnerGuid().IsPlayer());
-    const uint32 skill = (weapon ? attacker->GetWeaponSkillValue(attType, this) : attacker->GetMaxSkillValueForLevel(this));
-    int32 difference = int32(GetDefenseSkillValue(attacker) - skill);
-    // Defense/weapon skill factor: for players and NPCs
-    float factor = 0.04f;
-    // NPCs gain additional bonus dodge chance based on positive skill difference
-    if (!isPlayerOrPet && difference > 0)
-        factor = 0.1f;
-    chance += (difference * factor);
-    // Attacker's SPELL_AURA_MOD_COMBAT_RESULT_CHANCE contribution (or reduction)
-    chance += attacker->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_COMBAT_RESULT_CHANCE, VICTIMSTATE_DODGE);
-    // Attacker's expertise reduction
-    chance -= attacker->GetExpertisePercent(attType);
-    return std::max(0.0f, std::min(chance, 100.0f));
-}
-
-float Unit::CalculateEffectiveParryChance(const Unit *attacker, WeaponAttackType attType, const SpellEntry *ability) const
-{
-    float chance = 0.0f;
-
-    if (attType == RANGED_ATTACK)
-        return 0.0f;
-
-    chance += GetParryChance();
-    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit is incapable
-    if (chance < 0.01f)
-        return 0.0f;
-    const bool weapon = (!ability || ability->EquippedItemClass == ITEM_CLASS_WEAPON);
-    // Skill difference can be negative (and reduce our chance to mitigate an attack), which means:
-    // a) Attacker's level is higher
-    // b) Attacker has +skill bonuses
-    const bool isPlayerOrPet = (GetTypeId() == TYPEID_PLAYER || GetOwnerGuid().IsPlayer());
-    const uint32 skill = (weapon ? attacker->GetWeaponSkillValue(attType, this) : attacker->GetMaxSkillValueForLevel(this));
-    int32 difference = int32(GetDefenseSkillValue(attacker) - skill);
-    // Defense/weapon skill factor: for players and NPCs
-    float factor = 0.04f;
-    // NPCs gain additional bonus parry chance based on positive skill difference (same value as bonus miss rate)
-    if (!isPlayerOrPet && difference > 0)
-    {
-        if (difference > 10)
-        {
-            // First 10 points of difference (2 levels): usual decrease
-            chance += (10 * 0.1f);
-            difference -= 10;
-            // Each additional point of difference:
-            factor = 0.4f;
-            chance += (difference * 0.2f); // Pre-WotLK: Additional 1% miss chance for each level above 2 (total @ 3% per level)
-        }
-        else
-            factor = 0.1f;
-    }
-    chance += (difference * factor);
-    // Attacker's SPELL_AURA_MOD_COMBAT_RESULT_CHANCE contribution (or reduction)
-    chance += attacker->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_COMBAT_RESULT_CHANCE, VICTIMSTATE_PARRY);
-    // Attacker's expertise reduction
-    chance -= attacker->GetExpertisePercent(attType);
-    return std::max(0.0f, std::min(chance, 100.0f));
-}
-
-float Unit::CalculateEffectiveBlockChance(const Unit *attacker, WeaponAttackType attType, const SpellEntry *ability) const
-{
-    float chance = 0.0f;
-
-    chance += GetBlockChance();
-    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit is incapable
-    if (chance < 0.01f)
-        return 0.0f;
-    const bool weapon = (!ability || ability->EquippedItemClass == ITEM_CLASS_WEAPON);
-    // Skill difference can be negative (and reduce our chance to mitigate an attack), which means:
-    // a) Attacker's level is higher
-    // b) Attacker has +skill bonuses
-    const bool isPlayerOrPet = (GetTypeId() == TYPEID_PLAYER || GetOwnerGuid().IsPlayer());
-    const uint32 skill = (weapon ? attacker->GetWeaponSkillValue(attType, this) : attacker->GetMaxSkillValueForLevel(this));
-    const int32 difference = int32(GetDefenseSkillValue(attacker) - skill);
-    // Defense/weapon skill factor: for players and NPCs
-    float factor = 0.04f;
-    // NPCs cannot gain bonus block chance based on positive skill difference
-    if (!isPlayerOrPet && difference > 0)
-        factor = 0.0f;
-    chance += (difference * factor);
-    // Attacker's SPELL_AURA_MOD_COMBAT_RESULT_CHANCE contribution (or reduction)
-    chance += attacker->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_COMBAT_RESULT_CHANCE, VICTIMSTATE_BLOCKS);
-    return std::max(0.0f, std::min(chance, 100.0f));
-}
-
-float Unit::CalculateEffectiveCrushChance(const Unit *victim, WeaponAttackType attType) const
-{
-    float chance = 0.0f;
-
-    // Crushing blow chance is present when attacker's weapon skill is >= 15 over victim's own capped defense skill
-    // The chance starts at 15% and increased by 2% per each additional skill point of defense deficit
-    const uint32 cap = victim->GetMaxSkillValueForLevel();
-    const uint32 defense = std::min(victim->GetDefenseSkillValue(this), cap);
-    const int32 deficit = (int32(GetWeaponSkillValue(attType, victim)) - int32(defense));
-    if (deficit >= 15)
-        chance += ((2 * deficit) - 15);
-    return std::max(0.0f, std::min(chance, 100.0f));
-}
-
-float Unit::CalculateEffectiveGlanceChance(const Unit *victim, WeaponAttackType attType) const
-{
-    float chance = 0.0f;
-
-    // Glancing blow chance starts at 1% when victim's defense skill is > 10 lower than attacker's own capped weapon skill
-    // The chance is increased for each point of skill diffrernce
-    const uint32 cap = GetMaxSkillValueForLevel();
-    const uint32 skill = std::min(GetWeaponSkillValue(attType, victim), cap);
-    const int32 level = int32(GetLevelForTarget(victim));
-    const uint32 defense = victim->GetDefenseSkillValue(this);
-    // Penalty for caster classes lower than level 30 in TBC
-    if (GetTypeId() == TYPEID_PLAYER && (getClassMask() & CLASSMASK_WAND_USERS) && level < 30)
-        chance += (level + int32(defense - skill));
-    else
-        chance += (10 + int32(defense - skill));
-    return std::max(0.0f, std::min(chance, 100.0f));
-}
-
-float Unit::CalculateEffectiveDazeChance(const Unit *victim, WeaponAttackType attType) const
-{
-    float chance = 0.0f;
-
-    // Base chance starts at 20% and is modified by difference between victim's defense skill and attacker's weapon skill
-    const uint32 level = victim->GetLevelForTarget(this);
-    // Base chance is reduced for lower levels
-    if (level < 30)
-        chance += (0.65f * level) + 0.5f;
-    else
-        chance += 20.0f;
-    // Same mechanics as miss chance, but premultiplied by 4 (20% base instead of 5% base)
-    chance += (int32(GetWeaponSkillValue(attType, victim)) - int32(victim->GetDefenseSkillValue(this))) * 0.04f * 4;
-    // Chance is capped at 40%
-    return std::max(0.0f, std::min(chance, 40.0f));
-}
-
-float Unit::CalculateAbilityDeflectChance(const Unit *attacker, const SpellEntry *ability) const
-{
-    switch (ability->DmgClass)
-    {
-        case SPELL_DAMAGE_CLASS_MELEE:
-        case SPELL_DAMAGE_CLASS_RANGED: return CalculateEffectiveParryChance(attacker, GetWeaponAttackType(ability), ability);
-        case SPELL_DAMAGE_CLASS_MAGIC:  return CalculateEffectiveParryChance(attacker, RANGED_ATTACK, ability);
-    }
-    return 0.0f;
-}
-
-float Unit::GetDodgeChance() const
-{
-    float chance = 0.0f;
-    if (GetTypeId() == TYPEID_UNIT)
-        chance += 5.0f;
-    chance += m_modDodgeChance;
-    return chance;
-}
-
-float Unit::GetParryChance() const
-{
-    float chance = 0.0f;
-    // FIXME: Verify which creatures are eligible for parry together with DB team and implement in a more clean way
-    if (GetTypeId() == TYPEID_UNIT)
-        chance += 5.0f;
-    chance += m_modParryChance;
-    return chance;
-}
-
-float Unit::GetBlockChance() const
-{
-    float chance = 0.0f;
-    // FIXME: Verify which creatures are eligible for block together with DB team and implement in a more clean way
-    if (GetTypeId() == TYPEID_UNIT)
-        chance += 5.0f;
-    chance += m_modBlockChance;
-    return chance;
-}
-
-bool Unit::CanCrit(const SpellEntry *entry, SpellSchoolMask schoolMask, WeaponAttackType attType) const
-{
-    if (!IsSpellAbleToCrit(entry))
-        return false;
-    // Creatures do not crit with their spells or abilities, unless it is owned by a player (pet, totem, etc)
-    if (GetTypeId() == TYPEID_UNIT && !GetOwnerGuid().IsPlayer())
-        return false;
-    switch (entry->DmgClass)
-    {
-        case SPELL_DAMAGE_CLASS_MELEE:
-        case SPELL_DAMAGE_CLASS_RANGED: return CanCrit(attType);
-        case SPELL_DAMAGE_CLASS_NONE:
-        case SPELL_DAMAGE_CLASS_MAGIC:  return CanCrit(schoolMask);
-    }
-    return false;
-}
-
-float Unit::GetCritChance(WeaponAttackType attType) const
-{
-    float chance = 0.0f;
-    if (GetTypeId() == TYPEID_UNIT)
-        // Base crit chance (needed for units only, already included for players)
-        chance += 5.0f;
-    chance += m_modCritChance[attType];
-    return chance;
-}
-
-float Unit::GetCritChance(SpellSchoolMask schoolMask) const
-{
-    float chance = 0.0f;
-
-    uint32 mask = uint32(schoolMask);
-    if (!mask)
-        return 0.0f;
-
-    if (GetTypeId() == TYPEID_UNIT)
-        // Base crit chance (needed for units only, already included for players)
-        chance += 5.0f;
-    // Pick highest spell crit available for given school mask
-    for (uint8 school = 0; mask; ++school)
-    {
-        if (mask & 1)
-        {
-            const float crit = m_modSpellCritChance[school];
-            if (crit > chance)
-                chance = crit;
-        }
-        mask >>= 1;
-    }
-    return chance;
-}
-
-float Unit::GetCritChance(const SpellEntry *entry, SpellSchoolMask schoolMask) const
-{
-    float chance = 0.0f;
-
-    if (!entry)
-        return 0.0f;
-
-    // Add own hit chance
-    switch (entry->DmgClass)
-    {
-        case SPELL_DAMAGE_CLASS_MAGIC:
-            chance += GetCritChance(schoolMask);
-            break;
-        case SPELL_DAMAGE_CLASS_MELEE:
-        case SPELL_DAMAGE_CLASS_RANGED:
-            chance += GetCritChance(GetWeaponAttackType(entry));
-            break;
-    }
-    // Add mod
-    if (Player* modOwner = GetSpellModOwner())
-        modOwner->ApplySpellMod(entry->Id, SPELLMOD_CRITICAL_CHANCE, chance);
-    return chance;
-}
-
-float Unit::GetCritTakenChance(SpellSchoolMask dmgSchoolMask, SpellDmgClass dmgClass, bool heal) const
-{
-    float chance = 0.0f;
-    // Resilience and resilience-like auras:
-    if (!heal)
-    {
-        // Resilience percent decreases chance to be crit 1:1
-        switch (uint32(dmgClass))
-        {
-            case SPELL_DAMAGE_CLASS_MELEE:
-                chance += GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_CHANCE);
-                chance -= GetCombatRatingReduction(CR_CRIT_TAKEN_MELEE);
-                break;
-            case SPELL_DAMAGE_CLASS_RANGED:
-                chance += GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_RANGED_CRIT_CHANCE);
-                chance -= GetCombatRatingReduction(CR_CRIT_TAKEN_RANGED);
-                break;
-            case SPELL_DAMAGE_CLASS_MAGIC:
-                chance += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_ATTACKER_SPELL_CRIT_CHANCE, dmgSchoolMask);
-                chance -= GetCombatRatingReduction(CR_CRIT_TAKEN_SPELL);
-                break;
-        }
-        chance += GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_SPELL_AND_WEAPON_CRIT_CHANCE);
-    }
-    return chance;
-}
-
-float Unit::GetCritMultiplier(SpellSchoolMask dmgSchoolMask, uint32 creatureTypeMask, const SpellEntry *spell, bool heal) const
-{
-    // Default crit multiplier (attacks): 2x
-    float multiplier = 2.0f;
-    // Default crit multiplier for spells: 1.5x
-    if (spell)
-    {
-        switch (spell->DmgClass)
-        {
-            case SPELL_DAMAGE_CLASS_NONE:
-            case SPELL_DAMAGE_CLASS_MAGIC:
-                multiplier = 1.5f;
-                break;
-        }
-    }
-    // Multiplier bonus coefficient for damage
-    if (!heal)
-    {
-        float bonus = 0;
-        if (dmgSchoolMask)
-            bonus += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_CRIT_DAMAGE_BONUS, dmgSchoolMask); // Gems, talents
-        if (creatureTypeMask)
-            bonus += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_CRIT_PERCENT_VERSUS, creatureTypeMask); // Creature slaying
-        multiplier *= (1.0f + (bonus / 100.0f));
-    }
-    // Apply spell mods
-    if (spell)
-    {
-        if (Player* modOwner = GetSpellModOwner())
-        {
-            // Extract crit bonus part only from multiplier (exclude base of 1) and modify it
-            float bonus = (multiplier - 1.0f);
-            modOwner->ApplySpellMod(spell->Id, SPELLMOD_CRIT_DAMAGE_BONUS, bonus);
-            // Reconstruct final multiplier now with increased bonus part
-            multiplier = (1.0f + bonus);
-        }
-    }
-    return std::max(0.0f, multiplier);
-}
-
-float Unit::GetCritTakenMultiplier(SpellSchoolMask dmgSchoolMask, SpellDmgClass dmgClass, float ignorePct, bool heal) const
-{
-    // Default incoming crit multiplier: 1x (receive full damage)
-    float multiplier = 1.0f;
-    // Resilience and resilience-like auras:
-    if (!heal)
-    {
-        const float pct = 0.01f;
-        // Resilience cap and factor: % of incoming crit dmg reduction per % of resilience
-        const float factor = 2.0f * pct; // TBC
-        const float cap = 25.0f * pct; // TBC
-        const float ratio = (100.0f - ignorePct) * pct;
-        switch (uint32(dmgClass))
-        {
-            case SPELL_DAMAGE_CLASS_MELEE:
-                multiplier += (GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_DAMAGE) * pct);
-                multiplier -= std::min(cap, (GetCombatRatingReduction(CR_CRIT_TAKEN_MELEE) * factor)) * ratio;
-                break;
-            case SPELL_DAMAGE_CLASS_RANGED:
-                multiplier += (GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_RANGED_CRIT_DAMAGE) * pct);
-                multiplier -= std::min(cap, (GetCombatRatingReduction(CR_CRIT_TAKEN_RANGED) * factor)) * ratio;
-                break;
-            case SPELL_DAMAGE_CLASS_MAGIC:
-                multiplier += (GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_ATTACKER_SPELL_CRIT_DAMAGE, dmgSchoolMask) * pct);
-                multiplier -= std::min(cap, (GetCombatRatingReduction(CR_CRIT_TAKEN_SPELL) * factor)) * ratio;
-                break;
-        }
-    }
-    return std::max(0.0f, multiplier);
-}
-
-uint32 Unit::CalculateCritAmount(const Unit *victim, uint32 amount, const SpellEntry *entry, bool heal) const
-{
-    if (!entry)
-        return 0;
-    const SpellSchoolMask schoolMask = GetSpellSchoolMask(entry);
-    const uint32 creatureTypeMask = (victim ? victim->GetCreatureTypeMask() : 0);
-    const float multiplier = GetCritMultiplier(schoolMask, creatureTypeMask, entry, heal);
-    const SpellDmgClass dmgClass = SpellDmgClass(entry->DmgClass);
-    const float ignoreReduction = 0.0f;
-    const float taken = (victim ? victim->GetCritTakenMultiplier(schoolMask, dmgClass, ignoreReduction, heal) : 1.0f);
-    const uint32 outgoing = uint32(amount * multiplier);
-    // Crit amount can't be less than normal hit
-    const uint32 result = std::max(amount, uint32(outgoing * taken));
-    return result;
-}
-
-uint32 Unit::CalculateCritAmount(CalcDamageInfo *meleeInfo) const
-{
-    if (!meleeInfo)
-        return 0;
-    const Unit* victim = meleeInfo->target;
-    const uint32 amount = meleeInfo->damage;
-    const SpellSchoolMask schoolMask = meleeInfo->damageSchoolMask;
-    const uint32 creatureTypeMask = (victim ? victim->GetCreatureTypeMask() : 0);
-    const float multiplier = GetCritMultiplier(schoolMask, creatureTypeMask);
-    const SpellDmgClass dmgClass = ((meleeInfo->attackType == RANGED_ATTACK) ? SPELL_DAMAGE_CLASS_RANGED : SPELL_DAMAGE_CLASS_MELEE);
-    const float ignoreReduction = 0.0f;
-    const float taken = (victim ? victim->GetCritTakenMultiplier(schoolMask, dmgClass, ignoreReduction) : 1.0f);
-    const uint32 outgoing = uint32(amount * multiplier);
-    // Crit amount can't be less than normal hit
-    const uint32 result = std::max(amount, uint32(outgoing * taken));
-    meleeInfo->damage = result;
-    meleeInfo->cleanDamage = std::max(result, outgoing);
-    return result;
-}
-
-float Unit::GetHitChance(WeaponAttackType attackType) const
-{
-    if (attackType == RANGED_ATTACK)
-        return m_modRangedHitChance;
-    return m_modMeleeHitChance;
-}
-
-float Unit::GetHitChance(SpellSchoolMask schoolMask) const
-{
-    float chance = 0.0f;
-
-    if (!uint32(schoolMask))
-        return 0.0f;
-
-    chance += m_modSpellHitChance;
-    // Pick highest spell hit available for given school mask
-    chance += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_INCREASES_SPELL_PCT_TO_HIT, schoolMask);
-    return chance;
-}
-
-float Unit::GetHitChance(const SpellEntry *entry, SpellSchoolMask schoolMask) const
-{
-    float chance = 0.0f;
-
-    if (!entry)
-        return 0.0f;
-
-    // Add own hit chance
-    switch (entry->DmgClass)
-    {
-        case SPELL_DAMAGE_CLASS_MAGIC:
-            chance += GetHitChance(schoolMask);
-            break;
-        case SPELL_DAMAGE_CLASS_MELEE:
-        case SPELL_DAMAGE_CLASS_RANGED:
-            chance += GetHitChance(GetWeaponAttackType(entry));
-            break;
-    }
-    // Add mod
-    if (Player* modOwner = GetSpellModOwner())
-        modOwner->ApplySpellMod(entry->Id, SPELLMOD_RESIST_MISS_CHANCE, chance);
-    return chance;
-}
-
-float Unit::GetMissChance(WeaponAttackType attackType) const
-{
-    // Totems have no inherit miss chance
-    if (GetTypeId() == TYPEID_UNIT && ((const Creature*)this)->IsTotem())
-        return 0.0f;
-    // Default base chance to be missed for all acting units: 5%
-    float chance = 5.0f;
-    // Rating contribution
-    if (GetTypeId() == TYPEID_PLAYER)
-        chance += ((const Player*)this)->GetRatingBonusValue((attackType == RANGED_ATTACK) ? CR_HIT_TAKEN_RANGED : CR_HIT_TAKEN_MELEE);
-    return chance;
-}
-
-float Unit::GetMissChance(SpellSchoolMask /*schoolMask*/) const
-{
-    // Totems have no inherit miss chance
-    if (GetTypeId() == TYPEID_UNIT && ((const Creature*)this)->IsTotem())
-        return 0.0f;
-    // Default base chance to be missed by a spell for all acting units: 4%
-    float chance = 4.0f;
-    // Rating contribution
-    if (GetTypeId() == TYPEID_PLAYER)
-        chance += ((const Player*)this)->GetRatingBonusValue(CR_HIT_TAKEN_SPELL);
-    return chance;
-}
-
-float Unit::GetMissChance(const SpellEntry *entry, SpellSchoolMask schoolMask) const
-{
-    float chance = 0.0f;
-
-    if (!entry)
-        return 0.0f;
-
-    // Add own miss chance
-    switch (entry->DmgClass)
-    {
-        case SPELL_DAMAGE_CLASS_MELEE:
-        case SPELL_DAMAGE_CLASS_RANGED:
-            chance += GetMissChance(GetWeaponAttackType(entry));
-            break;
-        // By default, we use spell miss chance even for spells without dmgclass
-        default:
-            chance += GetMissChance(schoolMask);
-            break;
-    }
-    // AoE avoidance
-    if (IsAreaOfEffectSpell(entry))
-        chance += GetTotalAuraModifier(SPELL_AURA_MOD_AOE_AVOIDANCE);
-    return chance;
-}
-
-float Unit::CalculateEffectiveCritChance(const Unit* victim, WeaponAttackType attType, const SpellEntry *ability) const
-{
-    float chance = 0.0f;
-
-    chance += (ability ? GetCritChance(ability, SPELL_SCHOOL_MASK_NORMAL) : GetCritChance(attType));
-    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit is incapable
-    if (chance < 0.01f)
-        return 0.0f;
-    // Skip victim calculation if positive ability
-    if (ability && IsPositiveSpell(ability, this, victim))
-        return std::max(0.0f, std::min(chance, 100.0f));
-    const bool weapon = (!ability || ability->EquippedItemClass == ITEM_CLASS_WEAPON);
-    // Skill difference can be both negative and positive.
-    // a) Positive means that attacker's level is higher or additional weapon +skill bonuses
-    // b) Negative means that victim's level is higher or additional +defense bonuses
-    const bool ranged = (attType == RANGED_ATTACK);
-    const uint32 skill = (weapon ? GetWeaponSkillValue(attType, victim) : GetMaxSkillValueForLevel(victim));
-    const int32 difference = int32(skill - victim->GetDefenseSkillValue(this));
-    // Weapon skill factor: for players and NPCs
-    float factor = 0.04f;
-    chance += (difference * factor);
-    // Victim's crit taken chance
-    const SpellDmgClass dmgClass = (ranged ? SPELL_DAMAGE_CLASS_RANGED : SPELL_DAMAGE_CLASS_MELEE);
-    chance += victim->GetCritTakenChance(SPELL_SCHOOL_MASK_NORMAL, dmgClass);
-    return std::max(0.0f, std::min(chance, 100.0f));
-}
-
-float Unit::CalculateEffectiveMissChance(const Unit *victim, WeaponAttackType attType, const SpellEntry *ability) const
-{
-    float chance = 0.0f;
-
-    chance += (ability ? victim->GetMissChance(ability, SPELL_SCHOOL_MASK_NORMAL) : victim->GetMissChance(attType));
-    // Victim's own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit can't be missed
-    if (chance < 0.01f)
-        return 0.0f;
-    const bool ranged = (attType == RANGED_ATTACK);
-    const bool weapon = (!ability || ability->EquippedItemClass == ITEM_CLASS_WEAPON);
-    // Check if dual wielding, add additional miss penalty
-    if (!ability && !ranged && haveOffhandWeapon())
-        chance += 19.0f;
-    // Skill difference can be both negative and positive. Positive difference means that:
-    // a) Victim's level is higher
-    // b) Victim has additional defense skill bonuses
-    const bool vsPlayerOrPet = (victim->GetTypeId() == TYPEID_PLAYER || victim->GetOwnerGuid().IsPlayer());
-    const uint32 skill = (weapon ? GetWeaponSkillValue(attType, victim) : GetMaxSkillValueForLevel(victim));
-    int32 difference = int32(victim->GetDefenseSkillValue(this) - skill);
-    // Defense/weapon skill factor: for players and NPCs
-    float factor = 0.04f;
-    // NPCs gain additional bonus to incoming hit chance reduction based on positive skill difference (same value as bonus parry rate)
-    if (!vsPlayerOrPet && difference > 0)
-    {
-        if (difference > 10)
-        {
-            // First 10 points of difference (2 levels): usual decrease
-            chance += (10 * 0.1f);
-            difference -= 10;
-            // Each additional point of difference:
-            factor = 0.4f;
-            chance += (difference * 0.2f); // Pre-WotLK: Additional 1% miss chance for each level (final @ 3% per level)
-        }
-        else
-            factor = 0.1f;
-    }
-    chance += (difference * factor);
-    // Victim's auras affecting attacker's hit contribution:
-    chance -= victim->GetTotalAuraModifier(ranged ? SPELL_AURA_MOD_ATTACKER_RANGED_HIT_CHANCE: SPELL_AURA_MOD_ATTACKER_MELEE_HIT_CHANCE);
-    // Finally, take hit chance
-    chance -= (ability ? GetHitChance(ability, SPELL_SCHOOL_MASK_NORMAL) : GetHitChance(attType));
-    return std::max(0.0f, std::min(chance, 100.0f));
-}
-
-float Unit::CalculateSpellCritChance(const Unit *victim, SpellSchoolMask schoolMask, const SpellEntry *spell) const
-{
-    if (!spell || spell->HasAttribute(SPELL_ATTR_EX2_CANT_CRIT))
-        return 0.0f;
-
-    float chance = 0.0f;
-
-    switch (spell->DmgClass)
-    {
-        case SPELL_DAMAGE_CLASS_MELEE:
-        case SPELL_DAMAGE_CLASS_RANGED:
-            return CalculateEffectiveCritChance(victim, GetWeaponAttackType(spell), spell);
-    }
-    chance += GetCritChance(spell, schoolMask);
-    // Own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit is incapable
-    if (chance < 0.01f)
-        return 0.0f;
-    // Modify by victim in case of hostile hit
-    if (!IsPositiveSpell(spell, this, victim))
-        chance += victim->GetCritTakenChance(schoolMask, SpellDmgClass(spell->DmgClass));
-    // TODO: Scripted crit chance auras: class script auras need to be orgnaized and re-implemented in the future as a part of scripting system
-    const AuraList &scripts = GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
-    for (AuraList::const_iterator i = scripts.begin(); i != scripts.end(); ++i)
-    {
-        if (!((*i)->isAffectedOnSpell(spell)))
-            continue;
-        switch ((*i)->GetModifier()->m_miscvalue)
-        {
-            // Shatter
-            case 849: if (victim->isFrozen()) chance += 10.0f; break;
-            case 910: if (victim->isFrozen()) chance += 20.0f; break;
-            case 911: if (victim->isFrozen()) chance += 30.0f; break;
-            case 912: if (victim->isFrozen()) chance += 40.0f; break;
-            case 913: if (victim->isFrozen()) chance += 50.0f; break;
-            default:
-                break;
-        }
-    }
-    return std::max(0.0f, std::min(chance, 100.0f));
-}
-
-float Unit::CalculateSpellMissChance(const Unit *victim, SpellSchoolMask schoolMask, const SpellEntry *spell) const
-{
-    if (!spell || spell->HasAttribute(SPELL_ATTR_EX3_CANT_MISS))
-        return 0.0f;
-
-    float chance = 0.0f;
-    const float minimum = 1.0f; // Pre-WotLK: unavoidable spell miss is at least 1%
-
-    switch (spell->DmgClass)
-    {
-        case SPELL_DAMAGE_CLASS_MELEE:
-        case SPELL_DAMAGE_CLASS_RANGED:
-            return CalculateEffectiveMissChance(victim, GetWeaponAttackType(spell), spell);
-    }
-    if (spell->HasAttribute(SPELL_ATTR_EX5_USE_PHYSICAL_HIT_CHANCE))
-    {
-        // How it works:
-        // - First introduced in patch 2.3 for Taunt, Growl, Righteous Defense, Challenging Shout and Challenging Roar
-        // - Switches spell to use ability miss chance calculation, but leaves standard unavoidable miss percent
-        // In WotLK+:
-        // - Removed for Taunt, Growl and Righteous Defense, so these spells have 17% miss against bosses
-        // - Added glyphs for Taunt and Growl to negate remaining 8% of spell miss difference
-        // - AoE taunts on cooldowns still use ability miss calculation
-        return std::max(minimum, CalculateEffectiveMissChance(victim, GetWeaponAttackType(spell), spell));
-    }
-    chance += victim->GetMissChance(spell, schoolMask);
-    // Victim's own chance appears to be zero / below zero / unmeaningful for some reason (debuffs?): skip calculation, unit can't be missed
-    if (chance < 0.01f)
-        return 0.0f;
-    // Level difference: positive adds to miss chance, negative substracts
-    const bool vsPlayerOrPet = (victim->GetTypeId() == TYPEID_PLAYER || victim->GetOwnerGuid().IsPlayer());
-    int32 difference = int32(victim->GetLevelForTarget(this) - GetLevelForTarget(victim));
-    // Level difference factor: 1% per level
-    uint8 factor = 1;
-    // NPCs and players gain additional bonus to incoming spell hit chance reduction based on positive level difference
-    if (difference > 2)
-    {
-        chance += (2 * factor);
-        // Miss bonus for each additional level of difference above 2
-        factor = (vsPlayerOrPet ? 7 : 11);
-        chance += ((difference - 2) * factor);
-    }
-    else
-        chance += (difference * factor);
-    // Reduce by caster's spell hit chance
-    chance -= GetHitChance(spell, schoolMask);
-    // Reduce (or increase) by victim SPELL_AURA_MOD_ATTACKER_SPELL_HIT_CHANCE auras
-    chance -= victim->GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_ATTACKER_SPELL_HIT_CHANCE, schoolMask);
-    return std::max(minimum, std::min(chance, 100.0f));
-}
-
-float Unit::GetExpertisePercent(WeaponAttackType attType) const
-{
-    int32 expertise = 0;
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        switch (uint32(attType))
-        {
-            case BASE_ATTACK:
-                expertise += int32(GetUInt32Value(PLAYER_EXPERTISE));
-                break;
-            case OFF_ATTACK:
-                expertise += int32(GetUInt32Value(PLAYER_OFFHAND_EXPERTISE));
-                break;
-        }
-    }
-    else if (attType != RANGED_ATTACK)
-        expertise += GetTotalAuraModifier(SPELL_AURA_MOD_EXPERTISE);
-    return (expertise * 0.25f); // (expertise / 4)
-}
-
-int32 Unit::GetResistancePenetration(SpellSchools school) const
-{
-    // Technically, it is target resistance mod, but it's used as penetration (negative sign) 99.9% of the time
-    // So, let's logically reverse the sign and use it as such
-    return -(GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_TARGET_RESISTANCE, (1 << school)));
-}
-
-float Unit::CalculateEffectiveMagicResistancePercent(const Unit *attacker, SpellSchoolMask schoolMask, bool binary) const
-{
-    // Non-magical or contains Physical as a component (such as Chaos) - ignores resistances completely
-    if (schoolMask & SPELL_SCHOOL_MASK_NORMAL)
-        return 0.0f;
-    // Completely ignore holy resistance value (since beta stages)
-    uint32 schools = uint32(schoolMask & ~uint32(SPELL_SCHOOL_MASK_HOLY));
-    // Select a resistance value matching given school mask, prefer mininal for multischool spells
-    int32 resistance = 0;
-    for (uint32 school = 0; schools; ++school)
-    {
-        if (schools & 1)
-        {
-            // Base victim resistance
-            int32 amount = int32(GetResistance(SpellSchools(school)));
-            // Modify by penetration
-            amount -= attacker->GetResistancePenetration(SpellSchools(school));
-            // If unit has no resistance for this school: use it!
-            if (amount < 1)
-            {
-                resistance = 0; // Resistance can't be negative since early stages of development
-                break;
-            }
-            // Else if first school encountered or more vulnerable: memorize and continue
-            else if (!resistance || amount < resistance)
-                resistance = amount;
-        }
-        schools >>= 1;
-    }
-    // Attacker's level based skill, penalize when calculating for low levels (< 20):
-    const uint32 skill = std::max(attacker->GetMaxSkillValueForLevel(this), uint16(100));
-    float percent = float(float(resistance) / float(skill)) * 100 * 0.75f;
-    // Bonus resistance by level difference when calculating damage hit for NPCs only
-    if (!binary && GetTypeId() == TYPEID_UNIT && GetCharmerOrOwnerOrOwnGuid().IsCreature())
-        percent += (0.4f * std::max(int32(GetMaxSkillValueForLevel(attacker) - skill), 0));
-    // Magic resistance percentage cap
-    const float cap = 75.0f; // Pre-WotLK: 75%
-    return std::max(0.0f, std::min(percent, cap));
-}
-
-float Unit::CalculateSpellResistChance(const Unit *victim, SpellSchoolMask schoolMask, const SpellEntry *spell) const
-{
-    float chance = 0.0f;
-
-    // Chance to fully resist a spell by magic resistance
-    if (spell->DmgClass == SPELL_DAMAGE_CLASS_MAGIC && !spell->HasAttribute(SPELL_ATTR_EX4_IGNORE_RESISTANCES))
-    {
-        const bool binary = IsBinarySpell(spell);
-        const float percent = victim->CalculateEffectiveMagicResistancePercent(this, schoolMask, binary);
-        if (binary)
-            chance += percent;
-        else
-            chance += float(SPELL_PARTIAL_RESIST_DISTRIBUTION.at(uint32(percent * 100)).at(SPELL_PARTIAL_RESIST_PCT_100)) * 0.01f;
-    }
-    // Chance to fully resist entire spell by it's dispel type
-    if (const int32 type = int32(spell->Dispel))
-        chance += victim->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_DEBUFF_RESISTANCE, type);
-    // Chance to fully resist entire spell by it's mechanic
-    if (const int32 mechanic = int32(spell->Mechanic))
-        chance += victim->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_MECHANIC_RESISTANCE, mechanic);
-
-    // TODO: Move it in the future, effect mechanic resist must be processed differently
-    float effects = 0.0f;
-    for (uint32 i = EFFECT_INDEX_0; i < MAX_EFFECT_INDEX; ++i)
-    {
-        if (!spell->Effect[i])
-            continue;
-        if (const int32 mechanic = int32(spell->EffectMechanic[i]))
-        {
-            const float resist = victim->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_MECHANIC_RESISTANCE, mechanic);
-            if (resist > effects)
-                effects = resist;
-        }
-    }
-    chance += effects;
-    //
-    return std::max(0.0f, std::min(chance, 100.0f));
-}
-
-uint32 Unit::GetWeaponSkillValue(WeaponAttackType attType, Unit const* target) const
-{
-    uint32 value;
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        Item* item = ((Player*)this)->GetWeaponForAttack(attType, true, true);
-
-        // feral or unarmed skill only for base attack
-        if (attType != BASE_ATTACK && !item)
-            return 0;
-
-        if (IsInFeralForm())
-            return GetMaxSkillValueForLevel();              // always maximized SKILL_FERAL_COMBAT in fact
-
-        // weapon skill or (unarmed for base attack)
-        uint32 skill = item ? item->GetSkill() : uint32(SKILL_UNARMED);
-
-        // in PvP always use full skill (and bonuses on top of it if present)
-        value = (target && target->GetTypeId() == TYPEID_PLAYER)
-                ? std::max(((Player*)this)->GetMaxSkillValue(skill), ((Player*)this)->GetSkillValue(skill))
-                : ((Player*)this)->GetSkillValue(skill);
-        // Modify value from ratings
-        value += uint32(((Player*)this)->GetRatingBonusValue(CR_WEAPON_SKILL));
-        switch (attType)
-        {
-            case BASE_ATTACK:   value += uint32(((Player*)this)->GetRatingBonusValue(CR_WEAPON_SKILL_MAINHAND)); break;
-            case OFF_ATTACK:    value += uint32(((Player*)this)->GetRatingBonusValue(CR_WEAPON_SKILL_OFFHAND)); break;
-            case RANGED_ATTACK: value += uint32(((Player*)this)->GetRatingBonusValue(CR_WEAPON_SKILL_RANGED)); break;
-        }
-    }
-    else
-        value = GetUnitMeleeSkill(target);
-    return value;
-}
-
-void Unit::_UpdateSpells(uint32 time)
-{
-    if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL])
-        _UpdateAutoRepeatSpell();
-
-    // remove finished spells from current pointers
-    for (uint32 i = 0; i < CURRENT_MAX_SPELL; ++i)
-    {
-        if (m_currentSpells[i] && m_currentSpells[i]->getState() == SPELL_STATE_FINISHED)
-        {
-            m_currentSpells[i]->SetReferencedFromCurrent(false);
-            m_currentSpells[i] = nullptr;                      // remove pointer
-        }
-    }
-
-    // update auras
-    // m_AurasUpdateIterator can be updated in inderect called code at aura remove to skip next planned to update but removed auras
-    for (m_spellAuraHoldersUpdateIterator = m_spellAuraHolders.begin(); m_spellAuraHoldersUpdateIterator != m_spellAuraHolders.end();)
-    {
-        SpellAuraHolder* i_holder = m_spellAuraHoldersUpdateIterator->second;
-        ++m_spellAuraHoldersUpdateIterator;                 // need shift to next for allow update if need into aura update
-        i_holder->UpdateHolder(time);
-    }
-
-    // remove expired auras
-    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
-    {
-        SpellAuraHolder* holder = iter->second;
-
-        if (!(holder->IsPermanent() || holder->IsPassive()) && holder->GetAuraDuration() == 0)
-        {
-            RemoveSpellAuraHolder(holder, AURA_REMOVE_BY_EXPIRE);
-            iter = m_spellAuraHolders.begin();
-        }
-        else
-            ++iter;
-    }
-
-    if (!m_gameObj.empty())
-    {
-        GameObjectList::iterator ite1, dnext1;
-        for (ite1 = m_gameObj.begin(); ite1 != m_gameObj.end(); ite1 = dnext1)
-        {
-            dnext1 = ite1;
-            //(*i)->Update( difftime );
-            if (!(*ite1)->isSpawned())
-            {
-                (*ite1)->SetOwnerGuid(ObjectGuid());
-                (*ite1)->SetRespawnTime(0);
-                (*ite1)->Delete();
-                dnext1 = m_gameObj.erase(ite1);
-            }
-            else
-                ++dnext1;
-        }
-    }
-}
-
-void Unit::_UpdateAutoRepeatSpell()
-{
-    // check "realtime" interrupts
-    if ((GetTypeId() == TYPEID_PLAYER && ((Player*)this)->isMoving()) || IsNonMeleeSpellCasted(false, false, true))
-    {
-        // cancel wand shoot
-        if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Category == 351)
-            InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
-        m_AutoRepeatFirstCast = true;
-        return;
-    }
-
-    // apply delay
-    if (m_AutoRepeatFirstCast && getAttackTimer(RANGED_ATTACK) < 500)
-        setAttackTimer(RANGED_ATTACK, 500);
-    m_AutoRepeatFirstCast = false;
-
-    // castroutine
-    if (isAttackReady(RANGED_ATTACK))
-    {
-        // Check if able to cast
-        if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->CheckCast(true) != SPELL_CAST_OK)
-        {
-            InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
-            return;
-        }
-
-        // we want to shoot
-        Spell* spell = new Spell(this, m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo, true);
-        spell->SpellStart(&(m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_targets));
-
-        // all went good, reset attack
-        resetAttackTimer(RANGED_ATTACK);
-    }
-}
-
-void Unit::SetCurrentCastedSpell(Spell* pSpell)
-{
-    MANGOS_ASSERT(pSpell);                                  // nullptr may be never passed here, use InterruptSpell or InterruptNonMeleeSpells
-
-    CurrentSpellTypes CSpellType = pSpell->GetCurrentContainer();
-
-    if (pSpell == m_currentSpells[CSpellType]) return;      // avoid breaking self
-
-    // break same type spell if it is not delayed
-    InterruptSpell(CSpellType, false);
-
-    // special breakage effects:
-    switch (CSpellType)
-    {
-        case CURRENT_GENERIC_SPELL:
-        {
-            // generic spells always break channeled not delayed spells
-            InterruptSpell(CURRENT_CHANNELED_SPELL, false);
-
-            // autorepeat breaking
-            if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL])
-            {
-                // break autorepeat if not Auto Shot
-                if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Category == 351)
-                    InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
-                m_AutoRepeatFirstCast = true;
-            }
-        } break;
-
-        case CURRENT_CHANNELED_SPELL:
-        {
-            // channel spells always break generic non-delayed and any channeled spells
-            InterruptSpell(CURRENT_GENERIC_SPELL, false);
-            InterruptSpell(CURRENT_CHANNELED_SPELL);
-
-            // it also does break autorepeat if not Auto Shot
-            if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL] &&
-                    m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Category == 351)
-                InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
-        } break;
-
-        case CURRENT_AUTOREPEAT_SPELL:
-        {
-            // only Auto Shoot does not break anything
-            if (pSpell->m_spellInfo->Category == 351)
-            {
-                // generic autorepeats break generic non-delayed and channeled non-delayed spells
-                InterruptSpell(CURRENT_GENERIC_SPELL, false);
-                InterruptSpell(CURRENT_CHANNELED_SPELL, false);
-            }
-            // special action: set first cast flag
-            m_AutoRepeatFirstCast = true;
-        } break;
-
-        default:
-        {
-            // other spell types don't break anything now
-        } break;
-    }
-
-    // current spell (if it is still here) may be safely deleted now
-    if (m_currentSpells[CSpellType])
-        m_currentSpells[CSpellType]->SetReferencedFromCurrent(false);
-
-    // set new current spell
-    m_currentSpells[CSpellType] = pSpell;
-    pSpell->SetReferencedFromCurrent(true);
-}
-
-void Unit::InterruptSpell(CurrentSpellTypes spellType, bool withDelayed)
-{
-    if (m_currentSpells[spellType] && (withDelayed || m_currentSpells[spellType]->getState() != SPELL_STATE_DELAYED))
-    {
-        // send autorepeat cancel message for autorepeat spells
-        if (spellType == CURRENT_AUTOREPEAT_SPELL)
-        {
-            if (GetTypeId() == TYPEID_PLAYER)
-                ((Player*)this)->SendAutoRepeatCancel();
-        }
-
-        if (m_currentSpells[spellType]->getState() != SPELL_STATE_FINISHED)
-            m_currentSpells[spellType]->cancel();
-
-        // cancel can interrupt spell already (caster cancel ->target aura remove -> caster iterrupt)
-        if (m_currentSpells[spellType])
-        {
-            m_currentSpells[spellType]->SetReferencedFromCurrent(false);
-            m_currentSpells[spellType] = nullptr;
-        }
-    }
-}
-
-void Unit::FinishSpell(CurrentSpellTypes spellType, bool ok /*= true*/)
-{
-    Spell* spell = m_currentSpells[spellType];
-    if (!spell)
-        return;
-
-    if (spellType == CURRENT_CHANNELED_SPELL)
-        spell->SendChannelUpdate(0);
-
-    spell->finish(ok);
-}
-
-bool Unit::IsNonMeleeSpellCasted(bool withDelayed, bool skipChanneled, bool skipAutorepeat) const
-{
-    // We don't do loop here to explicitly show that melee spell is excluded.
-    // Maybe later some special spells will be excluded too.
-
-    // generic spells are casted when they are not finished and not delayed
-    if (m_currentSpells[CURRENT_GENERIC_SPELL] &&
-            (m_currentSpells[CURRENT_GENERIC_SPELL]->getState() != SPELL_STATE_FINISHED) &&
-            (withDelayed || m_currentSpells[CURRENT_GENERIC_SPELL]->getState() != SPELL_STATE_DELAYED))
-        return true;
-
-    // channeled spells may be delayed, but they are still considered casted
-    else if (!skipChanneled && m_currentSpells[CURRENT_CHANNELED_SPELL] &&
-             (m_currentSpells[CURRENT_CHANNELED_SPELL]->getState() != SPELL_STATE_FINISHED))
-        return true;
-
-    // autorepeat spells may be finished or delayed, but they are still considered casted
-    else if (!skipAutorepeat && m_currentSpells[CURRENT_AUTOREPEAT_SPELL])
-        return true;
-
-    return false;
-}
-
-void Unit::InterruptNonMeleeSpells(bool withDelayed, uint32 spell_id)
-{
-    // generic spells are interrupted if they are not finished or delayed
-    if (m_currentSpells[CURRENT_GENERIC_SPELL] && (!spell_id || m_currentSpells[CURRENT_GENERIC_SPELL]->m_spellInfo->Id == spell_id))
-        InterruptSpell(CURRENT_GENERIC_SPELL, withDelayed);
-
-    // autorepeat spells are interrupted if they are not finished or delayed
-    if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL] && (!spell_id || m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Id == spell_id))
-        InterruptSpell(CURRENT_AUTOREPEAT_SPELL, withDelayed);
-
-    // channeled spells are interrupted if they are not finished, even if they are delayed
-    if (m_currentSpells[CURRENT_CHANNELED_SPELL] && (!spell_id || m_currentSpells[CURRENT_CHANNELED_SPELL]->m_spellInfo->Id == spell_id))
-        InterruptSpell(CURRENT_CHANNELED_SPELL, true);
-}
-
-Spell* Unit::FindCurrentSpellBySpellId(uint32 spell_id) const
-{
-    for (uint32 i = 0; i < CURRENT_MAX_SPELL; ++i)
-        if (m_currentSpells[i] && m_currentSpells[i]->m_spellInfo->Id == spell_id)
-            return m_currentSpells[i];
-    return nullptr;
-}
-
-void Unit::SetInFront(Unit const* target)
-{
-    SetOrientation(GetAngle(target));
-}
-
-void Unit::SetFacingTo(float ori)
-{
-    Movement::MoveSplineInit init(*this);
-    init.SetFacing(ori);
-    init.Launch();
-}
-
-void Unit::SetFacingToObject(WorldObject* pObject)
-{
-    // never face when already moving
-    if (!IsStopped())
-        return;
-
-    // TODO: figure out under what conditions creature will move towards object instead of facing it where it currently is.
-    SetFacingTo(GetAngle(pObject));
-}
-
-bool Unit::isInAccessablePlaceFor(Unit const* unit) const
-{
-    if (IsInWater())
-        return unit->CanSwim();
-    else
-        return unit->CanWalk() || unit->CanFly();
-}
-
-bool Unit::IsInWater() const
-{
-    return GetTerrain()->IsInWater(GetPositionX(), GetPositionY(), GetPositionZ());
-}
-
-bool Unit::IsUnderWater() const
-{
-    return GetTerrain()->IsUnderWater(GetPositionX(), GetPositionY(), GetPositionZ());
-}
-
-void Unit::DeMorph()
-{
-    SetDisplayId(GetNativeDisplayId());
-}
-
-int32 Unit::GetTotalAuraModifier(AuraType auratype) const
-{
-    int32 modifier = 0;
-
-    AuraList const& mTotalAuraList = GetAurasByType(auratype);
-    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-        modifier += (*i)->GetModifier()->m_amount;
-
-    return modifier;
-}
-
-float Unit::GetTotalAuraMultiplier(AuraType auratype) const
-{
-    float multiplier = 1.0f;
-
-    AuraList const& mTotalAuraList = GetAurasByType(auratype);
-    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-        multiplier *= (100.0f + (*i)->GetModifier()->m_amount) / 100.0f;
-
-    return multiplier;
-}
-
-int32 Unit::GetMaxPositiveAuraModifier(AuraType auratype) const
-{
-    int32 modifier = 0;
-
-    AuraList const& mTotalAuraList = GetAurasByType(auratype);
-    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-        if ((*i)->GetModifier()->m_amount > modifier)
-            modifier = (*i)->GetModifier()->m_amount;
-
-    return modifier;
-}
-
-int32 Unit::GetMaxNegativeAuraModifier(AuraType auratype) const
-{
-    int32 modifier = 0;
-
-    AuraList const& mTotalAuraList = GetAurasByType(auratype);
-    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-        if ((*i)->GetModifier()->m_amount < modifier)
-            modifier = (*i)->GetModifier()->m_amount;
-
-    return modifier;
-}
-
-int32 Unit::GetTotalAuraModifierByMiscMask(AuraType auratype, uint32 misc_mask) const
-{
-    if (!misc_mask)
-        return 0;
-
-    int32 modifier = 0;
-
-    AuraList const& mTotalAuraList = GetAurasByType(auratype);
-    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-    {
-        Modifier* mod = (*i)->GetModifier();
-        if (mod->m_miscvalue & misc_mask)
-            modifier += mod->m_amount;
-    }
-    return modifier;
-}
-
-float Unit::GetTotalAuraMultiplierByMiscMask(AuraType auratype, uint32 misc_mask) const
-{
-    if (!misc_mask)
-        return 1.0f;
-
-    float multiplier = 1.0f;
-
-    AuraList const& mTotalAuraList = GetAurasByType(auratype);
-    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-    {
-        Modifier* mod = (*i)->GetModifier();
-        if (mod->m_miscvalue & misc_mask)
-            multiplier *= (100.0f + mod->m_amount) / 100.0f;
-    }
-    return multiplier;
-}
-
-int32 Unit::GetMaxPositiveAuraModifierByMiscMask(AuraType auratype, uint32 misc_mask) const
-{
-    if (!misc_mask)
-        return 0;
-
-    int32 modifier = 0;
-
-    AuraList const& mTotalAuraList = GetAurasByType(auratype);
-    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-    {
-        Modifier* mod = (*i)->GetModifier();
-        if (mod->m_miscvalue & misc_mask && mod->m_amount > modifier)
-            modifier = mod->m_amount;
-    }
-
-    return modifier;
-}
-
-int32 Unit::GetMaxNegativeAuraModifierByMiscMask(AuraType auratype, uint32 misc_mask) const
-{
-    if (!misc_mask)
-        return 0;
-
-    int32 modifier = 0;
-
-    AuraList const& mTotalAuraList = GetAurasByType(auratype);
-    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-    {
-        Modifier* mod = (*i)->GetModifier();
-        if (mod->m_miscvalue & misc_mask && mod->m_amount < modifier)
-            modifier = mod->m_amount;
-    }
-
-    return modifier;
-}
-
-int32 Unit::GetTotalAuraModifierByMiscValue(AuraType auratype, int32 misc_value) const
-{
-    int32 modifier = 0;
-
-    AuraList const& mTotalAuraList = GetAurasByType(auratype);
-    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-    {
-        Modifier* mod = (*i)->GetModifier();
-        if (mod->m_miscvalue == misc_value)
-            modifier += mod->m_amount;
-    }
-    return modifier;
-}
-
-float Unit::GetTotalAuraMultiplierByMiscValue(AuraType auratype, int32 misc_value) const
-{
-    float multiplier = 1.0f;
-
-    AuraList const& mTotalAuraList = GetAurasByType(auratype);
-    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-    {
-        Modifier* mod = (*i)->GetModifier();
-        if (mod->m_miscvalue == misc_value)
-            multiplier *= (100.0f + mod->m_amount) / 100.0f;
-    }
-    return multiplier;
-}
-
-int32 Unit::GetMaxPositiveAuraModifierByMiscValue(AuraType auratype, int32 misc_value) const
-{
-    int32 modifier = 0;
-
-    AuraList const& mTotalAuraList = GetAurasByType(auratype);
-    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-    {
-        Modifier* mod = (*i)->GetModifier();
-        if (mod->m_miscvalue == misc_value && mod->m_amount > modifier)
-            modifier = mod->m_amount;
-    }
-
-    return modifier;
-}
-
-int32 Unit::GetMaxNegativeAuraModifierByMiscValue(AuraType auratype, int32 misc_value) const
-{
-    int32 modifier = 0;
-
-    AuraList const& mTotalAuraList = GetAurasByType(auratype);
-    for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-    {
-        Modifier* mod = (*i)->GetModifier();
-        if (mod->m_miscvalue == misc_value && mod->m_amount < modifier)
-            modifier = mod->m_amount;
-    }
-
-    return modifier;
-}
-
-bool Unit::AddSpellAuraHolder(SpellAuraHolder* holder)
-{
-    SpellEntry const* aurSpellInfo = holder->GetSpellProto();
-
-    // ghost spell check, allow apply any auras at player loading in ghost mode (will be cleanup after load)
-    if (!isAlive() && !IsDeathPersistentSpell(aurSpellInfo) &&
-        !IsDeathOnlySpell(aurSpellInfo) && !aurSpellInfo->HasAttribute(SPELL_ATTR_EX2_CAN_TARGET_DEAD) &&
-        (GetTypeId() != TYPEID_PLAYER || !((Player*)this)->GetSession()->PlayerLoading()))
-    {
-        delete holder;
-        return false;
-    }
-
-    if (holder->GetTarget() != this)
-    {
-        sLog.outError("Holder (spell %u) add to spell aura holder list of %s (lowguid: %u) but spell aura holder target is %s (lowguid: %u)",
-                      holder->GetId(), (GetTypeId() == TYPEID_PLAYER ? "player" : "creature"), GetGUIDLow(),
-                      (holder->GetTarget()->GetTypeId() == TYPEID_PLAYER ? "player" : "creature"), holder->GetTarget()->GetGUIDLow());
-        delete holder;
-        return false;
-    }
-
-    // passive and persistent auras can stack with themselves any number of times
-    if ((!holder->IsPassive() && !holder->IsPersistent()) || holder->IsAreaAura())
-    {
-        SpellAuraHolderBounds spair = GetSpellAuraHolderBounds(aurSpellInfo->Id);
-
-        // take out same spell
-        for (SpellAuraHolderMap::iterator iter = spair.first; iter != spair.second; ++iter)
-        {
-            SpellAuraHolder* foundHolder = iter->second;
-            if (foundHolder->GetCasterGuid() == holder->GetCasterGuid())
-            {
-                // Aura can stack on self -> Stack it;
-                if (aurSpellInfo->StackAmount)
-                {
-                    // can be created with >1 stack by some spell mods
-                    foundHolder->ModStackAmount(holder->GetStackAmount());
-                    delete holder;
-                    return false;
-                }
-
-                // Check for coexisting Weapon-proced Auras
-                if (holder->IsWeaponBuffCoexistableWith(foundHolder))
-                    continue;
-
-                // Carry over removed Aura's remaining damage if Aura still has ticks remaining
-                if (foundHolder->GetSpellProto()->HasAttribute(SPELL_ATTR_EX4_STACK_DOT_MODIFIER))
-                {
-                    for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
-                    {
-                        if (Aura* aur = holder->GetAuraByEffectIndex(SpellEffectIndex(i)))
-                        {
-                            // m_auraname can be modified to SPELL_AURA_NONE for area auras, use original
-                            AuraType aurNameReal = AuraType(aurSpellInfo->EffectApplyAuraName[i]);
-
-                            if (aurNameReal == SPELL_AURA_PERIODIC_DAMAGE && aur->GetAuraDuration() > 0)
-                            {
-                                if (Aura* existing = foundHolder->GetAuraByEffectIndex(SpellEffectIndex(i)))
-                                {
-                                    int32 remainingTicks = existing->GetAuraMaxTicks() - existing->GetAuraTicks();
-                                    int32 remainingDamage = existing->GetModifier()->m_amount * remainingTicks;
-
-                                    aur->GetModifier()->m_amount += int32(remainingDamage / aur->GetAuraMaxTicks());
-                                }
-                                else
-                                    DEBUG_LOG("Holder (spell %u) on target (lowguid: %u) doesn't have aura on effect index %u. skipping.", aurSpellInfo->Id, holder->GetTarget()->GetGUIDLow(), i);
-                            }
-                        }
-                    }
-                }
-
-                // can be only single
-                RemoveSpellAuraHolder(foundHolder, AURA_REMOVE_BY_STACK);
-                break;
-            }
-            else
-            {
-                //any stackable case with amount should mod existing stack amount
-                if (aurSpellInfo->StackAmount && aurSpellInfo->rangeIndex != SPELL_RANGE_IDX_SELF_ONLY && !aurSpellInfo->HasAttribute(SPELL_ATTR_EX3_STACK_FOR_DIFF_CASTERS))
-                {
-                    foundHolder->ModStackAmount(holder->GetStackAmount());
-                    delete holder;
-                    return false;
-                }
-                else
-                {
-                    if (!IsStackableSpell(holder->GetSpellProto(), foundHolder->GetSpellProto(), holder->GetTarget()))
-                    {
-                        RemoveSpellAuraHolder(foundHolder, AURA_REMOVE_BY_STACK);
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    // normal spell or passive auras not stackable with other ranks
-    if (!IsPassiveSpell(aurSpellInfo) || !IsPassiveSpellStackableWithRanks(aurSpellInfo))
-    {
-        if (!RemoveNoStackAurasDueToAuraHolder(holder))
-        {
-            delete holder;
-            return false;                                   // couldn't remove conflicting aura with higher rank
-        }
-    }
-
-    // update tracked aura targets list (before aura add to aura list, to prevent unexpected remove recently added aura)
-    if (TrackedAuraType trackedType = holder->GetTrackedAuraType())
-    {
-        if (Unit* caster = holder->GetCaster())             // caster not in world
-        {
-            // Only compare TrackedAuras of same tracking type
-            TrackedAuraTargetMap& scTargets = caster->GetTrackedAuraTargets(trackedType);
-            for (TrackedAuraTargetMap::iterator itr = scTargets.begin(); itr != scTargets.end();)
-            {
-                SpellEntry const* itr_spellEntry = itr->first;
-                ObjectGuid itr_targetGuid = itr->second;    // Target on whom the tracked aura is
-
-                if (itr_targetGuid == GetObjectGuid())      // Note: I don't understand this check (based on old aura concepts, kept when adding holders)
-                {
-                    ++itr;
-                    continue;
-                }
-
-                bool removed = false;
-                switch (trackedType)
-                {
-                    case TRACK_AURA_TYPE_SINGLE_TARGET:
-                        if (IsSingleTargetSpells(itr_spellEntry, aurSpellInfo))
-                        {
-                            removed = true;
-                            // remove from target if target found
-                            if (Unit* itr_target = GetMap()->GetUnit(itr_targetGuid))
-                                itr_target->RemoveAurasDueToSpell(itr_spellEntry->Id); // TODO AURA_REMOVE_BY_TRACKING (might require additional work elsewhere)
-                            else                            // Normally the tracking will be removed by the AuraRemoval
-                                scTargets.erase(itr);
-                        }
-                        break;
-                    case TRACK_AURA_TYPE_NOT_TRACKED:       // These two can never happen
-                    case MAX_TRACKED_AURA_TYPES:
-                        MANGOS_ASSERT(false);
-                        break;
-                }
-
-                if (removed)
-                {
-                    itr = scTargets.begin();                // list can be chnaged at remove aura
-                    continue;
-                }
-
-                ++itr;
-            }
-
-            // TODO remove this switch after confirming that we dont need other cases
-            switch (trackedType)
-            {
-                case TRACK_AURA_TYPE_SINGLE_TARGET:         // Register spell holder single target
-                    scTargets[aurSpellInfo] = GetObjectGuid();
-                    break;
+                case POWER_MANA:   triggered_spell_id = 28722; break;
+                case POWER_RAGE:   triggered_spell_id = 28723; break;
+                case POWER_ENERGY: triggered_spell_id = 28724; break;
                 default:
-                    break;
+                    return SPELL_AURA_PROC_FAILED;
             }
-        }
-    }
-
-    // add aura, register in lists and arrays
-    holder->_AddSpellAuraHolder();
-    m_spellAuraHolders.insert(SpellAuraHolderMap::value_type(holder->GetId(), holder));
-
-    for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
-        if (Aura* aur = holder->GetAuraByEffectIndex(SpellEffectIndex(i)))
-            AddAuraToModList(aur);
-
-    holder->ApplyAuraModifiers(true, true);                 // This is the place where auras are actually applied onto the target
-    DEBUG_LOG("Holder of spell %u now is in use", holder->GetId());
-
-    // if aura deleted before boosts apply ignore
-    // this can be possible it it removed indirectly by triggered spell effect at ApplyModifier
-    if (holder->IsDeleted())
-        return false;
-
-    holder->HandleSpellSpecificBoosts(true);
-
-    return true;
-}
-
-void Unit::AddAuraToModList(Aura* aura)
-{
-    if (aura->GetModifier()->m_auraname < TOTAL_AURAS)
-        m_modAuras[aura->GetModifier()->m_auraname].push_back(aura);
-}
-
-void Unit::RemoveRankAurasDueToSpell(uint32 spellId)
-{
-    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
-    if (!spellInfo)
-        return;
-    SpellAuraHolderMap::const_iterator i, next;
-    for (i = m_spellAuraHolders.begin(); i != m_spellAuraHolders.end(); i = next)
-    {
-        next = i;
-        ++next;
-        uint32 i_spellId = (*i).second->GetId();
-        if ((*i).second && i_spellId && i_spellId != spellId)
-        {
-            if (sSpellMgr.IsRankSpellDueToSpell(spellInfo, i_spellId))
-            {
-                RemoveAurasDueToSpell(i_spellId);
-
-                if (m_spellAuraHolders.empty())
-                    break;
-                else
-                    next =  m_spellAuraHolders.begin();
-            }
-        }
-    }
-}
-
-bool Unit::RemoveNoStackAurasDueToAuraHolder(SpellAuraHolder* holder)
-{
-    if (!holder)
-        return false;
-
-    SpellEntry const* spellProto = holder->GetSpellProto();
-    if (!spellProto)
-        return false;
-
-    // passive spell special case (only non stackable with ranks)
-    if (IsPassiveSpell(spellProto))
-    {
-        if (IsPassiveSpellStackableWithRanks(spellProto))
-            return true;
-    }
-
-    const uint32 spellId = holder->GetId();
-    const SpellSpecific specific = GetSpellSpecific(spellId);
-    SpellEntry const* triggeredBy = holder->GetTriggeredBy();
-
-    SpellAuraHolderMap::iterator i, next;
-    for (i = m_spellAuraHolders.begin(); i != m_spellAuraHolders.end(); i = next)
-    {
-        next = i;
-        ++next;
-        if (!(*i).second) continue;
-
-        SpellAuraHolder* existing = (*i).second;
-        SpellEntry const* existingSpellProto = existing->GetSpellProto();
-
-        if (!existingSpellProto)
-            continue;
-
-        const uint32 existingSpellId = existingSpellProto->Id;
-        const SpellSpecific existingSpecific = GetSpellSpecific(existingSpellId);
-        const bool own = (holder->GetCasterGuid() == existing->GetCasterGuid());
-
-        // early checks that spellId is passive non stackable spell
-        if (IsPassiveSpell(existingSpellProto))
-        {
-            // passive non-stackable spells not stackable only for same caster
-            if (!own)
-                continue;
-
-            // passive non-stackable spells not stackable only with another rank of same spell
-            if (!sSpellMgr.IsRankSpellDueToSpell(spellProto, existingSpellId))
-                continue;
-        }
-
-        // prevent triggering aura of removing aura that triggered it
-        if ((existing->GetTriggeredBy() && existing->GetTriggeredBy()->Id == spellId)
-            || (holder->GetTriggeredBy() && holder->GetTriggeredBy()->Id == existingSpellId))
-            continue;
-
-        bool unique = false;
-        bool personal = false;
-        if (specific && existingSpecific && IsSpellSpecificIdentical(specific, existingSpecific))
-        {
-            personal = IsSpellSpecificUniquePerCaster(specific);
-            unique = (personal || IsSpellSpecificUniquePerTarget(specific));
-        }
-
-        const bool stackable = !sSpellMgr.IsNoStackSpellDueToSpell(spellProto, existingSpellProto);
-        if (unique || !stackable)
-        {
-            // check if this spell can be triggered by any talent aura
-            if (!unique && triggeredBy && sSpellMgr.IsSpellCanAffectSpell(triggeredBy, existingSpellProto))
-                continue;
-
-            if (!own)
-            {
-                if (personal && stackable)
-                    continue;
-                // holder cannot remove higher rank if it isn't from the same caster
-                if (IsSimilarExistingAuraStronger(holder, existing) || (sSpellMgr.IsRankSpellDueToSpell(spellProto, existingSpellId) && sSpellMgr.IsHighRankOfSpell(existingSpellId, spellId)))
-                    return false;
-            }
-
-            // Its a parent aura (create this aura in ApplyModifier)
-            if (existing->IsInUse())
-            {
-                sLog.outError("SpellAuraHolder (Spell %u) is in process but attempt removed at SpellAuraHolder (Spell %u) adding, need add stack rule for Unit::RemoveNoStackAurasDueToAuraHolder", i->second->GetId(), holder->GetId());
-                continue;
-            }
-
-            if (personal && stackable)
-                RemoveAurasByCasterSpell(existingSpellId, holder->GetCasterGuid());
-            else
-                RemoveAurasDueToSpell(existingSpellId);
-
-            if (m_spellAuraHolders.empty())
-                break;
-            else
-                next = m_spellAuraHolders.begin();
-        }
-    }
-    return true;
-}
-
-void Unit::RemoveAura(uint32 spellId, SpellEffectIndex effindex, Aura* except)
-{
-    SpellAuraHolderBounds spair = GetSpellAuraHolderBounds(spellId);
-    for (SpellAuraHolderMap::iterator iter = spair.first; iter != spair.second;)
-    {
-        Aura* aur = iter->second->m_auras[effindex];
-        if (aur && aur != except)
-        {
-            RemoveSingleAuraFromSpellAuraHolder(iter->second, effindex);
-            // may remove holder
-            spair = GetSpellAuraHolderBounds(spellId);
-            iter = spair.first;
-        }
-        else
-            ++iter;
-    }
-}
-void Unit::RemoveAurasByCasterSpell(uint32 spellId, ObjectGuid casterGuid)
-{
-    SpellAuraHolderBounds spair = GetSpellAuraHolderBounds(spellId);
-    for (SpellAuraHolderMap::iterator iter = spair.first; iter != spair.second;)
-    {
-        if (iter->second->GetCasterGuid() == casterGuid)
-        {
-            RemoveSpellAuraHolder(iter->second);
-            spair = GetSpellAuraHolderBounds(spellId);
-            iter = spair.first;
-        }
-        else
-            ++iter;
-    }
-}
-
-void Unit::RemoveSingleAuraFromSpellAuraHolder(uint32 spellId, SpellEffectIndex effindex, ObjectGuid casterGuid, AuraRemoveMode mode)
-{
-    SpellAuraHolderBounds spair = GetSpellAuraHolderBounds(spellId);
-    for (SpellAuraHolderMap::iterator iter = spair.first; iter != spair.second;)
-    {
-        Aura* aur = iter->second->m_auras[effindex];
-        if (aur && aur->GetCasterGuid() == casterGuid)
-        {
-            RemoveSingleAuraFromSpellAuraHolder(iter->second, effindex, mode);
-            spair = GetSpellAuraHolderBounds(spellId);
-            iter = spair.first;
-        }
-        else
-            ++iter;
-    }
-}
-
-void Unit::RemoveAuraHolderDueToSpellByDispel(uint32 spellId, uint32 stackAmount, ObjectGuid casterGuid, Unit* dispeller)
-{
-    SpellEntry const* spellEntry = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
-
-    // Custom dispel case
-    // Unstable Affliction
-    if (spellEntry->SpellFamilyName == SPELLFAMILY_WARLOCK && (spellEntry->SpellFamilyFlags & uint64(0x010000000000)))
-    {
-        if (Aura* dotAura = GetAura(SPELL_AURA_PERIODIC_DAMAGE, SPELLFAMILY_WARLOCK, uint64(0x010000000000), casterGuid))
-        {
-            // use clean value for initial damage
-            int32 damage = dotAura->GetSpellProto()->CalculateSimpleValue(EFFECT_INDEX_0);
-            damage *= 9;
-
-            // Remove spell auras from stack
-            RemoveAuraHolderFromStack(spellId, stackAmount, casterGuid, AURA_REMOVE_BY_DISPEL);
-
-            // backfire damage and silence
-            dispeller->CastCustomSpell(dispeller, 31117, &damage, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, nullptr, nullptr, casterGuid);
-            return;
-        }
-    }
-    // Lifebloom
-    else if (spellEntry->SpellFamilyName == SPELLFAMILY_DRUID && (spellEntry->SpellFamilyFlags & uint64(0x0000001000000000)))
-    {
-        if (Aura* dotAura = GetAura(SPELL_AURA_DUMMY, SPELLFAMILY_DRUID, uint64(0x0000001000000000), casterGuid))
-        {
-            if (dotAura->GetStackAmount() <= stackAmount)
-            {
-                // Lifebloom dummy store single stack amount always
-                int32 amount = dotAura->GetModifier()->m_amount;
-                CastCustomSpell(this, 33778, &amount, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, nullptr, dotAura, casterGuid);
-            }
-        }
-    }
-
-    RemoveAuraHolderFromStack(spellId, stackAmount, casterGuid, AURA_REMOVE_BY_DISPEL);
-}
-
-void Unit::RemoveAurasDueToSpellBySteal(uint32 spellId, ObjectGuid casterGuid, Unit* stealer)
-{
-    SpellAuraHolder* holder = GetSpellAuraHolder(spellId, casterGuid);
-    SpellEntry const* spellProto = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
-    SpellAuraHolder* new_holder = CreateSpellAuraHolder(spellProto, stealer, this);
-
-    // set its duration and maximum duration
-    // max duration 2 minutes (in msecs)
-    int32 dur = holder->GetAuraDuration();
-    int32 max_dur = 2 * MINUTE * IN_MILLISECONDS;
-    int32 new_max_dur = max_dur > dur ? dur : max_dur;
-    new_holder->SetAuraMaxDuration(new_max_dur);
-    new_holder->SetAuraDuration(new_max_dur);
-
-    for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
-    {
-        Aura* aur = holder->GetAuraByEffectIndex(SpellEffectIndex(i));
-
-        if (!aur)
-            continue;
-
-        int32 basePoints = aur->GetBasePoints();
-        // construct the new aura for the attacker - will never return nullptr, it's just a wrapper for
-        // some different constructors
-        Aura* new_aur = CreateAura(aur->GetSpellProto(), aur->GetEffIndex(), &basePoints, new_holder, stealer, this);
-
-        // set periodic to do at least one tick (for case when original aura has been at last tick preparing)
-        int32 periodic = aur->GetModifier()->periodictime;
-        new_aur->GetModifier()->periodictime = periodic < new_max_dur ? periodic : new_max_dur;
-
-        // add the new aura to stealer
-        new_holder->AddAura(new_aur, new_aur->GetEffIndex());
-    }
-
-    if (holder->ModStackAmount(-1))
-        // Remove aura as dispel
-        RemoveSpellAuraHolder(holder, AURA_REMOVE_BY_DISPEL);
-
-    // strange but intended behaviour: Stolen single target auras won't be treated as single targeted
-    new_holder->SetTrackedAuraType(TRACK_AURA_TYPE_NOT_TRACKED);
-
-    stealer->AddSpellAuraHolder(new_holder);
-}
-
-void Unit::RemoveAurasDueToSpellByCancel(uint32 spellId)
-{
-    SpellAuraHolderBounds spair = GetSpellAuraHolderBounds(spellId);
-    for (SpellAuraHolderMap::iterator iter = spair.first; iter != spair.second;)
-    {
-        RemoveSpellAuraHolder(iter->second, AURA_REMOVE_BY_CANCEL);
-        spair = GetSpellAuraHolderBounds(spellId);
-        iter = spair.first;
-    }
-}
-
-void Unit::RemoveAurasTriggeredBySpell(uint32 spellId, ObjectGuid casterGuid /*= ObjectGuid()*/)
-{
-    if (!spellId)
-        return;
-
-    SpellAuraHolderMap& auras = GetSpellAuraHolderMap();
-    for (SpellAuraHolderMap::iterator itr = auras.begin(); itr != auras.end();)
-    {
-        const SpellEntry* entry = itr->second->GetTriggeredBy();
-        if ((entry && entry->Id == spellId) && (casterGuid.IsEmpty() || casterGuid == itr->second->GetCasterGuid()))
-        {
-            RemoveSpellAuraHolder(itr->second);
-            itr = auras.begin();
-        }
-        else
-            ++itr;
-    }
-}
-
-void Unit::RemoveAurasWithDispelType(DispelType type, ObjectGuid casterGuid)
-{
-    // Create dispel mask by dispel type
-    uint32 dispelMask = GetDispellMask(type);
-    // Dispel all existing auras vs current dispel type
-    SpellAuraHolderMap& auras = GetSpellAuraHolderMap();
-    for (SpellAuraHolderMap::iterator itr = auras.begin(); itr != auras.end();)
-    {
-        SpellEntry const* spell = itr->second->GetSpellProto();
-        if (((1 << spell->Dispel) & dispelMask) && (!casterGuid || casterGuid == itr->second->GetCasterGuid()))
-        {
-            // Dispel aura
-            RemoveAurasDueToSpell(spell->Id);
-            itr = auras.begin();
-        }
-        else
-            ++itr;
-    }
-}
-
-void Unit::RemoveAuraHolderFromStack(uint32 spellId, uint32 stackAmount, ObjectGuid casterGuid, AuraRemoveMode mode)
-{
-    SpellAuraHolderBounds spair = GetSpellAuraHolderBounds(spellId);
-    for (SpellAuraHolderMap::iterator iter = spair.first; iter != spair.second; ++iter)
-    {
-        if (!casterGuid || iter->second->GetCasterGuid() == casterGuid)
-        {
-            if (iter->second->ModStackAmount(-int32(stackAmount)))
-            {
-                RemoveSpellAuraHolder(iter->second, mode);
-                break;
-            }
-        }
-    }
-}
-
-void Unit::RemoveAurasDueToSpell(uint32 spellId, SpellAuraHolder* except, AuraRemoveMode mode)
-{
-    SpellAuraHolderBounds bounds = GetSpellAuraHolderBounds(spellId);
-    for (SpellAuraHolderMap::iterator iter = bounds.first; iter != bounds.second;)
-    {
-        if (iter->second != except)
-        {
-            RemoveSpellAuraHolder(iter->second, mode);
-            bounds = GetSpellAuraHolderBounds(spellId);
-            iter = bounds.first;
-        }
-        else
-            ++iter;
-    }
-}
-
-void Unit::RemoveAurasDueToItemSpell(Item* castItem, uint32 spellId)
-{
-    SpellAuraHolderBounds bounds = GetSpellAuraHolderBounds(spellId);
-    for (SpellAuraHolderMap::iterator iter = bounds.first; iter != bounds.second;)
-    {
-        if (iter->second->GetCastItemGuid() == castItem->GetObjectGuid())
-        {
-            RemoveSpellAuraHolder(iter->second);
-            bounds = GetSpellAuraHolderBounds(spellId);
-            iter = bounds.first;
-        }
-        else
-            ++iter;
-    }
-}
-
-void Unit::RemoveAurasWithInterruptFlags(uint32 flags)
-{
-    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
-    {
-        if (iter->second->GetSpellProto()->AuraInterruptFlags & flags)
-        {
-            RemoveSpellAuraHolder(iter->second);
-            iter = m_spellAuraHolders.begin();
-        }
-        else
-            ++iter;
-    }
-}
-
-void Unit::RemoveAurasWithAttribute(uint32 flags)
-{
-    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
-    {
-        if (iter->second->GetSpellProto()->HasAttribute((SpellAttributes)flags))
-        {
-            RemoveSpellAuraHolder(iter->second);
-            iter = m_spellAuraHolders.begin();
-        }
-        else
-            ++iter;
-    }
-}
-
-void Unit::RemoveAurasOnCast(SpellEntry const* castedSpellEntry)
-{
-    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
-    {
-        SpellAuraHolder* holder = iter->second;
-        SpellEntry const* spellEntry = holder->GetSpellProto();
-        bool removeThisHolder = false;
-
-        if (spellEntry->AuraInterruptFlags & AURA_INTERRUPT_FLAG_UNK2)
-        {
-            if (castedSpellEntry->HasAttribute(SPELL_ATTR_EX_NOT_BREAK_STEALTH))
-            {
-                bool foundStealth = false;
-                for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
-                {
-                    if (Aura* aura = holder->m_auras[i])
-                    {
-                        if (aura->GetModifier()->m_auraname == SPELL_AURA_MOD_STEALTH)
-                        {
-                            foundStealth = true;
-                            break;
-                        }
-                    }
-                }
-                removeThisHolder = !foundStealth;
-            }
-            else
-                removeThisHolder = true;
-        }
-
-        if (removeThisHolder)
-        {
-            RemoveSpellAuraHolder(iter->second);
-            iter = m_spellAuraHolders.begin();
-        }
-        else
-            ++iter;
-    }
-}
-
-void Unit::RemoveNotOwnTrackedTargetAuras()
-{
-    // tracked aura targets from other casters are removed if the phase does no more fit
-    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
-    {
-        TrackedAuraType trackedType = iter->second->GetTrackedAuraType();
-        if (!trackedType)
-        {
-            ++iter;
-            continue;
-        }
-
-        if (iter->second->GetCasterGuid() != GetObjectGuid())
-        {
-            RemoveSpellAuraHolder(iter->second);
-            iter = m_spellAuraHolders.begin();
-            continue;
-        }
-
-        ++iter;
-    }
-
-    // tracked aura targets at other targets
-    for (uint8 type = TRACK_AURA_TYPE_SINGLE_TARGET; type < MAX_TRACKED_AURA_TYPES; ++type)
-    {
-        TrackedAuraTargetMap& scTargets = GetTrackedAuraTargets(TrackedAuraType(type));
-        for (TrackedAuraTargetMap::iterator itr = scTargets.begin(); itr != scTargets.end();)
-        {
-            SpellEntry const* itr_spellEntry = itr->first;
-            ObjectGuid itr_targetGuid = itr->second;
-
-            if (itr_targetGuid != GetObjectGuid())
-            {
-                scTargets.erase(itr);                           // remove for caster in any case
-
-                // remove from target if target found
-                if (Unit* itr_target = GetMap()->GetUnit(itr_targetGuid))
-                    itr_target->RemoveAurasByCasterSpell(itr_spellEntry->Id, GetObjectGuid());
-
-                itr = scTargets.begin();                        // list can be changed at remove aura
-                continue;
-            }
-
-            ++itr;
-        }
-    }
-}
-
-void Unit::RemoveSpellAuraHolder(SpellAuraHolder* holder, AuraRemoveMode mode)
-{
-    // Statue unsummoned at holder remove
-    SpellEntry const* AurSpellInfo = holder->GetSpellProto();
-    Totem* statue = nullptr;
-    Unit* caster = holder->GetCaster();
-    if (IsChanneledSpell(AurSpellInfo) && caster)
-        if (caster->GetTypeId() == TYPEID_UNIT && ((Creature*)caster)->IsTotem() && ((Totem*)caster)->GetTotemType() == TOTEM_STATUE)
-            statue = ((Totem*)caster);
-
-    if (m_spellAuraHoldersUpdateIterator != m_spellAuraHolders.end() && m_spellAuraHoldersUpdateIterator->second == holder)
-        ++m_spellAuraHoldersUpdateIterator;
-
-    SpellAuraHolderBounds bounds = GetSpellAuraHolderBounds(holder->GetId());
-    for (SpellAuraHolderMap::iterator itr = bounds.first; itr != bounds.second; ++itr)
-    {
-        if (itr->second == holder)
-        {
-            m_spellAuraHolders.erase(itr);
             break;
         }
-    }
-
-    holder->SetRemoveMode(mode);
-    holder->UnregisterAndCleanupTrackedAuras();
-
-    for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
-    {
-        if (Aura* aura = holder->m_auras[i])
-            RemoveAura(aura, mode);
-    }
-
-    holder->_RemoveSpellAuraHolder();
-
-    if (mode != AURA_REMOVE_BY_DELETE)
-        holder->HandleSpellSpecificBoosts(false);
-
-    if (statue)
-        statue->UnSummon();
-
-    // If holder in use (removed from code that plan access to it data after return)
-    // store it in holder list with delayed deletion
-    if (holder->IsInUse())
-    {
-        holder->SetDeleted();
-        m_deletedHolders.push_back(holder);
-    }
-    else
-        delete holder;
-
-    if (mode != AURA_REMOVE_BY_EXPIRE && IsChanneledSpell(AurSpellInfo) && !IsAreaOfEffectSpell(AurSpellInfo) &&
-            caster && caster->GetObjectGuid() != GetObjectGuid())
-    {
-        caster->InterruptSpell(CURRENT_CHANNELED_SPELL);
-    }
-}
-
-void Unit::RemoveSingleAuraFromSpellAuraHolder(SpellAuraHolder* holder, SpellEffectIndex index, AuraRemoveMode mode)
-{
-    Aura* aura = holder->GetAuraByEffectIndex(index);
-    if (!aura)
-        return;
-
-    if (aura->IsLastAuraOnHolder())
-        RemoveSpellAuraHolder(holder, mode);
-    else
-        RemoveAura(aura, mode);
-}
-
-void Unit::RemoveAura(Aura* Aur, AuraRemoveMode mode)
-{
-    // remove from list before mods removing (prevent cyclic calls, mods added before including to aura list - use reverse order)
-    if (Aur->GetModifier()->m_auraname < TOTAL_AURAS)
-    {
-        m_modAuras[Aur->GetModifier()->m_auraname].remove(Aur);
-    }
-
-    // Set remove mode
-    Aur->SetRemoveMode(mode);
-
-    // some ShapeshiftBoosts at remove trigger removing other auras including parent Shapeshift aura
-    // remove aura from list before to prevent deleting it before
-    /// m_Auras.erase(i);
-
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Aura %u now is remove mode %d", Aur->GetModifier()->m_auraname, mode);
-
-    // aura _MUST_ be remove from holder before unapply.
-    // un-apply code expected that aura not find by diff searches
-    // in another case it can be double removed for example, if target die/etc in un-apply process.
-    Aur->GetHolder()->RemoveAura(Aur->GetEffIndex());
-
-    // some auras also need to apply modifier (on caster) on remove
-    if (mode == AURA_REMOVE_BY_DELETE)
-    {
-        switch (Aur->GetModifier()->m_auraname)
-        {
-            // need properly undo any auras with player-caster mover set (or will crash at next caster move packet)
-            case SPELL_AURA_MOD_POSSESS:
-            case SPELL_AURA_MOD_POSSESS_PET:
-                Aur->ApplyModifier(false, true);
-                break;
-            default: break;
-        }
-    }
-    else
-        Aur->ApplyModifier(false, true);
-
-    // If aura in use (removed from code that plan access to it data after return)
-    // store it in aura list with delayed deletion
-    if (Aur->IsInUse())
-        m_deletedAuras.push_back(Aur);
-    else
-        delete Aur;
-}
-
-void Unit::RemoveAllAuras(AuraRemoveMode mode /*= AURA_REMOVE_BY_DEFAULT*/)
-{
-    while (!m_spellAuraHolders.empty())
-    {
-        SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin();
-        RemoveSpellAuraHolder(iter->second, mode);
-    }
-}
-
-void Unit::RemoveArenaAuras(bool onleave)
-{
-    // in join, remove positive buffs, on end, remove negative
-    // used to remove positive visible auras in arenas
-    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
-    {
-        if (!iter->second->GetSpellProto()->HasAttribute(SPELL_ATTR_EX4_UNK21) &&
-                // don't remove stances, shadowform, pally/hunter auras
-                !iter->second->IsPassive() &&               // don't remove passive auras
-                (!iter->second->GetSpellProto()->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY) ||
-                 !iter->second->GetSpellProto()->HasAttribute(SPELL_ATTR_HIDE_IN_COMBAT_LOG)) &&
-                // not unaffected by invulnerability auras or not having that unknown flag (that seemed the most probable)
-                (iter->second->IsPositive() != onleave))    // remove positive buffs on enter, negative buffs on leave
-        {
-            RemoveSpellAuraHolder(iter->second);
-            iter = m_spellAuraHolders.begin();
-        }
-        else
-            ++iter;
-    }
-}
-
-void Unit::RemoveAllAurasOnDeath()
-{
-    // used just after dieing to remove all visible auras
-    // and disable the mods for the passive ones
-    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
-    {
-        if (!iter->second->IsPassive() && !iter->second->IsDeathPersistent())
-        {
-            RemoveSpellAuraHolder(iter->second, AURA_REMOVE_BY_DEATH);
-            iter = m_spellAuraHolders.begin();
-        }
-        else
-            ++iter;
-    }
-}
-
-void Unit::RemoveAllAurasOnEvade()
-{
-    // used when evading to remove all auras except some special auras
-    // Fly should not be removed on evade - neither should linked auras
-    for (SpellAuraHolderMap::iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end();)
-    {
-        SpellEntry const* proto = iter->second->GetSpellProto();
-        if (!IsSpellHaveAura(proto, SPELL_AURA_FLY))
-        {
-            RemoveSpellAuraHolder(iter->second, AURA_REMOVE_BY_DEFAULT);
-            iter = m_spellAuraHolders.begin();
-        }
-        else
-            ++iter;
-    }
-}
-
-void Unit::DelaySpellAuraHolder(uint32 spellId, int32 delaytime, ObjectGuid casterGuid)
-{
-    SpellAuraHolderBounds bounds = GetSpellAuraHolderBounds(spellId);
-    for (SpellAuraHolderMap::iterator iter = bounds.first; iter != bounds.second; ++iter)
-    {
-        SpellAuraHolder* holder = iter->second;
-
-        if (casterGuid != holder->GetCasterGuid())
-            continue;
-
-        if (holder->GetAuraDuration() < delaytime)
-            holder->SetAuraDuration(0);
-        else
-            holder->SetAuraDuration(holder->GetAuraDuration() - delaytime);
-
-        holder->UpdateAuraDuration();
-
-        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell %u partially interrupted on %s, new duration: %u ms", spellId, GetGuidStr().c_str(), holder->GetAuraDuration());
-    }
-}
-
-void Unit::_RemoveAllAuraMods()
-{
-    for (SpellAuraHolderMap::const_iterator i = m_spellAuraHolders.begin(); i != m_spellAuraHolders.end(); ++i)
-    {
-        (*i).second->ApplyAuraModifiers(false);
-    }
-}
-
-void Unit::_ApplyAllAuraMods()
-{
-    for (SpellAuraHolderMap::const_iterator i = m_spellAuraHolders.begin(); i != m_spellAuraHolders.end(); ++i)
-    {
-        (*i).second->ApplyAuraModifiers(true);
-    }
-}
-
-bool Unit::HasAuraType(AuraType auraType) const
-{
-    return !GetAurasByType(auraType).empty();
-}
-
-bool Unit::HasAffectedAura(AuraType auraType, SpellEntry const* spellProto) const
-{
-    Unit::AuraList const& auras = GetAurasByType(auraType);
-
-    for (Unit::AuraList::const_iterator itr = auras.begin(); itr != auras.end(); ++itr)
-    {
-        if ((*itr)->isAffectedOnSpell(spellProto))
-            return true;
-    }
-
-    return false;
-}
-
-Aura* Unit::GetAura(uint32 spellId, SpellEffectIndex effindex)
-{
-    SpellAuraHolderBounds bounds = GetSpellAuraHolderBounds(spellId);
-    if (bounds.first != bounds.second)
-        return bounds.first->second->GetAuraByEffectIndex(effindex);
-    return nullptr;
-}
-
-Aura* Unit::GetAura(AuraType type, SpellFamily family, uint64 familyFlag, ObjectGuid casterGuid)
-{
-    AuraList const& auras = GetAurasByType(type);
-    for (AuraList::const_iterator i = auras.begin(); i != auras.end(); ++i)
-        if ((*i)->GetSpellProto()->IsFitToFamily(family, familyFlag) &&
-                (!casterGuid || (*i)->GetCasterGuid() == casterGuid))
-            return *i;
-
-    return nullptr;
-}
-
-bool Unit::HasAura(uint32 spellId, SpellEffectIndex effIndex) const
-{
-    SpellAuraHolderConstBounds spair = GetSpellAuraHolderBounds(spellId);
-    for (SpellAuraHolderMap::const_iterator i_holder = spair.first; i_holder != spair.second; ++i_holder)
-        if (i_holder->second->GetAuraByEffectIndex(effIndex))
-            return true;
-
-    return false;
-}
-
-void Unit::AddDynObject(DynamicObject* dynObj)
-{
-    m_dynObjGUIDs.push_back(dynObj->GetObjectGuid());
-}
-
-void Unit::RemoveDynObject(uint32 spellid)
-{
-    if (m_dynObjGUIDs.empty())
-        return;
-    for (GuidList::iterator i = m_dynObjGUIDs.begin(); i != m_dynObjGUIDs.end();)
-    {
-        DynamicObject* dynObj = GetMap()->GetDynamicObject(*i);
-        if (!dynObj)
-        {
-            i = m_dynObjGUIDs.erase(i);
-        }
-        else if (spellid == 0 || dynObj->GetSpellId() == spellid)
-        {
-            dynObj->Delete();
-            i = m_dynObjGUIDs.erase(i);
-        }
-        else
-            ++i;
-    }
-}
-
-void Unit::RemoveAllDynObjects()
-{
-    while (!m_dynObjGUIDs.empty())
-    {
-        if (DynamicObject* dynObj = GetMap()->GetDynamicObject(*m_dynObjGUIDs.begin()))
-            dynObj->Delete();
-        m_dynObjGUIDs.erase(m_dynObjGUIDs.begin());
-    }
-}
-
-DynamicObject* Unit::GetDynObject(uint32 spellId, SpellEffectIndex effIndex)
-{
-    for (GuidList::iterator i = m_dynObjGUIDs.begin(); i != m_dynObjGUIDs.end();)
-    {
-        DynamicObject* dynObj = GetMap()->GetDynamicObject(*i);
-        if (!dynObj)
-        {
-            i = m_dynObjGUIDs.erase(i);
-            continue;
-        }
-
-        if (dynObj->GetSpellId() == spellId && dynObj->GetEffIndex() == effIndex)
-            return dynObj;
-        ++i;
-    }
-    return nullptr;
-}
-
-DynamicObject* Unit::GetDynObject(uint32 spellId)
-{
-    for (GuidList::iterator i = m_dynObjGUIDs.begin(); i != m_dynObjGUIDs.end();)
-    {
-        DynamicObject* dynObj = GetMap()->GetDynamicObject(*i);
-        if (!dynObj)
-        {
-            i = m_dynObjGUIDs.erase(i);
-            continue;
-        }
-
-        if (dynObj->GetSpellId() == spellId)
-            return dynObj;
-        ++i;
-    }
-    return nullptr;
-}
-
-GameObject* Unit::GetGameObject(uint32 spellId) const
-{
-    for (GameObjectList::const_iterator i = m_gameObj.begin(); i != m_gameObj.end(); ++i)
-        if ((*i)->GetSpellId() == spellId)
-            return *i;
-
-    WildGameObjectMap::const_iterator find = m_wildGameObjs.find(spellId);
-    if (find != m_wildGameObjs.end())
-        return GetMap()->GetGameObject(find->second);       // Can be nullptr
-
-    return nullptr;
-}
-
-void Unit::AddGameObject(GameObject* gameObj)
-{
-    MANGOS_ASSERT(gameObj && !gameObj->GetOwnerGuid());
-    m_gameObj.push_back(gameObj);
-    gameObj->SetOwnerGuid(GetObjectGuid());
-
-    if (GetTypeId() == TYPEID_PLAYER && gameObj->GetSpellId())
-    {
-        SpellEntry const* createBySpell = sSpellTemplate.LookupEntry<SpellEntry>(gameObj->GetSpellId());
-        // Need disable spell use for owner
-        if (createBySpell && createBySpell->HasAttribute(SPELL_ATTR_DISABLED_WHILE_ACTIVE))
-            // note: item based cooldowns and cooldown spell mods with charges ignored (unknown existing cases)
-            ((Player*)this)->AddSpellAndCategoryCooldowns(createBySpell, 0, nullptr, true);
-    }
-}
-
-void Unit::AddWildGameObject(GameObject* gameObj)
-{
-    MANGOS_ASSERT(gameObj && gameObj->GetOwnerGuid().IsEmpty());
-    m_wildGameObjs[gameObj->GetSpellId()] = gameObj->GetObjectGuid();
-
-    // As of 335 there are no wild-summon spells with SPELL_ATTR_DISABLED_WHILE_ACTIVE
-
-    // Remove outdated wild summoned GOs
-    for (WildGameObjectMap::iterator itr = m_wildGameObjs.begin(); itr != m_wildGameObjs.end();)
-    {
-        GameObject* pGo = GetMap()->GetGameObject(itr->second);
-        if (pGo)
-            ++itr;
-        else
-            m_wildGameObjs.erase(itr++);
-    }
-}
-
-void Unit::RemoveGameObject(GameObject* gameObj, bool del)
-{
-    MANGOS_ASSERT(gameObj && gameObj->GetOwnerGuid() == GetObjectGuid());
-
-    gameObj->SetOwnerGuid(ObjectGuid());
-
-    // GO created by some spell
-    if (uint32 spellid = gameObj->GetSpellId())
-    {
-        RemoveAurasDueToSpell(spellid);
-
-        if (GetTypeId() == TYPEID_PLAYER)
-        {
-            SpellEntry const* createBySpell = sSpellTemplate.LookupEntry<SpellEntry>(spellid);
-            // Need activate spell use for owner
-            if (createBySpell && createBySpell->HasAttribute(SPELL_ATTR_DISABLED_WHILE_ACTIVE))
-                // note: item based cooldowns and cooldown spell mods with charges ignored (unknown existing cases)
-                ((Player*)this)->SendCooldownEvent(createBySpell);
-        }
-    }
-
-    m_gameObj.remove(gameObj);
-
-    if (del)
-    {
-        gameObj->SetRespawnTime(0);
-        gameObj->Delete();
-    }
-}
-
-void Unit::RemoveGameObject(uint32 spellid, bool del)
-{
-    if (m_gameObj.empty())
-        return;
-
-    GameObjectList::iterator i, next;
-    for (i = m_gameObj.begin(); i != m_gameObj.end(); i = next)
-    {
-        next = i;
-        if (spellid == 0 || (*i)->GetSpellId() == spellid)
-        {
-            (*i)->SetOwnerGuid(ObjectGuid());
-            if (del)
-            {
-                (*i)->SetRespawnTime(0);
-                (*i)->Delete();
-            }
-
-            next = m_gameObj.erase(i);
-        }
-        else
-            ++next;
-    }
-}
-
-void Unit::RemoveAllGameObjects()
-{
-    // remove references to unit
-    for (GameObjectList::iterator i = m_gameObj.begin(); i != m_gameObj.end();)
-    {
-        (*i)->SetOwnerGuid(ObjectGuid());
-        (*i)->SetRespawnTime(0);
-        (*i)->Delete();
-        i = m_gameObj.erase(i);
-    }
-
-    // wild summoned GOs - only remove references, do not remove GOs
-    m_wildGameObjs.clear();
-}
-
-void Unit::SendSpellNonMeleeDamageLog(SpellNonMeleeDamage* log) const
-{
-    WorldPacket data(SMSG_SPELLNONMELEEDAMAGELOG, (16 + 4 + 4 + 1 + 4 + 4 + 1 + 1 + 4 + 4 + 1)); // we guess size
-    data << log->target->GetPackGUID();
-    data << log->attacker->GetPackGUID();
-    data << uint32(log->SpellID);
-    data << uint32(log->damage);                            // damage amount
-    data << uint8(log->schoolMask);                         // damage school
-    data << uint32(log->absorb);                            // AbsorbedDamage
-    data << uint32(log->resist);                            // resist
-    data << uint8(log->physicalLog);                        // if 1, then client show spell name (example: %s's ranged shot hit %s for %u school or %s suffers %u school damage from %s's spell_name
-    data << uint8(log->unused);                             // unused
-    data << uint32(log->blocked);                           // blocked
-    data << uint32(log->HitInfo);
-    data << uint8(0);                                       // flag to use extend data
-    SendMessageToSet(data, true);
-}
-
-void Unit::SendSpellNonMeleeDamageLog(Unit* target, uint32 SpellID, uint32 Damage, SpellSchoolMask damageSchoolMask, uint32 AbsorbedDamage, uint32 Resist, bool PhysicalDamage, uint32 Blocked, bool CriticalHit)
-{
-    SpellNonMeleeDamage log(this, target, SpellID, damageSchoolMask);
-    log.damage = Damage - AbsorbedDamage - Resist - Blocked;
-    log.absorb = AbsorbedDamage;
-    log.resist = Resist;
-    log.physicalLog = PhysicalDamage;
-    log.blocked = Blocked;
-    log.HitInfo = SPELL_HIT_TYPE_UNK1 | SPELL_HIT_TYPE_UNK3 | SPELL_HIT_TYPE_UNK6;
-    if (CriticalHit)
-        log.HitInfo |= SPELL_HIT_TYPE_CRIT;
-    SendSpellNonMeleeDamageLog(&log);
-}
-
-void Unit::SendPeriodicAuraLog(SpellPeriodicAuraLogInfo* pInfo) const
-{
-    Aura* aura = pInfo->aura;
-    Modifier* mod = aura->GetModifier();
-
-    WorldPacket data(SMSG_PERIODICAURALOG, 30);
-    data << aura->GetTarget()->GetPackGUID();
-    data << aura->GetCasterGuid().WriteAsPacked();
-    data << uint32(aura->GetId());                          // spellId
-    data << uint32(1);                                      // count
-    data << uint32(mod->m_auraname);                        // auraId
-    switch (mod->m_auraname)
-    {
-        case SPELL_AURA_PERIODIC_DAMAGE:
-        case SPELL_AURA_PERIODIC_DAMAGE_PERCENT:
-            data << uint32(pInfo->damage);                  // damage
-            data << uint32(GetSpellSchoolMask(aura->GetSpellProto()));
-            data << uint32(pInfo->absorb);                  // absorb
-            data << uint32(pInfo->resist);                  // resist
+        case 4537:                                          // Dreamwalker Raiment 6 pieces bonus
+            triggered_spell_id = 28750;                     // Blessing of the Claw
             break;
-        case SPELL_AURA_PERIODIC_HEAL:
-        case SPELL_AURA_OBS_MOD_HEALTH:
-            data << uint32(pInfo->damage);                  // damage
+        case 5497:                                          // Improved Mana Gems (Serpent-Coil Braid)
+            triggered_spell_id = 37445;                     // Mana Surge
             break;
-        case SPELL_AURA_OBS_MOD_MANA:
-        case SPELL_AURA_PERIODIC_ENERGIZE:
-            data << uint32(mod->m_miscvalue);               // power type
-            data << uint32(pInfo->damage);                  // damage
-            break;
-        case SPELL_AURA_PERIODIC_MANA_LEECH:
-            data << uint32(mod->m_miscvalue);               // power type
-            data << uint32(pInfo->damage);                  // amount
-            data << float(pInfo->multiplier);               // gain multiplier
-            break;
-        default:
-            sLog.outError("Unit::SendPeriodicAuraLog: unknown aura %u", uint32(mod->m_auraname));
-            return;
     }
 
-    aura->GetTarget()->SendMessageToSet(data, true);
-}
+    // not processed
+    if (!triggered_spell_id)
+        return SPELL_AURA_PROC_OK;
 
-void Unit::ProcDamageAndSpell(Unit* pVictim, uint32 procAttacker, uint32 procVictim, uint32 procExtra, uint32 amount, WeaponAttackType attType, SpellEntry const* procSpell)
-{
-    // Not much to do if no flags are set.
-    if (procAttacker)
-        ProcDamageAndSpellFor(false, pVictim, procAttacker, procExtra, attType, procSpell, amount);
-    // Now go on with a victim's events'n'auras
-    // Not much to do if no flags are set or there is no victim
-    if (pVictim && pVictim->isAlive() && procVictim)
-        pVictim->ProcDamageAndSpellFor(true, this, procVictim, procExtra, attType, procSpell, amount);
-}
+    // standard non-dummy case
+    SpellEntry const* triggerEntry = sSpellTemplate.LookupEntry<SpellEntry>(triggered_spell_id);
 
-void Unit::SendSpellMiss(Unit* target, uint32 spellID, SpellMissInfo missInfo) const
-{
-    WorldPacket data(SMSG_SPELLLOGMISS, (4 + 8 + 1 + 4 + 8 + 1));
-    data << uint32(spellID);
-    data << GetObjectGuid();
-    data << uint8(0);                                       // can be 0 or 1
-    data << uint32(1);                                      // target count
-    // for(i = 0; i < target count; ++i)
-    data << target->GetObjectGuid();                        // target GUID
-    data << uint8(missInfo);
-    // end loop
-    SendMessageToSet(data, true);
-}
-
-void Unit::SendAttackStateUpdate(CalcDamageInfo* damageInfo) const
-{
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "WORLD: Sending SMSG_ATTACKERSTATEUPDATE");
-
-    WorldPacket data(SMSG_ATTACKERSTATEUPDATE, (16 + 84));  // we guess size
-    data << (uint32)damageInfo->HitInfo;
-    data << GetPackGUID();
-    data << damageInfo->target->GetPackGUID();
-    data << uint32(damageInfo->damage);                     // Full damage
-
-    data << uint8(1);                                       // Sub damage count
-    //===  Sub damage description
-    data << uint32(damageInfo->damageSchoolMask);           // School of sub damage
-    data << float(damageInfo->damage);                      // sub damage
-    data << uint32(damageInfo->damage);                     // Sub Damage
-    data << uint32(damageInfo->absorb);                     // Absorb
-    data << uint32(damageInfo->resist);                     // Resist
-    //=================================================
-    data << uint32(damageInfo->TargetState);
-    data << uint32(0);                                      // unknown, usually seen with -1, 0 and 1000
-    data << uint32(0);                                      // spell id, seen with heroic strike and disarm as examples.
-    // HITINFO_NOACTION normally set if spell
-    data << uint32(damageInfo->blocked_amount);
-    SendMessageToSet(data, true);  /**/
-}
-
-void Unit::SendAttackStateUpdate(uint32 HitInfo, Unit* target, SpellSchoolMask damageSchoolMask, uint32 Damage, uint32 AbsorbDamage, uint32 Resist, VictimState TargetState, uint32 BlockedAmount)
-{
-    CalcDamageInfo dmgInfo;
-    dmgInfo.HitInfo = HitInfo;
-    dmgInfo.attacker = this;
-    dmgInfo.target = target;
-    dmgInfo.damage = Damage - AbsorbDamage - Resist - BlockedAmount;
-    dmgInfo.damageSchoolMask = damageSchoolMask;
-    dmgInfo.absorb = AbsorbDamage;
-    dmgInfo.resist = Resist;
-    dmgInfo.TargetState = TargetState;
-    dmgInfo.blocked_amount = BlockedAmount;
-    SendAttackStateUpdate(&dmgInfo);
-}
-
-void Unit::SetPowerType(Powers new_powertype)
-{
-    // set power type
-    SetByteValue(UNIT_FIELD_BYTES_0, 3, new_powertype);
-
-    // group updates
-    if (GetTypeId() == TYPEID_PLAYER)
+    if (!triggerEntry)
     {
-        if (((Player*)this)->GetGroup())
-            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_POWER_TYPE);
+        sLog.outError("Unit::HandleOverrideClassScriptAuraProc: Spell %u triggering for class script id %u", triggered_spell_id, scriptId);
+        return SPELL_AURA_PROC_FAILED;
     }
-    else if (((Creature*)this)->IsPet())
+
+    if (cooldown && GetTypeId() == TYPEID_PLAYER && ((Player*)this)->HasSpellCooldown(triggered_spell_id))
+        return SPELL_AURA_PROC_FAILED;
+
+    CastSpell(pVictim, triggered_spell_id, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
+
+    if (cooldown && GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->AddSpellCooldown(triggered_spell_id, 0, time(nullptr) + cooldown);
+
+    return SPELL_AURA_PROC_OK;
+}
+
+SpellAuraProcResult Unit::HandleMendingAuraProc(Unit* /*pVictim*/, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
+{
+    // aura can be deleted at casts
+    SpellEntry const* spellProto = triggeredByAura->GetSpellProto();
+    SpellEffectIndex effIdx = triggeredByAura->GetEffIndex();
+    int32 heal = triggeredByAura->GetModifier()->m_amount;
+    ObjectGuid caster_guid = triggeredByAura->GetCasterGuid();
+
+    // jumps
+    int32 jumps = triggeredByAura->GetHolder()->GetAuraCharges() - 1;
+
+    // current aura expire
+    triggeredByAura->GetHolder()->SetAuraCharges(1);        // will removed at next charges decrease
+
+    // next target selection
+    if (jumps > 0 && GetTypeId() == TYPEID_PLAYER && caster_guid.IsPlayer())
     {
-        Pet* pet = ((Pet*)this);
-        if (pet->isControlled())
+        float radius;
+        if (spellProto->EffectRadiusIndex[effIdx])
+            radius = GetSpellRadius(sSpellRadiusStore.LookupEntry(spellProto->EffectRadiusIndex[effIdx]));
+        else
+            radius = GetSpellMaxRange(sSpellRangeStore.LookupEntry(spellProto->rangeIndex));
+
+        if (Player* caster = ((Player*)triggeredByAura->GetCaster()))
         {
-            Unit* owner = GetOwner();
-            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
-                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_POWER_TYPE);
-        }
-    }
+            caster->ApplySpellMod(spellProto->Id, SPELLMOD_RADIUS, radius, nullptr);
 
-    // special cases for power type switching (druid and pets only)
-    if (GetTypeId() == TYPEID_PLAYER || (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsPet()))
-    {
-        uint32 maxValue = GetCreatePowers(new_powertype);
-        uint32 curValue = maxValue;
-
-        // special cases with current power = 0
-        if (new_powertype == POWER_RAGE)
-            curValue = 0;
-
-        // set power (except for mana)
-        if (new_powertype != POWER_MANA)
-        {
-            SetMaxPower(new_powertype, maxValue);
-            SetPower(new_powertype, curValue);
-        }
-    }
-}
-
-FactionTemplateEntry const* Unit::getFactionTemplateEntry() const
-{
-    FactionTemplateEntry const* entry = sFactionTemplateStore.LookupEntry(getFaction());
-    if (!entry)
-    {
-        static ObjectGuid guid;                             // prevent repeating spam same faction problem
-
-        if (GetObjectGuid() != guid)
-        {
-            guid = GetObjectGuid();
-
-            if (guid.GetHigh() == HIGHGUID_PET)
-                sLog.outError("%s (base creature entry %u) have invalid faction template id %u, owner %s", GetGuidStr().c_str(), GetEntry(), getFaction(), ((Pet*)this)->GetOwnerGuid().GetString().c_str());
-            else
-                sLog.outError("%s have invalid faction template id %u", GetGuidStr().c_str(), getFaction());
-        }
-    }
-    return entry;
-}
-
-bool Unit::IsHostileTo(Unit const* unit) const
-{
-    // always non-hostile to self
-    if (unit == this)
-        return false;
-
-    // always non-hostile to GM in GM mode
-    if (unit->GetTypeId() == TYPEID_PLAYER && ((Player const*)unit)->isGameMaster())
-        return false;
-
-    // always hostile to enemy
-    if (getVictim() == unit || unit->getVictim() == this)
-        return true;
-
-    // test pet/charm masters instead pers/charmeds
-    Unit const* testerOwner = GetCharmerOrOwner();
-    Unit const* targetOwner = unit->GetCharmerOrOwner();
-
-    // always hostile to owner's enemy
-    if (testerOwner && (testerOwner->getVictim() == unit || unit->getVictim() == testerOwner))
-        return true;
-
-    // always hostile to enemy owner
-    if (targetOwner && (getVictim() == targetOwner || targetOwner->getVictim() == this))
-        return true;
-
-    // always hostile to owner of owner's enemy
-    if (testerOwner && targetOwner && (testerOwner->getVictim() == targetOwner || targetOwner->getVictim() == testerOwner))
-        return true;
-
-    Unit const* tester = testerOwner ? testerOwner : this;
-    Unit const* target = targetOwner ? targetOwner : unit;
-
-    // always non-hostile to target with common owner, or to owner/pet
-    if (tester == target)
-        return false;
-
-    // special cases (Duel, etc)
-    if (tester->GetTypeId() == TYPEID_PLAYER && target->GetTypeId() == TYPEID_PLAYER)
-    {
-        Player const* pTester = (Player const*)tester;
-        Player const* pTarget = (Player const*)target;
-
-        // Duel
-        if (pTester->IsInDuelWith(pTarget))
-            return true;
-
-        // Group
-        if (pTester->GetGroup() && pTester->GetGroup() == pTarget->GetGroup())
-            return false;
-
-        // Sanctuary
-        if (pTarget->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_SANCTUARY) && pTester->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_SANCTUARY))
-            return false;
-
-        // PvP FFA state
-        if (pTester->IsFFAPvP() && pTarget->IsFFAPvP())
-            return true;
-
-        //= PvP states
-        // Green/Blue (can't attack)
-        if (pTester->GetTeam() == pTarget->GetTeam())
-            return false;
-
-        // Red (can attack) if true, Blue/Yellow (can't attack) in another case
-        return pTester->IsPvP() && pTarget->IsPvP();
-    }
-
-    // faction base cases
-    FactionTemplateEntry const* tester_faction = tester->getFactionTemplateEntry();
-    FactionTemplateEntry const* target_faction = target->getFactionTemplateEntry();
-    if (!tester_faction || !target_faction)
-        return false;
-
-    if (target->isAttackingPlayer() && tester->IsContestedGuard())
-        return true;
-
-    // PvC forced reaction and reputation case
-    if (tester->GetTypeId() == TYPEID_PLAYER)
-    {
-        if (target_faction->faction)
-        {
-            // forced reaction
-            if (ReputationRank const* force = ((Player*)tester)->GetReputationMgr().GetForcedRankIfAny(target_faction))
-                return *force <= REP_HOSTILE;
-
-            // if faction have reputation then hostile state for tester at 100% dependent from at_war state
-            if (FactionEntry const* raw_target_faction = sFactionStore.LookupEntry(target_faction->faction))
-                if (FactionState const* factionState = ((Player*)tester)->GetReputationMgr().GetState(raw_target_faction))
-                    return !!(factionState->Flags & FACTION_FLAG_AT_WAR);
-        }
-    }
-    // CvP forced reaction and reputation case
-    else if (target->GetTypeId() == TYPEID_PLAYER)
-    {
-        if (tester_faction->faction)
-        {
-            // forced reaction
-            if (ReputationRank const* force = ((Player*)target)->GetReputationMgr().GetForcedRankIfAny(tester_faction))
-                return *force <= REP_HOSTILE;
-
-            // apply reputation state
-            FactionEntry const* raw_tester_faction = sFactionStore.LookupEntry(tester_faction->faction);
-            if (raw_tester_faction && raw_tester_faction->reputationListID >= 0)
-                return ((Player const*)target)->GetReputationMgr().GetRank(raw_tester_faction) <= REP_HOSTILE;
-        }
-    }
-
-    // common faction based case (CvC,PvC,CvP)
-    return tester_faction->IsHostileTo(*target_faction);
-}
-
-bool Unit::IsFriendlyTo(Unit const* unit) const
-{
-    // always friendly to self
-    if (unit == this)
-        return true;
-
-    // always friendly to GM in GM mode
-    if (unit->GetTypeId() == TYPEID_PLAYER && ((Player const*)unit)->isGameMaster())
-        return true;
-
-    // always non-friendly to enemy
-    if (getVictim() == unit || unit->getVictim() == this)
-        return false;
-
-    // test pet/charm masters instead pers/charmeds
-    Unit const* testerOwner = GetCharmerOrOwner();
-    Unit const* targetOwner = unit->GetCharmerOrOwner();
-
-    // always non-friendly to owner's enemy
-    if (testerOwner && (testerOwner->getVictim() == unit || unit->getVictim() == testerOwner))
-        return false;
-
-    // always non-friendly to enemy owner
-    if (targetOwner && (getVictim() == targetOwner || targetOwner->getVictim() == this))
-        return false;
-
-    // always non-friendly to owner of owner's enemy
-    if (testerOwner && targetOwner && (testerOwner->getVictim() == targetOwner || targetOwner->getVictim() == testerOwner))
-        return false;
-
-    Unit const* tester = testerOwner ? testerOwner : this;
-    Unit const* target = targetOwner ? targetOwner : unit;
-
-    // always friendly to target with common owner, or to owner/pet
-    if (tester == target)
-        return true;
-
-    // special cases (Duel)
-    if (tester->GetTypeId() == TYPEID_PLAYER && target->GetTypeId() == TYPEID_PLAYER)
-    {
-        Player const* pTester = (Player const*)tester;
-        Player const* pTarget = (Player const*)target;
-
-        // Duel
-        if (pTester->IsInDuelWith(pTarget))
-            return false;
-
-        // Group
-        if (pTester->GetGroup() && pTester->GetGroup() == pTarget->GetGroup())
-            return true;
-
-        // Sanctuary
-        if (pTarget->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_SANCTUARY) && pTester->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_SANCTUARY))
-            return true;
-
-        // PvP FFA state
-        if (pTester->IsFFAPvP() && pTarget->IsFFAPvP())
-            return false;
-
-        //= PvP states
-        // Green/Blue (non-attackable)
-        if (pTester->GetTeam() == pTarget->GetTeam())
-            return true;
-
-        // Blue (friendly/non-attackable) if not PVP, or Yellow/Red in another case (attackable)
-        return !pTarget->IsPvP();
-    }
-
-    // faction base cases
-    FactionTemplateEntry const* tester_faction = tester->getFactionTemplateEntry();
-    FactionTemplateEntry const* target_faction = target->getFactionTemplateEntry();
-    if (!tester_faction || !target_faction)
-        return false;
-
-    if (target->isAttackingPlayer() && tester->IsContestedGuard())
-        return false;
-
-    // PvC forced reaction and reputation case
-    if (tester->GetTypeId() == TYPEID_PLAYER)
-    {
-        if (target_faction->faction)
-        {
-            // forced reaction
-            if (ReputationRank const* force = ((Player*)tester)->GetReputationMgr().GetForcedRankIfAny(target_faction))
-                return *force >= REP_FRIENDLY;
-
-            // if faction have reputation then friendly state for tester at 100% dependent from at_war state
-            if (FactionEntry const* raw_target_faction = sFactionStore.LookupEntry(target_faction->faction))
-                if (FactionState const* factionState = ((Player*)tester)->GetReputationMgr().GetState(raw_target_faction))
-                    return !(factionState->Flags & FACTION_FLAG_AT_WAR);
-        }
-    }
-    // CvP forced reaction and reputation case
-    else if (target->GetTypeId() == TYPEID_PLAYER)
-    {
-        if (tester_faction->faction)
-        {
-            // forced reaction
-            if (ReputationRank const* force = ((Player*)target)->GetReputationMgr().GetForcedRankIfAny(tester_faction))
-                return *force >= REP_FRIENDLY;
-
-            // apply reputation state
-            if (FactionEntry const* raw_tester_faction = sFactionStore.LookupEntry(tester_faction->faction))
-                if (raw_tester_faction->reputationListID >= 0)
-                    return ((Player const*)target)->GetReputationMgr().GetRank(raw_tester_faction) >= REP_FRIENDLY;
-        }
-    }
-
-    // common faction based case (CvC,PvC,CvP)
-    return tester_faction->IsFriendlyTo(*target_faction);
-}
-
-bool Unit::IsHostileToPlayers() const
-{
-    FactionTemplateEntry const* my_faction = getFactionTemplateEntry();
-    if (!my_faction || !my_faction->faction)
-        return false;
-
-    FactionEntry const* raw_faction = sFactionStore.LookupEntry(my_faction->faction);
-    if (raw_faction && raw_faction->reputationListID >= 0)
-        return false;
-
-    return my_faction->IsHostileToPlayers();
-}
-
-bool Unit::IsNeutralToAll() const
-{
-    FactionTemplateEntry const* my_faction = getFactionTemplateEntry();
-    if (!my_faction || !my_faction->faction)
-        return true;
-
-    FactionEntry const* raw_faction = sFactionStore.LookupEntry(my_faction->faction);
-    if (raw_faction && raw_faction->reputationListID >= 0)
-        return false;
-
-    return my_faction->IsNeutralToAll();
-}
-
-bool Unit::Attack(Unit* victim, bool meleeAttack)
-{
-    if (!victim || victim == this)
-        return false;
-
-    // dead units can neither attack nor be attacked
-    if (!isAlive() || !victim->IsInWorld() || !victim->isAlive())
-        return false;
-
-    // player cannot attack in mount state
-    if (GetTypeId() == TYPEID_PLAYER && IsMounted())
-        return false;
-
-    // nobody can attack GM in GM-mode
-    if (victim->GetTypeId() == TYPEID_PLAYER)
-    {
-        if (((Player*)victim)->isGameMaster())
-            return false;
-    }
-    else
-    {
-        if (((Creature*)victim)->IsInEvadeMode())
-            return false;
-    }
-
-    // remove SPELL_AURA_MOD_UNATTACKABLE at attack (in case non-interruptible spells stun aura applied also that not let attack)
-    if (HasAuraType(SPELL_AURA_MOD_UNATTACKABLE))
-        RemoveSpellsCausingAura(SPELL_AURA_MOD_UNATTACKABLE);
-
-    // in fighting already
-    if (m_attacking)
-    {
-        if (m_attacking == victim)
-        {
-            // switch to melee attack from ranged/magic
-            if (meleeAttack)
+            if (Player* target = ((Player*)this)->GetNextRandomRaidMember(radius))
             {
-                if (!hasUnitState(UNIT_STAT_MELEE_ATTACKING))
-                {
-                    addUnitState(UNIT_STAT_MELEE_ATTACKING);
-                    SendMeleeAttackStart(victim);
-                }
-                return true;
-            }
-            return false;
-        }
-
-        // remove old target data
-        AttackStop(true);
-    }
-    // new battle
-    else
-    {
-        // set position before any AI calls/assistance
-        if (GetTypeId() == TYPEID_UNIT)
-            ((Creature*)this)->SetCombatStartPosition(GetPositionX(), GetPositionY(), GetPositionZ());
-    }
-
-    // Set our target
-    SetTargetGuid(victim->GetObjectGuid());
-
-    if (meleeAttack)
-        addUnitState(UNIT_STAT_MELEE_ATTACKING);
-
-    m_attacking = victim;
-    m_attacking->_addAttacker(this);
-
-    if (GetTypeId() == TYPEID_UNIT)
-    {
-        ((Creature*)this)->SendAIReaction(AI_REACTION_HOSTILE);
-        ((Creature*)this)->CallAssistance();
-    }
-
-    // delay offhand weapon attack to next attack time
-    if (haveOffhandWeapon())
-        resetAttackTimer(OFF_ATTACK);
-
-    if (meleeAttack)
-        SendMeleeAttackStart(victim);
-
-    return true;
-}
-
-void Unit::AttackedBy(Unit* attacker)
-{
-    // trigger AI reaction
-    if (AI())
-        AI()->AttackedBy(attacker);
-
-    // do not pet reaction for self inflicted damage (like environmental)
-    if (attacker == this)
-        return;
-
-    // trigger pet AI reaction
-    if (Pet* pet = GetPet())
-        pet->AttackedBy(attacker);
-}
-
-bool Unit::AttackStop(bool targetSwitch /*= false*/, bool includingCast /*= false*/)
-{
-    // interrupt cast only id includingCast == true and we have something to interrupt.
-    if (includingCast && IsNonMeleeSpellCasted(false))
-        InterruptNonMeleeSpells(false);
-
-    // Clear our target only if targetSwitch == true
-    if (targetSwitch)
-        SetTargetGuid(ObjectGuid());
-
-    clearUnitState(UNIT_STAT_MELEE_ATTACKING);
-
-    InterruptSpell(CURRENT_MELEE_SPELL);
-
-    if (m_attacking)
-    {
-        SendMeleeAttackStop(m_attacking);
-
-        m_attacking->_removeAttacker(this);
-        m_attacking = nullptr;
-        return true;
-    }
-    return false;
-}
-
-void Unit::CombatStop(bool includingCast)
-{
-    AttackStop(true, includingCast);
-    RemoveAllAttackers();
-
-    if (GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->SendAttackSwingCancelAttack();     // melee and ranged forced attack cancel
-    else
-    {
-        ((Creature*)this)->SetNoCallAssistance(false);
-
-        if (((Creature*)this)->HasSearchedAssistance())
-        {
-            ((Creature*)this)->SetNoSearchAssistance(false);
-            UpdateSpeed(MOVE_RUN, false);
-        }
-
-        if (((Creature*)this)->GetTemporaryFactionFlags() & TEMPFACTION_RESTORE_COMBAT_STOP)
-            ((Creature*)this)->ClearTemporaryFaction();
-    }
-
-    if (AI())
-        AI()->CombatStop();
-
-    ClearInCombat();
-}
-
-struct CombatStopWithPetsHelper
-{
-    explicit CombatStopWithPetsHelper(bool _includingCast) : includingCast(_includingCast) {}
-    void operator()(Unit* unit) const { unit->CombatStop(includingCast); }
-    bool includingCast;
-};
-
-void Unit::CombatStopWithPets(bool includingCast)
-{
-    CombatStop(includingCast);
-    CallForAllControlledUnits(CombatStopWithPetsHelper(includingCast), CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
-}
-
-struct IsAttackingPlayerHelper
-{
-    explicit IsAttackingPlayerHelper() {}
-    bool operator()(Unit const* unit) const { return unit->isAttackingPlayer(); }
-};
-
-bool Unit::isAttackingPlayer() const
-{
-    if (hasUnitState(UNIT_STAT_ATTACK_PLAYER))
-        return true;
-
-    return CheckAllControlledUnits(IsAttackingPlayerHelper(), CONTROLLED_PET | CONTROLLED_TOTEMS | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
-}
-
-void Unit::RemoveAllAttackers()
-{
-    while (!m_attackers.empty())
-    {
-        AttackerSet::iterator iter = m_attackers.begin();
-        (*iter)->AttackStop();
-
-        if (m_attacking)
-        {
-            sLog.outError("WORLD: Unit has an attacker that isn't attacking it!");
-            m_attackers.erase(iter);
-        }
-    }
-}
-
-bool Unit::HasAuraStateForCaster(AuraState flag, ObjectGuid casterGuid) const
-{
-    if (!HasAuraState(flag))
-        return false;
-
-    // single per-caster aura state
-    if (flag == AURA_STATE_CONFLAGRATE)
-    {
-        Unit::AuraList const& dotList = GetAurasByType(SPELL_AURA_PERIODIC_DAMAGE);
-        for (Unit::AuraList::const_iterator i = dotList.begin(); i != dotList.end(); ++i)
-        {
-            if ((*i)->GetCasterGuid() == casterGuid &&
-                    //  Immolate
-                    (*i)->GetSpellProto()->IsFitToFamily(SPELLFAMILY_WARLOCK, uint64(0x0000000000000004)))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    return true;
-}
-
-void Unit::ModifyAuraState(AuraState flag, bool apply)
-{
-    if (apply)
-    {
-        if (!HasFlag(UNIT_FIELD_AURASTATE, 1 << (flag - 1)))
-        {
-            SetFlag(UNIT_FIELD_AURASTATE, 1 << (flag - 1));
-            if (GetTypeId() == TYPEID_PLAYER)
-            {
-                const PlayerSpellMap& sp_list = ((Player*)this)->GetSpellMap();
-                for (PlayerSpellMap::const_iterator itr = sp_list.begin(); itr != sp_list.end(); ++itr)
-                {
-                    if (itr->second.state == PLAYERSPELL_REMOVED) continue;
-                    SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(itr->first);
-                    if (!spellInfo || !IsPassiveSpell(spellInfo)) continue;
-                    if (AuraState(spellInfo->CasterAuraState) == flag)
-                        CastSpell(this, itr->first, TRIGGERED_OLD_TRIGGERED, nullptr);
-                }
-            }
-        }
-    }
-    else
-    {
-        if (HasFlag(UNIT_FIELD_AURASTATE, 1 << (flag - 1)))
-        {
-            RemoveFlag(UNIT_FIELD_AURASTATE, 1 << (flag - 1));
-
-            Unit::SpellAuraHolderMap& tAuras = GetSpellAuraHolderMap();
-            for (Unit::SpellAuraHolderMap::iterator itr = tAuras.begin(); itr != tAuras.end();)
-            {
-                SpellEntry const* spellProto = (*itr).second->GetSpellProto();
-                if (spellProto->CasterAuraState == flag)
-                {
-                    // exceptions (applied at state but not removed at state change)
-                    // Rampage
-                    if (spellProto->SpellIconID == 2006 && spellProto->IsFitToFamilyMask(uint64(0x0000000000100000)))
-                    {
-                        ++itr;
-                        continue;
-                    }
-
-                    RemoveSpellAuraHolder(itr->second);
-                    itr = tAuras.begin();
-                }
-                else
-                    ++itr;
-            }
-        }
-    }
-}
-
-Unit* Unit::GetOwner() const
-{
-    if (ObjectGuid ownerid = GetOwnerGuid())
-        return ObjectAccessor::GetUnit(*this, ownerid);
-    return nullptr;
-}
-
-Unit* Unit::GetCharmer() const
-{
-    if (ObjectGuid charmerid = GetCharmerGuid())
-        return ObjectAccessor::GetUnit(*this, charmerid);
-    return nullptr;
-}
-
-bool Unit::IsCharmerOrOwnerPlayerOrPlayerItself() const
-{
-    if (GetTypeId() == TYPEID_PLAYER)
-        return true;
-
-    return GetCharmerOrOwnerGuid().IsPlayer();
-}
-
-Player* Unit::GetCharmerOrOwnerPlayerOrPlayerItself()
-{
-    ObjectGuid guid = GetCharmerOrOwnerGuid();
-    if (guid.IsPlayer())
-        return ObjectAccessor::FindPlayer(guid);
-
-    return GetTypeId() == TYPEID_PLAYER ? (Player*)this : nullptr;
-}
-
-Player const* Unit::GetCharmerOrOwnerPlayerOrPlayerItself() const
-{
-    ObjectGuid guid = GetCharmerOrOwnerGuid();
-    if (guid.IsPlayer())
-        return ObjectAccessor::FindPlayer(guid);
-
-    return GetTypeId() == TYPEID_PLAYER ? (Player const*)this : nullptr;
-}
-
-Pet* Unit::GetPet() const
-{
-    if (ObjectGuid pet_guid = GetPetGuid())
-    {
-        if (Pet* pet = GetMap()->GetPet(pet_guid))
-            return pet;
-
-        sLog.outError("Unit::GetPet: %s not exist.", pet_guid.GetString().c_str());
-        const_cast<Unit*>(this)->SetPet(nullptr);
-    }
-
-    return nullptr;
-}
-
-Pet* Unit::_GetPet(ObjectGuid guid) const
-{
-    return GetMap()->GetPet(guid);
-}
-
-Unit* Unit::GetCharm() const
-{
-    if (ObjectGuid charm_guid = GetCharmGuid())
-    {
-        if (Unit* pet = ObjectAccessor::GetUnit(*this, charm_guid))
-            return pet;
-
-        sLog.outError("Unit::GetCharm: Charmed %s not exist.", charm_guid.GetString().c_str());
-        const_cast<Unit*>(this)->SetCharm(nullptr);
-    }
-
-    return nullptr;
-}
-
-void Unit::Uncharm()
-{
-    if (Unit* charm = GetCharm())
-    {
-        charm->RemoveSpellsCausingAura(SPELL_AURA_MOD_CHARM);
-        charm->RemoveSpellsCausingAura(SPELL_AURA_MOD_POSSESS);
-        charm->RemoveSpellsCausingAura(SPELL_AURA_MOD_POSSESS_PET);
-    }
-}
-
-void Unit::SetPet(Pet* pet)
-{
-    SetPetGuid(pet ? pet->GetObjectGuid() : ObjectGuid());
-}
-
-void Unit::SetCharm(Unit* pet)
-{
-    SetCharmGuid(pet ? pet->GetObjectGuid() : ObjectGuid());
-}
-
-void Unit::AddGuardian(Pet* pet)
-{
-    m_guardianPets.insert(pet->GetObjectGuid());
-}
-
-void Unit::RemoveGuardian(Pet* pet)
-{
-    m_guardianPets.erase(pet->GetObjectGuid());
-}
-
-void Unit::RemoveGuardians()
-{
-    while (!m_guardianPets.empty())
-    {
-        ObjectGuid guid = *m_guardianPets.begin();
-
-        if (Pet* pet = GetMap()->GetPet(guid))
-            pet->Unsummon(PET_SAVE_AS_DELETED, this); // can remove pet guid from m_guardianPets
-
-        m_guardianPets.erase(guid);
-    }
-}
-
-Pet* Unit::FindGuardianWithEntry(uint32 entry)
-{
-    for (GuidSet::const_iterator itr = m_guardianPets.begin(); itr != m_guardianPets.end(); ++itr)
-        if (Pet* pet = GetMap()->GetPet(*itr))
-            if (pet->GetEntry() == entry)
-                return pet;
-
-    return nullptr;
-}
-
-Unit* Unit::_GetTotem(TotemSlot slot) const
-{
-    return GetTotem(slot);
-}
-
-Totem* Unit::GetTotem(TotemSlot slot) const
-{
-    if (!IsInWorld() || !m_TotemSlot[slot])
-        return nullptr;
-
-    Creature* totem = GetMap()->GetCreature(m_TotemSlot[slot]);
-    return totem && totem->IsTotem() ? (Totem*)totem : nullptr;
-}
-
-bool Unit::IsAllTotemSlotsUsed() const
-{
-    for (int i = 0; i < MAX_TOTEM_SLOT; ++i)
-        if (!m_TotemSlot[i])
-            return false;
-    return true;
-}
-
-void Unit::_AddTotem(TotemSlot slot, Totem* totem)
-{
-    m_TotemSlot[slot] = totem->GetObjectGuid();
-}
-
-void Unit::_RemoveTotem(Totem* totem)
-{
-    for (int i = 0; i < MAX_TOTEM_SLOT; ++i)
-    {
-        if (m_TotemSlot[i] == totem->GetObjectGuid())
-        {
-            m_TotemSlot[i].Clear();
-            break;
-        }
-    }
-}
-
-void Unit::UnsummonAllTotems() const
-{
-    for (int i = 0; i < MAX_TOTEM_SLOT; ++i)
-        if (Totem* totem = GetTotem(TotemSlot(i)))
-            totem->UnSummon();
-}
-
-int32 Unit::DealHeal(Unit* pVictim, uint32 addhealth, SpellEntry const* spellProto, bool critical)
-{
-    int32 gain = pVictim->ModifyHealth(int32(addhealth));
-
-    Unit* unit = this;
-
-    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem() && ((Totem*)this)->GetTotemType() != TOTEM_STATUE)
-        unit = GetOwner();
-
-    unit->SendHealSpellLog(pVictim, spellProto->Id, addhealth, critical);
-
-    if (unit->GetTypeId() == TYPEID_PLAYER)
-    {
-        if (BattleGround* bg = ((Player*)unit)->GetBattleGround())
-            bg->UpdatePlayerScore((Player*)unit, SCORE_HEALING_DONE, gain);
-    }
-
-    // Script Event HealedBy
-    if (pVictim->AI())
-        pVictim->AI()->HealedBy(this, addhealth);
-
-    return gain;
-}
-
-Unit* Unit::SelectMagnetTarget(Unit* victim, Spell* spell, SpellEffectIndex eff)
-{
-    if (!victim)
-        return nullptr;
-
-    // Magic case
-    if (spell && (spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_NONE || spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_MAGIC))
-    {
-        if (spell->m_spellInfo->HasAttribute(SPELL_ATTR_ABILITY) || spell->m_spellInfo->HasAttribute(SPELL_ATTR_EX_CANT_BE_REDIRECTED) || spell->m_spellInfo->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY))
-            return nullptr;
-
-        Unit::AuraList const& magnetAuras = victim->GetAurasByType(SPELL_AURA_SPELL_MAGNET);
-        for (Unit::AuraList::const_iterator itr = magnetAuras.begin(); itr != magnetAuras.end(); ++itr)
-        {
-            if (Unit* magnet = (*itr)->GetCaster())
-            {
-                if (magnet->isAlive() && magnet->IsWithinLOSInMap(this) && spell->CheckTarget(magnet, eff))
-                {
-                    if (SpellAuraHolder* holder = (*itr)->GetHolder())
-                        if (holder->DropAuraCharge())
-                            victim->RemoveSpellAuraHolder(holder);
-                    return magnet;
-                }
-            }
-        }
-    }
-    // Melee && ranged case
-    else
-    {
-        AuraList const& hitTriggerAuras = victim->GetAurasByType(SPELL_AURA_ADD_CASTER_HIT_TRIGGER);
-        for (AuraList::const_iterator i = hitTriggerAuras.begin(); i != hitTriggerAuras.end(); ++i)
-        {
-            if (Unit* magnet = (*i)->GetCaster())
-            {
-                if (magnet->isAlive() && magnet->IsWithinLOSInMap(this) && (!spell || spell->CheckTarget(magnet, eff)))
-                {
-                    if (roll_chance_i((*i)->GetModifier()->m_amount))
-                    {
-                        if (SpellAuraHolder* holder = (*i)->GetHolder())
-                            if (holder->DropAuraCharge())
-                                victim->RemoveSpellAuraHolder(holder);
-                        return magnet;
-                    }
-                }
+                // aura will applied from caster, but spell casted from current aura holder
+                SpellModifier* mod = new SpellModifier(SPELLMOD_CHARGES, SPELLMOD_FLAT, jumps - 5, spellProto->Id, spellProto->SpellFamilyFlags);
+
+                // remove before apply next (locked against deleted)
+                triggeredByAura->SetInUse(true);
+                RemoveAurasByCasterSpell(spellProto->Id, caster->GetObjectGuid());
+
+                caster->AddSpellMod(mod, true);
+                CastCustomSpell(target, spellProto->Id, &heal, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, nullptr, triggeredByAura, caster->GetObjectGuid());
+                caster->AddSpellMod(mod, false);
+                triggeredByAura->SetInUse(false);
             }
         }
     }
 
-    // No magnet Target found
-    return nullptr;
+    // heal
+    CastCustomSpell(this, 33110, &heal, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED, nullptr, nullptr, caster_guid);
+    return SPELL_AURA_PROC_OK;
 }
 
-void Unit::SendHealSpellLog(Unit* pVictim, uint32 SpellID, uint32 Damage, bool critical)
+SpellAuraProcResult Unit::HandleModCastingSpeedNotStackAuraProc(Unit* /*pVictim*/, uint32 /*damage*/, Aura* /*triggeredByAura*/, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
 {
-    // we guess size
-    WorldPacket data(SMSG_SPELLHEALLOG, (8 + 8 + 4 + 4 + 1));
-    data << pVictim->GetPackGUID();
-    data << GetPackGUID();
-    data << uint32(SpellID);
-    data << uint32(Damage);
-    data << uint8(critical ? 1 : 0);
-    data << uint8(0);                                       // unused in client?
-    SendMessageToSet(data, true);
+    // Skip melee hits or instant cast spells
+    return !(procSpell == nullptr || GetSpellCastTime(procSpell) == 0) ? SPELL_AURA_PROC_OK : SPELL_AURA_PROC_FAILED;
 }
 
-void Unit::SendEnergizeSpellLog(Unit* pVictim, uint32 SpellID, uint32 Damage, Powers powertype) const
+SpellAuraProcResult Unit::HandleReflectSpellsSchoolAuraProc(Unit* /*pVictim*/, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
 {
-    WorldPacket data(SMSG_SPELLENERGIZELOG, (8 + 8 + 4 + 4 + 4 + 1));
-    data << pVictim->GetPackGUID();
-    data << GetPackGUID();
-    data << uint32(SpellID);
-    data << uint32(powertype);
-    data << uint32(Damage);
-    SendMessageToSet(data, true);
+    // Skip Melee hits and spells ws wrong school
+    return !(procSpell == nullptr || (triggeredByAura->GetModifier()->m_miscvalue & procSpell->SchoolMask) == 0) ? SPELL_AURA_PROC_OK : SPELL_AURA_PROC_FAILED;
 }
 
-void Unit::EnergizeBySpell(Unit* pVictim, uint32 SpellID, uint32 Damage, Powers powertype)
+SpellAuraProcResult Unit::HandleModPowerCostSchoolAuraProc(Unit* /*pVictim*/, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
 {
-    SendEnergizeSpellLog(pVictim, SpellID, Damage, powertype);
-    // needs to be called after sending spell log
-    pVictim->ModifyPower(powertype, Damage);
+    // Skip melee hits and spells ws wrong school or zero cost
+    return !(procSpell == nullptr ||
+             (procSpell->manaCost == 0 && procSpell->ManaCostPercentage == 0) ||           // Cost check
+             (triggeredByAura->GetModifier()->m_miscvalue & procSpell->SchoolMask) == 0) ? SPELL_AURA_PROC_OK : SPELL_AURA_PROC_FAILED;  // School check
 }
 
-/** Calculate spell coefficents and level penalties for spell/melee damage or heal
- *
- * this is the caster of the spell/ melee attacker
- * @param spellProto SpellEntry of the used spell
- * @param total current value onto which the Bonus and level penalty will be calculated
- * @param benefit additional benefit from ie spellpower-auras
- * @param ap_benefit additional melee attackpower benefit from auras
- * @param damagetype what kind of damage
- * @param donePart calculate for done or taken
- */
-int32 Unit::SpellBonusWithCoeffs(SpellEntry const* spellProto, int32 total, int32 benefit, int32 ap_benefit,  DamageEffectType damagetype, bool donePart)
+SpellAuraProcResult Unit::HandleMechanicImmuneResistanceAuraProc(Unit* /*pVictim*/, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
 {
-    // Distribute Damage over multiple effects, reduce by AoE
-    float coeff = 1.0f;
+    // Compare mechanic
+    return !(procSpell == nullptr || procSpell->Mechanic != triggeredByAura->GetModifier()->m_miscvalue)
+           ? SPELL_AURA_PROC_OK : SPELL_AURA_PROC_FAILED;
+}
 
-    // Not apply this to creature casted spells
-    if (GetTypeId() == TYPEID_UNIT && !((Creature*)this)->IsPet())
-        coeff = 1.0f;
-    // Check for table values
-    else if (SpellBonusEntry const* bonus = sSpellMgr.GetSpellBonusData(spellProto->Id))
-    {
-        coeff = damagetype == DOT ? bonus->dot_damage : bonus->direct_damage;
-
-        // apply ap bonus at done part calculation only (it flat total mod so common with taken)
-        if (donePart && (bonus->ap_bonus || bonus->ap_dot_bonus))
-        {
-            float ap_bonus = damagetype == DOT ? bonus->ap_dot_bonus : bonus->ap_bonus;
-
-            total += int32(ap_bonus * (GetTotalAttackPowerValue(IsSpellRequiresRangedAP(spellProto) ? RANGED_ATTACK : BASE_ATTACK) + ap_benefit));
-        }
-    }
-    // Default calculation
-    else if (benefit)
-        coeff = CalculateDefaultCoefficient(spellProto, damagetype);
-
-    if (benefit)
-    {
-        float LvlPenalty = CalculateLevelPenalty(spellProto);
-
-        // Spellmod SpellDamage
-        if (coeff) // If something has 0 coeff to begin with, do not add spellmod
-        {
-            if (Player* modOwner = GetSpellModOwner()) // Spellmod SpellDamage
-            {
-                coeff *= 100.0f;
-                modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_SPELL_BONUS_DAMAGE, coeff);
-                coeff /= 100.0f;
-            }
-        }
-
-        total += int32(benefit * coeff * LvlPenalty);
-    }
-
-    return total;
-};
-
-/**
- * Calculates caster part of spell damage bonuses,
- * also includes different bonuses dependent from target auras
- */
-uint32 Unit::SpellDamageBonusDone(Unit* pVictim, SpellEntry const* spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 stack)
+SpellAuraProcResult Unit::HandleManaShieldAuraProc(Unit* pVictim, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 cooldown)
 {
-    if (!spellProto || !pVictim || damagetype == DIRECT_DAMAGE || spellProto->HasAttribute(SPELL_ATTR_EX6_NO_DMG_PERCENT_MODS))
-        return pdamage;
+    SpellEntry const* dummySpell = triggeredByAura->GetSpellProto();
 
-    // For totems get damage bonus from owner (statue isn't totem in fact)
-    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem() && ((Totem*)this)->GetTotemType() != TOTEM_STATUE)
-    {
-        if (Unit* owner = GetOwner())
-            return owner->SpellDamageBonusDone(pVictim, spellProto, pdamage, damagetype);
-    }
+    Item* castItem = triggeredByAura->GetCastItemGuid() && GetTypeId() == TYPEID_PLAYER
+                     ? ((Player*)this)->GetItemByGuid(triggeredByAura->GetCastItemGuid()) : nullptr;
 
-    uint32 creatureTypeMask = pVictim->GetCreatureTypeMask();
-    float DoneTotalMod = 1.0f;
-    int32 DoneTotal = 0;
+    uint32 triggered_spell_id = 0;
+    Unit* target = pVictim;
 
-    // Creature damage
-    if (GetTypeId() == TYPEID_UNIT && !((Creature*)this)->IsPet())
-        DoneTotalMod *= Creature::_GetSpellDamageMod(((Creature*)this)->GetCreatureInfo()->Rank);
-
-    AuraList const& mModDamagePercentDone = GetAurasByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
-    for (AuraList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
-    {
-        if (((*i)->GetModifier()->m_miscvalue & GetSpellSchoolMask(spellProto)) &&
-                (*i)->GetSpellProto()->EquippedItemClass == -1 &&
-                // -1 == any item class (not wand then)
-                (*i)->GetSpellProto()->EquippedItemInventoryTypeMask == 0)
-            // 0 == any inventory type (not wand then)
-        {
-            DoneTotalMod *= ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
-        }
-    }
-
-    // Add flat bonus from spell damage versus
-    DoneTotal += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_FLAT_SPELL_DAMAGE_VERSUS, creatureTypeMask);
-
-    // Add pct bonus from spell damage versus
-    DoneTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_DONE_VERSUS, creatureTypeMask);
-
-    // Add flat bonus from spell damage creature
-    DoneTotal += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_DONE_CREATURE, creatureTypeMask);
-
-    // done scripted mod (take it from owner)
-    Unit* owner = GetOwner();
-    if (!owner)
-        owner = this;
-
-    AuraList const& mOverrideClassScript = owner->GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
-    for (AuraList::const_iterator i = mOverrideClassScript.begin(); i != mOverrideClassScript.end(); ++i)
-    {
-        if (!(*i)->isAffectedOnSpell(spellProto))
-            continue;
-        switch ((*i)->GetModifier()->m_miscvalue)
-        {
-            // Molten Fury
-            case 4920:
-            case 4919:
-            {
-                if (pVictim->HasAuraState(AURA_STATE_HEALTHLESS_35_PERCENT))
-                    DoneTotalMod *= (100.0f + (*i)->GetModifier()->m_amount) / 100.0f;
-                break;
-            }
-            // Soul Siphon
-            case 4992:
-            case 4993:
-            {
-                // effect 1 m_amount
-                int32 maxPercent = (*i)->GetModifier()->m_amount;
-                // effect 0 m_amount
-                int32 stepPercent = CalculateSpellDamage(this, (*i)->GetSpellProto(), EFFECT_INDEX_0);
-                // count affliction effects and calc additional damage in percentage
-                int32 modPercent = 0;
-                SpellAuraHolderMap const& victimAuras = pVictim->GetSpellAuraHolderMap();
-                for (SpellAuraHolderMap::const_iterator itr = victimAuras.begin(); itr != victimAuras.end(); ++itr)
-                {
-                    SpellEntry const* m_spell = itr->second->GetSpellProto();
-                    if (m_spell->SpellFamilyName != SPELLFAMILY_WARLOCK || !(m_spell->SpellFamilyFlags & uint64(0x0000871B804CC41A)))
-                        continue;
-                    modPercent += stepPercent * itr->second->GetStackAmount();
-                    if (modPercent >= maxPercent)
-                    {
-                        modPercent = maxPercent;
-                        break;
-                    }
-                }
-                DoneTotalMod *= (modPercent + 100.0f) / 100.0f;
-                break;
-            }
-            // Starfire Bonus
-            case 5481:
-            {
-                if (pVictim->GetAura(SPELL_AURA_PERIODIC_DAMAGE, SPELLFAMILY_DRUID, uint64(0x0000000000200002)))
-                    DoneTotalMod *= ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
-                break;
-            }
-            case 4418: // Increased Shock Damage
-            case 4554: // Increased Lightning Damage
-            case 4555: // Improved Moonfire
-            case 5142: // Increased Lightning Damage
-            case 5147: // Improved Consecration
-            case 5148: // Idol of the Shooting Star
-            case 6008: // Increased Lightning Damage / Totem of Hex
-            {
-                DoneTotal += (*i)->GetModifier()->m_amount;
-                break;
-            }
-        }
-    }
-
-    // Custom scripted damage
-    switch (spellProto->SpellFamilyName)
+    switch (dummySpell->SpellFamilyName)
     {
         case SPELLFAMILY_MAGE:
         {
-            // Ice Lance
-            if (spellProto->SpellIconID == 186)
+            // Incanter's Regalia set (add trigger chance to Mana Shield)
+            if (dummySpell->SpellFamilyFlags & uint64(0x0000000000008000) && HasAura(37424)) // Improved Mana Shield
             {
-                if (pVictim->isFrozen())
-                    DoneTotalMod *= 3.0f;
+                if (GetTypeId() != TYPEID_PLAYER)
+                    return SPELL_AURA_PROC_FAILED;
+
+                target = this;
+                triggered_spell_id = 37436;
+                break;
             }
             break;
         }
@@ -6478,1323 +2473,49 @@ uint32 Unit::SpellDamageBonusDone(Unit* pVictim, SpellEntry const* spellProto, u
             break;
     }
 
-    // Done fixed damage bonus auras
-    int32 DoneAdvertisedBenefit = SpellBaseDamageBonusDone(GetSpellSchoolMask(spellProto));
+    // processed charge only counting case
+    if (!triggered_spell_id)
+        return SPELL_AURA_PROC_FAILED;
 
-    // Pets just add their bonus damage to their spell damage
-    // note that their spell damage is just gain of their own auras
-    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsPet())
-        DoneAdvertisedBenefit += ((Pet*)this)->GetBonusDamage();
+    SpellEntry const* triggerEntry = sSpellTemplate.LookupEntry<SpellEntry>(triggered_spell_id);
 
-    // apply ap bonus and benefit affected by spell power implicit coeffs and spell level penalties
-    DoneTotal = SpellBonusWithCoeffs(spellProto, DoneTotal, DoneAdvertisedBenefit, 0, damagetype, true);
-
-    float tmpDamage = (int32(pdamage) + DoneTotal * int32(stack)) * DoneTotalMod;
-    // apply spellmod to Done damage (flat and pct)
-    if (Player* modOwner = GetSpellModOwner())
-        modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, tmpDamage);
-
-    return tmpDamage > 0 ? uint32(tmpDamage) : 0;
-}
-
-/**
- * Calculates target part of spell damage bonuses,
- * will be called on each tick for periodic damage over time auras
- */
-uint32 Unit::SpellDamageBonusTaken(Unit* pCaster, SpellEntry const* spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 stack)
-{
-    if (!spellProto || !pCaster || damagetype == DIRECT_DAMAGE)
-        return pdamage;
-
-    uint32 schoolMask = spellProto->SchoolMask;
-
-    // Taken total percent damage auras
-    float TakenTotalMod = 1.0f;
-    int32 TakenTotal = 0;
-
-    // ..taken
-    TakenTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, schoolMask);
-
-    // .. taken pct: dummy auras
-    AuraList const& mDummyAuras = GetAurasByType(SPELL_AURA_DUMMY);
-    for (AuraList::const_iterator i = mDummyAuras.begin(); i != mDummyAuras.end(); ++i)
+    if (!triggerEntry)
     {
-        switch ((*i)->GetSpellProto()->SpellIconID)
-        {
-            // Cheat Death
-            case 2109:
-                if (((*i)->GetModifier()->m_miscvalue & GetSpellSchoolMask(spellProto)))
-                {
-                    if (GetTypeId() != TYPEID_PLAYER)
-                        continue;
-                    float mod = -((Player*)this)->GetRatingBonusValue(CR_CRIT_TAKEN_SPELL) * 2 * 4;
-                    if (mod < float((*i)->GetModifier()->m_amount))
-                        mod = float((*i)->GetModifier()->m_amount);
-                    TakenTotalMod *= (mod + 100.0f) / 100.0f;
-                }
-                break;
-        }
+        sLog.outError("Unit::HandleManaShieldAuraProc: Spell %u have nonexistent triggered spell %u", dummySpell->Id, triggered_spell_id);
+        return SPELL_AURA_PROC_FAILED;
     }
 
-    // From caster spells
-    // Mod damage taken from AoE spells
-    if (IsAreaOfEffectSpell(spellProto))
-        TakenTotalMod *= GetTotalAuraMultiplier(SPELL_AURA_MOD_AOE_DAMAGE_AVOIDANCE);
+    // default case
+    if (!target || (target != this && !target->isAlive()))
+        return SPELL_AURA_PROC_FAILED;
 
-    // Taken fixed damage bonus auras
-    int32 TakenAdvertisedBenefit = SpellBaseDamageBonusTaken(GetSpellSchoolMask(spellProto));
+    if (cooldown && GetTypeId() == TYPEID_PLAYER && ((Player*)this)->HasSpellCooldown(triggered_spell_id))
+        return SPELL_AURA_PROC_FAILED;
 
-    // apply benefit affected by spell power implicit coeffs and spell level penalties
-    TakenTotal = pCaster->SpellBonusWithCoeffs(spellProto, TakenTotal, TakenAdvertisedBenefit, 0, damagetype, false);
+    CastSpell(target, triggered_spell_id, TRIGGERED_OLD_TRIGGERED, castItem, triggeredByAura);
 
-    float tmpDamage = (int32(pdamage) + TakenTotal * int32(stack)) * TakenTotalMod;
+    if (cooldown && GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->AddSpellCooldown(triggered_spell_id, 0, time(nullptr) + cooldown);
 
-    return tmpDamage > 0 ? uint32(tmpDamage) : 0;
+    return SPELL_AURA_PROC_OK;
 }
 
-int32 Unit::SpellBaseDamageBonusDone(SpellSchoolMask schoolMask)
+SpellAuraProcResult Unit::HandleAttackPowerAttackerBonusAuraProc(Unit* /*pVictim*/, uint32 /*damage*/, Aura* triggeredByAura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
 {
-    int32 DoneAdvertisedBenefit = 0;
+    SpellEntry const* dummySpell = triggeredByAura->GetSpellProto();
 
-    // ..done
-    AuraList const& mDamageDone = GetAurasByType(SPELL_AURA_MOD_DAMAGE_DONE);
-    for (AuraList::const_iterator i = mDamageDone.begin(); i != mDamageDone.end(); ++i)
+    switch (dummySpell->SpellFamilyName)
     {
-        if (((*i)->GetModifier()->m_miscvalue & schoolMask) != 0 &&
-                (*i)->GetSpellProto()->EquippedItemClass == -1 &&                   // -1 == any item class (not wand then)
-                (*i)->GetSpellProto()->EquippedItemInventoryTypeMask == 0)          //  0 == any inventory type (not wand then)
-            DoneAdvertisedBenefit += (*i)->GetModifier()->m_amount;
-    }
-
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        // Damage bonus from stats
-        AuraList const& mDamageDoneOfStatPercent = GetAurasByType(SPELL_AURA_MOD_SPELL_DAMAGE_OF_STAT_PERCENT);
-        for (AuraList::const_iterator i = mDamageDoneOfStatPercent.begin(); i != mDamageDoneOfStatPercent.end(); ++i)
+        case SPELLFAMILY_HUNTER:
         {
-            if ((*i)->GetModifier()->m_miscvalue & schoolMask)
+            // Hunter's Mark (1-4 Ranks)
+            if (dummySpell->SpellFamilyFlags & uint64(0x0000000000000400))
             {
-                // stat used stored in miscValueB for this aura
-                Stats usedStat = Stats((*i)->GetMiscBValue());
-                DoneAdvertisedBenefit += int32(GetStat(usedStat) * (*i)->GetModifier()->m_amount / 100.0f);
-            }
-        }
-        // ... and attack power
-        AuraList const& mDamageDonebyAP = GetAurasByType(SPELL_AURA_MOD_SPELL_DAMAGE_OF_ATTACK_POWER);
-        for (AuraList::const_iterator i = mDamageDonebyAP.begin(); i != mDamageDonebyAP.end(); ++i)
-        {
-            if ((*i)->GetModifier()->m_miscvalue & schoolMask)
-                DoneAdvertisedBenefit += int32(GetTotalAttackPowerValue(BASE_ATTACK) * (*i)->GetModifier()->m_amount / 100.0f);
-        }
-    }
-    return DoneAdvertisedBenefit;
-}
-
-int32 Unit::SpellBaseDamageBonusTaken(SpellSchoolMask schoolMask) const
-{
-    int32 TakenAdvertisedBenefit = 0;
-
-    // ..taken
-    AuraList const& mDamageTaken = GetAurasByType(SPELL_AURA_MOD_DAMAGE_TAKEN);
-    for (AuraList::const_iterator i = mDamageTaken.begin(); i != mDamageTaken.end(); ++i)
-    {
-        if (((*i)->GetModifier()->m_miscvalue & schoolMask) != 0)
-            TakenAdvertisedBenefit += (*i)->GetModifier()->m_amount;
-    }
-
-    return TakenAdvertisedBenefit;
-}
-
-bool Unit::IsSpellCrit(Unit* pVictim, SpellEntry const* spellProto, SpellSchoolMask schoolMask, WeaponAttackType attackType)
-{
-    if (!CanCrit(spellProto, schoolMask, attackType))
-        return false;
-
-    const float chance = CalculateSpellCritChance(pVictim, schoolMask, spellProto);
-    return roll_chance_f(chance);
-}
-
-/**
- * Calculates caster part of healing spell bonuses,
- * also includes different bonuses dependent from target auras
- */
-uint32 Unit::SpellHealingBonusDone(Unit* pVictim, SpellEntry const* spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack)
-{
-    // For totems get healing bonus from owner (statue isn't totem in fact)
-    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem() && ((Totem*)this)->GetTotemType() != TOTEM_STATUE)
-        if (Unit* owner = GetOwner())
-            return owner->SpellHealingBonusDone(pVictim, spellProto, healamount, damagetype, stack);
-
-    // No heal amount for this class spells
-    if (spellProto->DmgClass == SPELL_DAMAGE_CLASS_NONE)
-        return healamount < 0 ? 0 : healamount;
-
-    // Healing Done
-    // Done total percent damage auras
-    float  DoneTotalMod = 1.0f;
-    int32  DoneTotal = 0;
-
-    // Healing done percent
-    AuraList const& mHealingDonePct = GetAurasByType(SPELL_AURA_MOD_HEALING_DONE_PERCENT);
-    for (AuraList::const_iterator i = mHealingDonePct.begin(); i != mHealingDonePct.end(); ++i)
-        DoneTotalMod *= (100.0f + (*i)->GetModifier()->m_amount) / 100.0f;
-
-    // done scripted mod (take it from owner)
-    Unit* owner = GetOwner();
-    if (!owner) owner = this;
-    AuraList const& mOverrideClassScript = owner->GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
-    for (AuraList::const_iterator i = mOverrideClassScript.begin(); i != mOverrideClassScript.end(); ++i)
-    {
-        if (!(*i)->isAffectedOnSpell(spellProto))
-            continue;
-        switch ((*i)->GetModifier()->m_miscvalue)
-        {
-            case 4415: // Increased Rejuvenation Healing
-            case 4953:
-            case 3736: // Hateful Totem of the Third Wind / Increased Lesser Healing Wave / LK Arena (4/5/6) Totem of the Third Wind / Savage Totem of the Third Wind
-                DoneTotal += (*i)->GetModifier()->m_amount;
-                break;
-            default:
-                break;
-        }
-    }
-
-    // Done fixed damage bonus auras
-    int32 DoneAdvertisedBenefit  = SpellBaseHealingBonusDone(GetSpellSchoolMask(spellProto));
-
-    // apply ap bonus and benefit affected by spell power implicit coeffs and spell level penalties
-    DoneTotal = SpellBonusWithCoeffs(spellProto, DoneTotal, DoneAdvertisedBenefit, 0, damagetype, true);
-
-    // use float as more appropriate for negative values and percent applying
-    float heal = (healamount + DoneTotal * int32(stack)) * DoneTotalMod;
-    // apply spellmod to Done amount
-    if (Player* modOwner = GetSpellModOwner())
-        modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, heal);
-
-    return heal < 0 ? 0 : uint32(heal);
-}
-
-/**
- * Calculates target part of healing spell bonuses,
- * will be called on each tick for periodic damage over time auras
- */
-uint32 Unit::SpellHealingBonusTaken(Unit* pCaster, SpellEntry const* spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack)
-{
-    float  TakenTotalMod = 1.0f;
-
-    // Healing taken percent
-    float minval = float(GetMaxNegativeAuraModifier(SPELL_AURA_MOD_HEALING_PCT));
-    if (minval)
-        TakenTotalMod *= (100.0f + minval) / 100.0f;
-
-    float maxval = float(GetMaxPositiveAuraModifier(SPELL_AURA_MOD_HEALING_PCT));
-    if (maxval)
-        TakenTotalMod *= (100.0f + maxval) / 100.0f;
-
-    // No heal amount for this class spells
-    if (spellProto->DmgClass == SPELL_DAMAGE_CLASS_NONE)
-    {
-        healamount = int32(healamount * TakenTotalMod);
-        return healamount < 0 ? 0 : healamount;
-    }
-
-    // Healing Done
-    // Done total percent damage auras
-    int32  TakenTotal = 0;
-
-    // Taken fixed damage bonus auras
-    int32 TakenAdvertisedBenefit = SpellBaseHealingBonusTaken(GetSpellSchoolMask(spellProto));
-
-    // Blessing of Light dummy affects healing taken from Holy Light and Flash of Light
-    if (spellProto->SpellFamilyName == SPELLFAMILY_PALADIN && (spellProto->SpellFamilyFlags & uint64(0x00000000C0000000)))
-    {
-        AuraList const& auraDummy = GetAurasByType(SPELL_AURA_DUMMY);
-        for (AuraList::const_iterator i = auraDummy.begin(); i != auraDummy.end(); ++i)
-        {
-            if ((*i)->GetSpellProto()->SpellVisual == 9180)
-            {
-                if (((spellProto->SpellFamilyFlags & uint64(0x0000000040000000)) && (*i)->GetEffIndex() == EFFECT_INDEX_1) ||  // Flash of Light
-                        ((spellProto->SpellFamilyFlags & uint64(0x0000000080000000)) && (*i)->GetEffIndex() == EFFECT_INDEX_0))    // Holy Light
-                    TakenTotal += ((*i)->GetModifier()->m_amount * CalculateLevelPenalty(spellProto));  // BoL is penalized since 2.3.0
-            }
-        }
-    }
-
-    // apply benefit affected by spell power implicit coeffs and spell level penalties
-    TakenTotal = pCaster->SpellBonusWithCoeffs(spellProto, TakenTotal, TakenAdvertisedBenefit, 0, damagetype, false);
-
-    // Healing Way dummy affects healing taken from Healing Wave
-    if (spellProto->SpellFamilyName == SPELLFAMILY_SHAMAN && (spellProto->SpellFamilyFlags & uint64(0x0000000000000040)))
-    {
-        AuraList const& auraDummy = GetAurasByType(SPELL_AURA_DUMMY);
-        for (AuraList::const_iterator i = auraDummy.begin(); i != auraDummy.end(); ++i)
-            if ((*i)->GetId() == 29203)
-                TakenTotalMod *= ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
-    }
-
-    // use float as more appropriate for negative values and percent applying
-    float heal = (healamount + TakenTotal * int32(stack)) * TakenTotalMod;
-
-    return heal < 0 ? 0 : uint32(heal);
-}
-
-int32 Unit::SpellBaseHealingBonusDone(SpellSchoolMask schoolMask)
-{
-    int32 AdvertisedBenefit = 0;
-
-    AuraList const& mHealingDone = GetAurasByType(SPELL_AURA_MOD_HEALING_DONE);
-    for (AuraList::const_iterator i = mHealingDone.begin(); i != mHealingDone.end(); ++i)
-        if (((*i)->GetModifier()->m_miscvalue & schoolMask) != 0)
-            AdvertisedBenefit += (*i)->GetModifier()->m_amount;
-
-    // Healing bonus of spirit, intellect and strength
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        // Healing bonus from stats
-        AuraList const& mHealingDoneOfStatPercent = GetAurasByType(SPELL_AURA_MOD_SPELL_HEALING_OF_STAT_PERCENT);
-        for (AuraList::const_iterator i = mHealingDoneOfStatPercent.begin(); i != mHealingDoneOfStatPercent.end(); ++i)
-        {
-            // stat used dependent from misc value (stat index)
-            Stats usedStat = Stats((*i)->GetSpellProto()->EffectMiscValue[(*i)->GetEffIndex()]);
-            AdvertisedBenefit += int32(GetStat(usedStat) * (*i)->GetModifier()->m_amount / 100.0f);
-        }
-
-        // ... and attack power
-        AuraList const& mHealingDonebyAP = GetAurasByType(SPELL_AURA_MOD_SPELL_HEALING_OF_ATTACK_POWER);
-        for (AuraList::const_iterator i = mHealingDonebyAP.begin(); i != mHealingDonebyAP.end(); ++i)
-            if ((*i)->GetModifier()->m_miscvalue & schoolMask)
-                AdvertisedBenefit += int32(GetTotalAttackPowerValue(BASE_ATTACK) * (*i)->GetModifier()->m_amount / 100.0f);
-    }
-    return AdvertisedBenefit;
-}
-
-int32 Unit::SpellBaseHealingBonusTaken(SpellSchoolMask schoolMask) const
-{
-    int32 AdvertisedBenefit = 0;
-    AuraList const& mDamageTaken = GetAurasByType(SPELL_AURA_MOD_HEALING);
-    for (AuraList::const_iterator i = mDamageTaken.begin(); i != mDamageTaken.end(); ++i)
-        if ((*i)->GetModifier()->m_miscvalue & schoolMask)
-            AdvertisedBenefit += (*i)->GetModifier()->m_amount;
-
-    return AdvertisedBenefit;
-}
-
-bool Unit::IsImmuneToDamage(SpellSchoolMask shoolMask)
-{
-    // If m_immuneToSchool type contain this school type, IMMUNE damage.
-    SpellImmuneList const& schoolList = m_spellImmune[IMMUNITY_SCHOOL];
-    for (SpellImmuneList::const_iterator itr = schoolList.begin(); itr != schoolList.end(); ++itr)
-        if (itr->type & shoolMask)
-            return true;
-
-    // If m_immuneToDamage type contain magic, IMMUNE damage.
-    SpellImmuneList const& damageList = m_spellImmune[IMMUNITY_DAMAGE];
-    for (SpellImmuneList::const_iterator itr = damageList.begin(); itr != damageList.end(); ++itr)
-        if (itr->type & shoolMask)
-            return true;
-
-    return false;
-}
-
-bool Unit::IsImmuneToSpell(SpellEntry const* spellInfo, bool /*castOnSelf*/)
-{
-    if (!spellInfo)
-        return false;
-
-    // TODO add spellEffect immunity checks!, player with flag in bg is immune to immunity buffs from other friendly players!
-    // SpellImmuneList const& dispelList = m_spellImmune[IMMUNITY_EFFECT];
-
-    SpellImmuneList const& dispelList = m_spellImmune[IMMUNITY_DISPEL];
-    for (SpellImmuneList::const_iterator itr = dispelList.begin(); itr != dispelList.end(); ++itr)
-        if (itr->type == spellInfo->Dispel)
-            return true;
-
-    if (!spellInfo->HasAttribute(SPELL_ATTR_EX_UNAFFECTED_BY_SCHOOL_IMMUNE) &&          // unaffected by school immunity
-            !spellInfo->HasAttribute(SPELL_ATTR_EX_DISPEL_AURAS_ON_IMMUNITY))           // can remove immune (by dispell or immune it)
-    {
-        SpellImmuneList const& schoolList = m_spellImmune[IMMUNITY_SCHOOL];
-        for (SpellImmuneList::const_iterator itr = schoolList.begin(); itr != schoolList.end(); ++itr)
-            if (!(IsPositiveSpell(itr->spellId) && IsPositiveSpell(spellInfo->Id)) &&
-                    (itr->type & GetSpellSchoolMask(spellInfo)))
-                return true;
-    }
-
-    if (uint32 mechanic = spellInfo->Mechanic)
-    {
-        SpellImmuneList const& mechanicList = m_spellImmune[IMMUNITY_MECHANIC];
-        for (SpellImmuneList::const_iterator itr = mechanicList.begin(); itr != mechanicList.end(); ++itr)
-            if (itr->type == mechanic)
-                return true;
-
-        AuraList const& immuneAuraApply = GetAurasByType(SPELL_AURA_MECHANIC_IMMUNITY_MASK);
-        for (AuraList::const_iterator iter = immuneAuraApply.begin(); iter != immuneAuraApply.end(); ++iter)
-            if ((*iter)->GetModifier()->m_miscvalue & (1 << (mechanic - 1)))
-                return true;
-    }
-
-    return false;
-}
-
-bool Unit::IsImmuneToSpellEffect(SpellEntry const* spellInfo, SpellEffectIndex index, bool /*castOnSelf*/) const
-{
-    // If m_immuneToEffect type contain this effect type, IMMUNE effect.
-    uint32 effect = spellInfo->Effect[index];
-    SpellImmuneList const& effectList = m_spellImmune[IMMUNITY_EFFECT];
-    for (SpellImmuneList::const_iterator itr = effectList.begin(); itr != effectList.end(); ++itr)
-        if (itr->type == effect)
-            return true;
-
-    if (uint32 mechanic = spellInfo->EffectMechanic[index])
-    {
-        SpellImmuneList const& mechanicList = m_spellImmune[IMMUNITY_MECHANIC];
-        for (SpellImmuneList::const_iterator itr = mechanicList.begin(); itr != mechanicList.end(); ++itr)
-            if (itr->type == mechanic)
-                return true;
-
-        AuraList const& immuneAuraApply = GetAurasByType(SPELL_AURA_MECHANIC_IMMUNITY_MASK);
-        for (AuraList::const_iterator iter = immuneAuraApply.begin(); iter != immuneAuraApply.end(); ++iter)
-            if ((*iter)->GetModifier()->m_miscvalue & (1 << (mechanic - 1)))
-                return true;
-    }
-
-    if (uint32 aura = spellInfo->EffectApplyAuraName[index])
-    {
-        SpellImmuneList const& list = m_spellImmune[IMMUNITY_STATE];
-        for (SpellImmuneList::const_iterator itr = list.begin(); itr != list.end(); ++itr)
-            if (itr->type == aura)
-                return true;
-    }
-    return false;
-}
-
-/**
- * Calculates caster part of melee damage bonuses,
- * also includes different bonuses dependent from target auras
- */
-uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackType attType, SpellEntry const* spellProto, DamageEffectType damagetype, uint32 stack)
-{
-    if (!pVictim || pdamage == 0 || (spellProto && spellProto->HasAttribute(SPELL_ATTR_EX6_NO_DMG_PERCENT_MODS)))
-        return pdamage;
-
-    // differentiate for weapon damage based spells
-    bool isWeaponDamageBasedSpell = !(spellProto && (damagetype == DOT || IsSpellHaveEffect(spellProto, SPELL_EFFECT_SCHOOL_DAMAGE)));
-    Item*  pWeapon          = GetTypeId() == TYPEID_PLAYER ? ((Player*)this)->GetWeaponForAttack(attType, true, false) : nullptr;
-    uint32 creatureTypeMask = pVictim->GetCreatureTypeMask();
-    uint32 schoolMask       = spellProto ? spellProto->SchoolMask : uint32(GetMeleeDamageSchoolMask());
-
-    // FLAT damage bonus auras
-    // =======================
-    int32 DoneFlat  = 0;
-    int32 APbonus   = 0;
-
-    // ..done flat, already included in weapon damage based spells
-    if (!isWeaponDamageBasedSpell)
-    {
-        AuraList const& mModDamageDone = GetAurasByType(SPELL_AURA_MOD_DAMAGE_DONE);
-        for (AuraList::const_iterator i = mModDamageDone.begin(); i != mModDamageDone.end(); ++i)
-        {
-            if ((*i)->GetModifier()->m_miscvalue & schoolMask &&                         // schoolmask has to fit with the intrinsic spell school
-                    (*i)->GetModifier()->m_miscvalue & GetMeleeDamageSchoolMask() &&         // AND schoolmask has to fit with weapon damage school (essential for non-physical spells)
-                    (((*i)->GetSpellProto()->EquippedItemClass == -1) ||                     // general, weapon independent
-                     (pWeapon && pWeapon->IsFitToSpellRequirements((*i)->GetSpellProto()))))  // OR used weapon fits aura requirements
-            {
-                DoneFlat += (*i)->GetModifier()->m_amount;
-            }
-        }
-
-        // Pets just add their bonus damage to their melee damage
-        if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsPet())
-            DoneFlat += ((Pet*)this)->GetBonusDamage();
-    }
-
-    // ..done flat (by creature type mask)
-    DoneFlat += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_DONE_CREATURE, creatureTypeMask);
-
-    // ..done flat (base at attack power for marked target and base at attack power for creature type)
-    if (attType == RANGED_ATTACK)
-    {
-        APbonus += pVictim->GetTotalAuraModifier(SPELL_AURA_RANGED_ATTACK_POWER_ATTACKER_BONUS);
-        APbonus += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_RANGED_ATTACK_POWER_VERSUS, creatureTypeMask);
-    }
-    else
-    {
-        APbonus += pVictim->GetTotalAuraModifier(SPELL_AURA_MELEE_ATTACK_POWER_ATTACKER_BONUS);
-        APbonus += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_MELEE_ATTACK_POWER_VERSUS, creatureTypeMask);
-    }
-
-    // PERCENT damage auras
-    // ====================
-    float DonePercent   = 1.0f;
-
-    // ..done pct, already included in weapon damage based spells
-    if (!isWeaponDamageBasedSpell)
-    {
-        AuraList const& mModDamagePercentDone = GetAurasByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
-        for (AuraList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
-        {
-            if ((*i)->GetModifier()->m_miscvalue & schoolMask &&                         // schoolmask has to fit with the intrinsic spell school
-                    (*i)->GetModifier()->m_miscvalue & GetMeleeDamageSchoolMask() &&         // AND schoolmask has to fit with weapon damage school (essential for non-physical spells)
-                    (((*i)->GetSpellProto()->EquippedItemClass == -1) ||                     // general, weapon independent
-                     (pWeapon && pWeapon->IsFitToSpellRequirements((*i)->GetSpellProto()))))  // OR used weapon fits aura requirements
-            {
-                DonePercent *= ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
-            }
-        }
-
-        if (attType == OFF_ATTACK)
-            DonePercent *= GetModifierValue(UNIT_MOD_DAMAGE_OFFHAND, TOTAL_PCT);                    // no school check required
-    }
-
-    // ..done pct (by creature type mask)
-    DonePercent *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_DONE_VERSUS, creatureTypeMask);
-
-    // special dummys/class scripts and other effects
-    // =============================================
-    Unit* owner = GetOwner();
-    if (!owner)
-        owner = this;
-
-    // .. done (class scripts)
-    AuraList const& mclassScritAuras = GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
-    for (AuraList::const_iterator i = mclassScritAuras.begin(); i != mclassScritAuras.end(); ++i)
-    {
-        switch ((*i)->GetMiscValue())
-        {
-            // Dirty Deeds
-            case 6427:
-            case 6428:
-                if (pVictim->HasAuraState(AURA_STATE_HEALTHLESS_35_PERCENT))
-                {
-                    Aura* eff0 = GetAura((*i)->GetId(), EFFECT_INDEX_0);
-                    if (!eff0 || (*i)->GetEffIndex() != EFFECT_INDEX_1)
-                    {
-                        sLog.outError("Spell structure of DD (%u) changed.", (*i)->GetId());
-                        continue;
-                    }
-
-                    // effect 0 have expected value but in negative state
-                    DonePercent *= (-eff0->GetModifier()->m_amount + 100.0f) / 100.0f;
-                }
-                break;
-        }
-    }
-
-    // final calculation
-    // =================
-
-    float DoneTotal = 0.0f;
-
-    // scaling of non weapon based spells
-    if (!isWeaponDamageBasedSpell)
-    {
-        // apply ap bonus and benefit affected by spell power implicit coeffs and spell level penalties
-        DoneTotal = SpellBonusWithCoeffs(spellProto, DoneTotal, DoneFlat, APbonus, damagetype, true);
-    }
-    // weapon damage based spells
-    else if (APbonus || DoneFlat)
-    {
-        bool normalized = spellProto ? IsSpellHaveEffect(spellProto, SPELL_EFFECT_NORMALIZED_WEAPON_DMG) : false;
-        DoneTotal += int32(APbonus / 14.0f * GetAPMultiplier(attType, normalized));
-
-        // for weapon damage based spells we still have to apply damage done percent mods
-        // (that are already included into pdamage) to not-yet included DoneFlat
-        // e.g. from doneVersusCreature, apBonusVs...
-        UnitMods unitMod;
-        switch (attType)
-        {
-            default:
-            case BASE_ATTACK:   unitMod = UNIT_MOD_DAMAGE_MAINHAND; break;
-            case OFF_ATTACK:    unitMod = UNIT_MOD_DAMAGE_OFFHAND;  break;
-            case RANGED_ATTACK: unitMod = UNIT_MOD_DAMAGE_RANGED;   break;
-        }
-
-        DoneTotal += DoneFlat;
-
-        DoneTotal *= GetModifierValue(unitMod, TOTAL_PCT);
-    }
-
-    float tmpDamage = float(int32(pdamage) + DoneTotal * int32(stack)) * DonePercent;
-
-    // apply spellmod to Done damage
-    if (spellProto)
-    {
-        if (Player* modOwner = GetSpellModOwner())
-            modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, tmpDamage);
-    }
-
-    // bonus result can be negative
-    return tmpDamage > 0 ? uint32(tmpDamage) : 0;
-}
-
-/**
- * Calculates target part of melee damage bonuses,
- * will be called on each tick for periodic damage over time auras
- */
-uint32 Unit::MeleeDamageBonusTaken(Unit* pCaster, uint32 pdamage, WeaponAttackType attType, SpellEntry const* spellProto, DamageEffectType damagetype, uint32 stack)
-{
-    if (!pCaster)
-        return pdamage;
-
-    if (pdamage == 0)
-        return pdamage;
-
-    // differentiate for weapon damage based spells
-    bool isWeaponDamageBasedSpell = !(spellProto && (damagetype == DOT || IsSpellHaveEffect(spellProto, SPELL_EFFECT_SCHOOL_DAMAGE)));
-    uint32 schoolMask       = spellProto ? spellProto->SchoolMask : uint32(GetMeleeDamageSchoolMask());
-    uint32 mechanicMask     = spellProto ? GetAllSpellMechanicMask(spellProto) : 0;
-
-    // Shred also have bonus as MECHANIC_BLEED damages
-    if (spellProto && spellProto->SpellFamilyName == SPELLFAMILY_DRUID && spellProto->SpellFamilyFlags & uint64(0x00008000))
-        mechanicMask |= (1 << (MECHANIC_BLEED - 1));
-
-    // FLAT damage bonus auras
-    // =======================
-    int32 TakenFlat = 0;
-
-    // ..taken flat (base at attack power for marked target and base at attack power for creature type)
-    if (attType == RANGED_ATTACK)
-        TakenFlat += GetTotalAuraModifier(SPELL_AURA_MOD_RANGED_DAMAGE_TAKEN);
-    else
-        TakenFlat += GetTotalAuraModifier(SPELL_AURA_MOD_MELEE_DAMAGE_TAKEN);
-
-    // ..taken flat (by school mask)
-    TakenFlat += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, schoolMask);
-
-    // PERCENT damage auras
-    // ====================
-    float TakenPercent  = 1.0f;
-
-    // ..taken pct (by school mask)
-    TakenPercent *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, schoolMask);
-
-    // ..taken pct (melee/ranged)
-    if (attType == RANGED_ATTACK)
-        TakenPercent *= GetTotalAuraMultiplier(SPELL_AURA_MOD_RANGED_DAMAGE_TAKEN_PCT);
-    else
-        TakenPercent *= GetTotalAuraMultiplier(SPELL_AURA_MOD_MELEE_DAMAGE_TAKEN_PCT);
-
-    // ..taken pct (aoe avoidance)
-    if (spellProto && IsAreaOfEffectSpell(spellProto))
-        TakenPercent *= GetTotalAuraMultiplier(SPELL_AURA_MOD_AOE_DAMAGE_AVOIDANCE);
-
-    // special dummys/class scripts and other effects
-    // =============================================
-
-    // .. taken (dummy auras)
-    AuraList const& mDummyAuras = GetAurasByType(SPELL_AURA_DUMMY);
-    for (AuraList::const_iterator i = mDummyAuras.begin(); i != mDummyAuras.end(); ++i)
-    {
-        switch ((*i)->GetSpellProto()->SpellIconID)
-        {
-            case 2109:                                      // Cheating Death
-                if ((*i)->GetModifier()->m_miscvalue & SPELL_SCHOOL_MASK_NORMAL)
-                {
-                    if (GetTypeId() != TYPEID_PLAYER)
-                        continue;
-
-                    float mod = ((Player*)this)->GetRatingBonusValue(CR_CRIT_TAKEN_MELEE) * (-8.0f);
-                    if (mod < float((*i)->GetModifier()->m_amount))
-                        mod = float((*i)->GetModifier()->m_amount);
-
-                    TakenPercent *= (mod + 100.0f) / 100.0f;
-                }
-                break;
-            case 2312:                                      // Mangle
-                if (mechanicMask & (1 << (MECHANIC_BLEED - 1)))
-                    TakenPercent *= (100.0f + (*i)->GetModifier()->m_amount) / 100.0f;
-                break;
-        }
-    }
-
-    // final calculation
-    // =================
-
-    // scaling of non weapon based spells
-    if (!isWeaponDamageBasedSpell)
-    {
-        // apply benefit affected by spell power implicit coeffs and spell level penalties
-        TakenFlat = pCaster->SpellBonusWithCoeffs(spellProto, 0, TakenFlat, 0, damagetype, false);
-    }
-
-    float tmpDamage = float(int32(pdamage) + TakenFlat * int32(stack)) * TakenPercent;
-
-    // bonus result can be negative
-    return tmpDamage > 0 ? uint32(tmpDamage) : 0;
-}
-
-void Unit::ApplySpellImmune(uint32 spellId, uint32 op, uint32 type, bool apply)
-{
-    if (apply)
-    {
-        for (SpellImmuneList::iterator itr = m_spellImmune[op].begin(), next; itr != m_spellImmune[op].end(); itr = next)
-        {
-            next = itr; ++next;
-            if (itr->type == type)
-            {
-                m_spellImmune[op].erase(itr);
-                next = m_spellImmune[op].begin();
-            }
-        }
-        SpellImmune Immune;
-        Immune.spellId = spellId;
-        Immune.type = type;
-        m_spellImmune[op].push_back(Immune);
-    }
-    else
-    {
-        for (SpellImmuneList::iterator itr = m_spellImmune[op].begin(); itr != m_spellImmune[op].end(); ++itr)
-        {
-            if (itr->spellId == spellId)
-            {
-                m_spellImmune[op].erase(itr);
-                break;
-            }
-        }
-    }
-}
-
-void Unit::ApplySpellDispelImmunity(const SpellEntry* spellProto, DispelType type, bool apply)
-{
-    ApplySpellImmune(spellProto->Id, IMMUNITY_DISPEL, type, apply);
-
-    if (apply && spellProto->HasAttribute(SPELL_ATTR_EX_DISPEL_AURAS_ON_IMMUNITY))
-        RemoveAurasWithDispelType(type);
-}
-
-float Unit::GetWeaponProcChance() const
-{
-    // normalized proc chance for weapon attack speed
-    // (odd formula...)
-    if (isAttackReady(BASE_ATTACK))
-        return (GetAttackTime(BASE_ATTACK) * 1.8f / 1000.0f);
-    else if (haveOffhandWeapon() && isAttackReady(OFF_ATTACK))
-        return (GetAttackTime(OFF_ATTACK) * 1.6f / 1000.0f);
-
-    return 0.0f;
-}
-
-float Unit::GetPPMProcChance(uint32 WeaponSpeed, float PPM) const
-{
-    // proc per minute chance calculation
-    if (PPM <= 0.0f)
-        return 0.0f;
-    return WeaponSpeed * PPM / 600.0f;                      // result is chance in percents (probability = Speed_in_sec * (PPM / 60))
-}
-
-void Unit::Mount(uint32 mount, uint32 spellId)
-{
-    if (!mount)
-        return;
-
-    RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_MOUNTING);
-
-    SetUInt32Value(UNIT_FIELD_MOUNTDISPLAYID, mount);
-
-    SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_MOUNT);
-
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        // Called by Taxi system / GM command
-        if (!spellId)
-            ((Player*)this)->UnsummonPetTemporaryIfAny();
-        // Called by mount aura
-        else if (SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId))
-        {
-            // Flying case (Unsummon any pet)
-            if (IsSpellHaveAura(spellInfo, SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED))
-                ((Player*)this)->UnsummonPetTemporaryIfAny();
-            // Normal case (Unsummon only permanent pet)
-            else if (Pet* pet = GetPet())
-            {
-                if (pet->isControlled() && (!(pet->isTemporarySummoned() || ((Player*)this)->InArena())
-                    || sWorld.getConfig(CONFIG_BOOL_PET_UNSUMMON_AT_MOUNT)))
-                    ((Player*)this)->UnsummonPetTemporaryIfAny();
-                else
-                    pet->SetModeFlags(PET_MODE_DISABLE_ACTIONS);
-            }
-        }
-    }
-}
-
-void Unit::Unmount(bool from_aura)
-{
-    if (!IsMounted())
-        return;
-
-    RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_MOUNTED);
-
-    SetUInt32Value(UNIT_FIELD_MOUNTDISPLAYID, 0);
-    RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_MOUNT);
-
-    // Called NOT by Taxi system / GM command
-    if (from_aura)
-    {
-        WorldPacket data(SMSG_DISMOUNT, 8);
-        data << GetPackGUID();
-        SendMessageToSet(data, true);
-    }
-
-    // only resummon old pet if the player is already added to a map
-    // this prevents adding a pet to a not created map which would otherwise cause a crash
-    // (it could probably happen when logging in after a previous crash)
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        if (Pet* pet = GetPet())
-        {
-            // Get reaction state and display appropriately
-            if (CharmInfo* charmInfo = pet->GetCharmInfo())
-                pet->SetModeFlags(PetModeFlags(charmInfo->GetReactState() | charmInfo->GetCommandState() * 0x100));
-        }
-        else
-            ((Player*)this)->ResummonPetTemporaryUnSummonedIfAny();
-    }
-}
-
-void Unit::SetInCombatWith(Unit* enemy)
-{
-    Unit* eOwner = enemy->GetCharmerOrOwnerOrSelf();
-    if (eOwner->IsPvP())
-    {
-        SetInCombatState(true, enemy);
-        return;
-    }
-
-    // check for duel
-    if (eOwner->GetTypeId() == TYPEID_PLAYER && ((Player*)eOwner)->duel)
-    {
-        if (Player const* myOwner = GetCharmerOrOwnerPlayerOrPlayerItself())
-        {
-            if (myOwner->IsInDuelWith((Player const*)eOwner))
-            {
-                SetInCombatState(true, enemy);
-                return;
-            }
-        }
-    }
-
-    SetInCombatState(false, enemy);
-}
-
-void Unit::SetInCombatState(bool PvP, Unit* enemy)
-{
-    // only alive units can be in combat
-    if (!isAlive())
-        return;
-
-    if (PvP)
-        m_CombatTimer = 5000;
-
-    bool creatureNotInCombat = GetTypeId() == TYPEID_UNIT && !HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IN_COMBAT);
-
-    SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IN_COMBAT);
-
-    if (isCharmed() || (GetTypeId() != TYPEID_PLAYER && ((Creature*)this)->IsPet()))
-        SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PET_IN_COMBAT);
-
-    // interrupt all delayed non-combat casts
-    for (uint32 i = CURRENT_FIRST_NON_MELEE_SPELL; i < CURRENT_MAX_SPELL; ++i)
-        if (Spell* spell = GetCurrentSpell(CurrentSpellTypes(i)))
-            if (IsNonCombatSpell(spell->m_spellInfo))
-                InterruptSpell(CurrentSpellTypes(i), false);
-
-    if (creatureNotInCombat)
-    {
-        // should probably be removed for the attacked (+ it's party/group) only, not global
-        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_OOC_NOT_ATTACKABLE);
-
-        // client does not handle this state on it's own (reset to default at LoadCreatureAddon)
-        if (getStandState() == UNIT_STAND_STATE_CUSTOM)
-            SetStandState(UNIT_STAND_STATE_STAND);
-
-        Creature* pCreature = (Creature*)this;
-
-        if (pCreature->AI())
-            pCreature->AI()->EnterCombat(enemy);
-
-        // Some bosses are set into combat with zone
-        if (GetMap()->IsDungeon() && (pCreature->GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_AGGRO_ZONE) && enemy && enemy->IsControlledByPlayer())
-            pCreature->SetInCombatWithZone();
-
-        if (InstanceData* mapInstance = GetInstanceData())
-            mapInstance->OnCreatureEnterCombat(pCreature);
-
-        if (m_isCreatureLinkingTrigger)
-            GetMap()->GetCreatureLinkingHolder()->DoCreatureLinkingEvent(LINKING_EVENT_AGGRO, pCreature, enemy);
-    }
-}
-
-void Unit::ClearInCombat()
-{
-    m_CombatTimer = 0;
-    RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IN_COMBAT);
-
-    if (isCharmed() || (GetTypeId() != TYPEID_PLAYER && ((Creature*)this)->IsPet()))
-        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PET_IN_COMBAT);
-
-    // Player's state will be cleared in Player::UpdateContestedPvP
-    if (GetTypeId() == TYPEID_UNIT)
-    {
-        Creature* cThis = static_cast<Creature*>(this);
-        if (cThis->GetCreatureInfo()->UnitFlags & UNIT_FLAG_OOC_NOT_ATTACKABLE && !(cThis->GetTemporaryFactionFlags() & TEMPFACTION_TOGGLE_OOC_NOT_ATTACK))
-            SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_OOC_NOT_ATTACKABLE);
-
-        clearUnitState(UNIT_STAT_ATTACK_PLAYER);
-    }
-}
-
-bool Unit::isTargetableForAttack(bool inverseAlive /*=false*/) const
-{
-    if (GetTypeId() == TYPEID_PLAYER && ((Player*)this)->isGameMaster())
-        return false;
-
-    if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE))
-        return false;
-
-    // to be removed if unit by any reason enter combat
-    if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_OOC_NOT_ATTACKABLE))
-        return false;
-
-    // inversealive is needed for some spells which need to be casted at dead targets (aoe)
-    if (isAlive() == inverseAlive)
-        return false;
-
-    return IsInWorld() && !hasUnitState(UNIT_STAT_DIED) && !IsTaxiFlying();
-}
-
-int32 Unit::ModifyHealth(int32 dVal)
-{
-    if (dVal == 0)
-        return 0;
-
-    int32 curHealth = (int32)GetHealth();
-
-    int32 val = dVal + curHealth;
-    if (val <= 0)
-    {
-        SetHealth(0);
-        return -curHealth;
-    }
-
-    int32 maxHealth = (int32)GetMaxHealth();
-
-    int32 gain;
-    if (val < maxHealth)
-    {
-        SetHealth(val);
-        gain = val - curHealth;
-    }
-    else
-    {
-        SetHealth(maxHealth);
-        gain = maxHealth - curHealth;
-    }
-
-    return gain;
-}
-
-int32 Unit::ModifyPower(Powers power, int32 dVal)
-{
-    if (dVal == 0)
-        return 0;
-
-    int32 curPower = (int32)GetPower(power);
-
-    int32 val = dVal + curPower;
-    if (val <= 0)
-    {
-        SetPower(power, 0);
-        return -curPower;
-    }
-
-    int32 maxPower = (int32)GetMaxPower(power);
-
-    int32 gain;
-    if (val < maxPower)
-    {
-        SetPower(power, val);
-        gain = val - curPower;
-    }
-    else
-    {
-        SetPower(power, maxPower);
-        gain = maxPower - curPower;
-    }
-
-    return gain;
-}
-
-bool Unit::isVisibleForOrDetect(Unit const* u, WorldObject const* viewPoint, bool detect, bool inVisibleList, bool is3dDistance) const
-{
-    if (!u || !IsInMap(u))
-        return false;
-
-    // Always can see self
-    if (u == this)
-        return true;
-
-    // player visible for other player if not logout and at same transport
-    // including case when player is out of world
-    bool at_same_transport =
-        GetTypeId() == TYPEID_PLAYER &&  u->GetTypeId() == TYPEID_PLAYER &&
-        !((Player*)this)->GetSession()->PlayerLogout() && !((Player*)u)->GetSession()->PlayerLogout() &&
-        !((Player*)this)->GetSession()->PlayerLoading() && !((Player*)u)->GetSession()->PlayerLoading() &&
-        ((Player*)this)->GetTransport() && ((Player*)this)->GetTransport() == ((Player*)u)->GetTransport();
-
-    // not in world
-    if (!at_same_transport && (!IsInWorld() || !u->IsInWorld()))
-        return false;
-
-    // forbidden to seen (while Removing corpse)
-    if (m_Visibility == VISIBILITY_REMOVE_CORPSE)
-        return false;
-
-    Map& _map = *u->GetMap();
-    // Grid dead/alive checks
-    if (u->GetTypeId() == TYPEID_PLAYER)
-    {
-        // non visible at grid for any stealth state
-        if (!IsVisibleInGridForPlayer((Player*)u))
-            return false;
-
-        // if player is dead then he can't detect anyone in any cases
-        if (!u->isAlive())
-            detect = false;
-    }
-    else
-    {
-        // all dead creatures/players not visible for any creatures
-        if (!u->isAlive() || !isAlive())
-            return false;
-    }
-
-    // different visible distance checks
-    if (u->IsTaxiFlying())                                  // what see player in flight
-    {
-        // use object grey distance for all (only see objects any way)
-        if (!IsWithinDistInMap(viewPoint, World::GetMaxVisibleDistanceInFlight() + (inVisibleList ? World::GetVisibleObjectGreyDistance() : 0.0f), is3dDistance))
-            return false;
-    }
-    else if (!at_same_transport)                            // distance for show player/pet/creature (no transport case)
-    {
-        // Any units far than max visible distance for viewer or not in our map are not visible too
-        if (!IsWithinDistInMap(viewPoint, _map.GetVisibilityDistance() + (inVisibleList ? World::GetVisibleUnitGreyDistance() : 0.0f), is3dDistance))
-            return false;
-    }
-
-    // always seen by owner
-    if (GetCharmerOrOwnerGuid() == u->GetObjectGuid())
-        return true;
-
-    // isInvisibleForAlive() those units can only be seen by dead or if other
-    // unit is also invisible for alive.. if an isinvisibleforalive unit dies we
-    // should be able to see it too
-    if (u->isAlive() && isAlive() && isInvisibleForAlive() != u->isInvisibleForAlive())
-        if (u->GetTypeId() != TYPEID_PLAYER || !((Player*)u)->isGameMaster())
-            return false;
-
-    // Visible units, always are visible for all units, except for units under invisibility
-    if (m_Visibility == VISIBILITY_ON && u->m_invisibilityMask == 0)
-        return true;
-
-    // GMs see any players, not higher GMs and all units
-    if (u->GetTypeId() == TYPEID_PLAYER && ((Player*)u)->isGameMaster())
-    {
-        if (GetTypeId() == TYPEID_PLAYER)
-            return ((Player*)this)->GetSession()->GetSecurity() <= ((Player*)u)->GetSession()->GetSecurity();
-        else
-            return true;
-    }
-
-    // non faction visibility non-breakable for non-GMs
-    if (m_Visibility == VISIBILITY_OFF)
-        return false;
-
-    // grouped players should always see stealthed party members
-    if (GetTypeId() == TYPEID_PLAYER && u->GetTypeId() == TYPEID_PLAYER)
-        if (((Player*)this)->IsGroupVisibleFor(((Player*)u)) && u->IsFriendlyTo(this))
-            return true;
-
-    // raw invisibility
-    bool invisible = (m_invisibilityMask != 0 || u->m_invisibilityMask != 0);
-    if (u->GetTypeId() == TYPEID_PLAYER) // if object is player with mover, use its visibility masks, so that an invisible player MCing a creature can see stuff
-    {
-        if (Player* player = (Player*)u)
-        {
-            if (Unit* mover=player->GetMover())
-            {
-                invisible= (m_invisibilityMask != 0 || mover->m_invisibilityMask != 0);
-            }
-        }
-    }
-
-    // detectable invisibility case
-    if (invisible && (
-                // Invisible units, always are visible for units under same invisibility type
-                (m_invisibilityMask & u->m_invisibilityMask) != 0 ||
-                // Invisible units, always are visible for unit that can detect this invisibility (have appropriate level for detect)
-                u->canDetectInvisibilityOf(this) ||
-                // Units that can detect invisibility always are visible for units that can be detected
-                canDetectInvisibilityOf(u)))
-    {
-        invisible = false;
-    }
-
-    // special cases for always overwrite invisibility/stealth
-    if (invisible || m_Visibility == VISIBILITY_GROUP_STEALTH)
-    {
-        if (u->IsHostileTo(this))
-        {
-            // Hunter mark functionality
-            AuraList const& auras = GetAurasByType(SPELL_AURA_MOD_STALKED);
-            for (AuraList::const_iterator iter = auras.begin(); iter != auras.end(); ++iter)
-                if ((*iter)->GetCasterGuid() == u->GetObjectGuid())
-                    return true;
-        }
-
-        // none other cases for detect invisibility, so invisible
-        if (invisible)
-            return false;
-    }
-
-    // unit got in stealth in this moment and must ignore old detected state
-    if (m_Visibility == VISIBILITY_GROUP_NO_DETECT)
-        return false;
-
-    // GM invisibility checks early, invisibility if any detectable, so if not stealth then visible
-    if (m_Visibility != VISIBILITY_GROUP_STEALTH)
-        return true;
-
-    // NOW ONLY STEALTH CASE
-
-    // if in non-detect mode then invisible for unit
-    // mobs always detect players (detect == true)... return 'false' for those mobs which have (detect == false)
-    // players detect players only in Player::HandleStealthedUnitsDetection()
-    if (!detect)
-        return (u->GetTypeId() == TYPEID_PLAYER) ? ((Player*)u)->HaveAtClient(this) : false;
-
-    // Special cases
-
-    // If is attacked then stealth is lost, some creature can use stealth too
-    if (!getAttackers().empty())
-        return true;
-
-    // If there is collision rogue is seen regardless of level difference
-    if (IsWithinDist(u, 0.24f))
-        return true;
-
-    // If a mob or player is stunned he will not be able to detect stealth
-    if (u->hasUnitState(UNIT_STAT_STUNNED) && (u != this))
-        return false;
-
-    // set max ditance
-    float visibleDistance = (u->GetTypeId() == TYPEID_PLAYER) ? MAX_PLAYER_STEALTH_DETECT_RANGE : ((Creature const*)u)->GetAttackDistance(this);
-
-    // Always invisible from back (when stealth detection is on), also filter max distance cases
-    bool isInFront = viewPoint->isInFrontInMap(this, visibleDistance);
-    if (!isInFront)
-        return false;
-
-    // if doesn't have stealth detection (Shadow Sight), then check how stealthy the unit is, otherwise just check los
-    if (!u->HasAuraType(SPELL_AURA_DETECT_STEALTH))
-    {
-        // Calculation if target is in front
-
-        // Visible distance based on stealth value (stealth rank 4 300MOD, 10.5 - 3 = 7.5)
-        visibleDistance = 10.5f - (GetTotalAuraModifier(SPELL_AURA_MOD_STEALTH) / 100.0f);
-
-        // Visible distance is modified by
-        //-Level Diff (every level diff = 1.0f in visible distance)
-        visibleDistance += int32(u->GetLevelForTarget(this)) - int32(GetLevelForTarget(u));
-
-        // This allows to check talent tree and will add addition stealth dependent on used points)
-        int32 stealthMod = GetTotalAuraModifier(SPELL_AURA_MOD_STEALTH_LEVEL);
-        if (stealthMod < 0)
-            stealthMod = 0;
-
-        //-Stealth Mod(positive like Master of Deception) and Stealth Detection(negative like paranoia)
-        // based on wowwiki every 5 mod we have 1 more level diff in calculation
-        visibleDistance += (int32(u->GetTotalAuraModifier(SPELL_AURA_MOD_STEALTH_DETECT)) - stealthMod) / 5.0f;
-        visibleDistance = visibleDistance > MAX_PLAYER_STEALTH_DETECT_RANGE ? MAX_PLAYER_STEALTH_DETECT_RANGE : visibleDistance;
-
-        // recheck new distance
-        if (visibleDistance <= 0 || !IsWithinDist(viewPoint, visibleDistance))
-            return false;
-    }
-
-    // Now check is target visible with LoS
-    float ox, oy, oz;
-    viewPoint->GetPosition(ox, oy, oz);
-    return IsWithinLOS(ox, oy, oz);
-}
-
-void Unit::UpdateVisibilityAndView()
-{
-    static const AuraType auratypes[] = {SPELL_AURA_BIND_SIGHT, SPELL_AURA_FAR_SIGHT, SPELL_AURA_NONE};
-    for (AuraType const* type = &auratypes[0]; *type != SPELL_AURA_NONE; ++type)
-    {
-        AuraList& alist = m_modAuras[*type];
-        if (alist.empty())
-            continue;
-
-        for (AuraList::iterator it = alist.begin(); it != alist.end();)
-        {
-            Aura* aura = (*it);
-            Unit* owner = aura->GetCaster();
-
-            if (!owner || !isVisibleForOrDetect(owner, this, false))
-            {
-                alist.erase(it);
-                RemoveAura(aura);
-                it = alist.begin();
-            }
-            else
-                ++it;
-        }
-    }
-
-    GetViewPoint().Call_UpdateVisibilityForOwner();
-    UpdateObjectVisibility();
-    ScheduleAINotify(0);
-    GetViewPoint().Event_ViewPointVisibilityChanged();
-}
-
-void Unit::SetVisibility(UnitVisibility x)
-{
-    m_Visibility = x;
-
-    if (IsInWorld())
-        UpdateVisibilityAndView();
-}
-
-bool Unit::canDetectInvisibilityOf(Unit const* u) const
-{
-    if (uint32 mask = (m_detectInvisibilityMask & u->m_invisibilityMask))
-    {
-        for (int32 i = 0; i < 32; ++i)
-        {
-            if (((1 << i) & mask) == 0)
-                continue;
-
-            // find invisibility level
-            int32 invLevel = 0;
-            Unit::AuraList const& iAuras = u->GetAurasByType(SPELL_AURA_MOD_INVISIBILITY);
-            for (Unit::AuraList::const_iterator itr = iAuras.begin(); itr != iAuras.end(); ++itr)
-                if ((*itr)->GetModifier()->m_miscvalue == i && invLevel < (*itr)->GetModifier()->m_amount)
-                    invLevel = (*itr)->GetModifier()->m_amount;
-
-            // find invisibility detect level
-            int32 detectLevel = 0;
-            Unit::AuraList const& dAuras = GetAurasByType(SPELL_AURA_MOD_INVISIBILITY_DETECTION);
-            for (Unit::AuraList::const_iterator itr = dAuras.begin(); itr != dAuras.end(); ++itr)
-                if ((*itr)->GetModifier()->m_miscvalue == i && detectLevel < (*itr)->GetModifier()->m_amount)
-                    detectLevel = (*itr)->GetModifier()->m_amount;
-
-            if (i == 6 && GetTypeId() == TYPEID_PLAYER)     // special drunk detection case
-                detectLevel = ((Player*)this)->GetDrunkValue();
-
-            if (invLevel <= detectLevel)
-                return true;
-        }
-    }
-
-    return false;
-}
-
-void Unit::UpdateSpeed(UnitMoveType mtype, bool forced, float ratio)
-{
-    // not in combat pet have same speed as owner
-    switch (mtype)
-    {
-        case MOVE_RUN:
-        case MOVE_WALK:
-        case MOVE_SWIM:
-            if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsPet() && hasUnitState(UNIT_STAT_FOLLOW))
-            {
-                if (Unit* owner = GetOwner())
-                {
-                    SetSpeedRate(mtype, owner->GetSpeedRate(mtype), forced);
-                    return;
-                }
-            }
-            break;
-        default:
-            break;
-    }
-
-    int32 main_speed_mod  = 0;
-    float stack_bonus     = 1.0f;
-    float non_stack_bonus = 1.0f;
-
-    switch (mtype)
-    {
-        case MOVE_WALK:
-            break;
-        case MOVE_RUN:
-        {
-            if (IsMounted()) // Use on mount auras
-            {
-                main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED);
-                stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_MOUNTED_SPEED_ALWAYS);
-                non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK)) / 100.0f;
-            }
-            else
-            {
-                main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_SPEED);
-                stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_SPEED_ALWAYS);
-                non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_SPEED_NOT_STACK)) / 100.0f;
-            }
-            break;
-        }
-        case MOVE_RUN_BACK:
-            return;
-        case MOVE_SWIM:
-        {
-            main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_SWIM_SPEED);
-            break;
-        }
-        case MOVE_SWIM_BACK:
-            return;
-        case MOVE_FLIGHT:
-        {
-            if (IsMounted()) // Use on mount auras
-            {
-                main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED);
-                stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_STACKING);
-                non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_NOT_STACKING)) / 100.0f;
-            }
-            else             // Use not mount (shapeshift for example) auras (should stack)
-            {
-                main_speed_mod  = GetTotalAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED);
-                stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_FLIGHT_SPEED_STACKING);
-                non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_NOT_STACKING)) / 100.0f;
-            }
-            break;
-        }
-        case MOVE_FLIGHT_BACK:
-            return;
-        default:
-            sLog.outError("Unit::UpdateSpeed: Unsupported move type (%d)", mtype);
-            return;
-    }
-
-    float bonus = non_stack_bonus > stack_bonus ? non_stack_bonus : stack_bonus;
-    // now we ready for speed calculation
-    float speed  = main_speed_mod ? bonus * (100.0f + main_speed_mod) / 100.0f : bonus;
-
-    switch (mtype)
-    {
-        case MOVE_RUN:
-        case MOVE_SWIM:
-        case MOVE_FLIGHT:
-        {
-            // Normalize speed by 191 aura SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED if need
-            // TODO: possible affect only on MOVE_RUN
-            if (int32 normalization = GetMaxPositiveAuraModifier(SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED))
-            {
-                // Use speed from aura
-                float max_speed = normalization / baseMoveSpeed[mtype];
-                if (speed > max_speed)
-                    speed = max_speed;
+                int32 basevalue = triggeredByAura->GetBasePoints();
+
+                triggeredByAura->GetModifier()->m_amount += basevalue / 10;
+                if (triggeredByAura->GetModifier()->m_amount > basevalue * 4)
+                    triggeredByAura->GetModifier()->m_amount = basevalue * 4;
             }
             break;
         }
@@ -7802,3054 +2523,45 @@ void Unit::UpdateSpeed(UnitMoveType mtype, bool forced, float ratio)
             break;
     }
 
-    // for creature case, we check explicit if mob searched for assistance
-    if (GetTypeId() == TYPEID_UNIT)
-    {
-        if (((Creature*)this)->HasSearchedAssistance())
-            speed *= 0.66f;                                 // best guessed value, so this will be 33% reduction. Based off initial speed, mob can then "run", "walk fast" or "walk".
-    }
-    // for player case, we look for some custom rates
-    else
-    {
-        if (getDeathState() == CORPSE)
-            speed *= sWorld.getConfig(((Player*)this)->InBattleGround() ? CONFIG_FLOAT_GHOST_RUN_SPEED_BG : CONFIG_FLOAT_GHOST_RUN_SPEED_WORLD);
-    }
-
-    // Apply strongest slow aura mod to speed
-    int32 slow = GetMaxNegativeAuraModifier(SPELL_AURA_MOD_DECREASE_SPEED);
-    if (slow)
-        speed *= (100.0f + slow) / 100.0f;
-
-    if (GetTypeId() == TYPEID_UNIT)
-    {
-        switch (mtype)
-        {
-            case MOVE_RUN:
-                speed *= ((Creature*)this)->GetCreatureInfo()->SpeedRun;
-                break;
-            case MOVE_WALK:
-                speed *= ((Creature*)this)->GetCreatureInfo()->SpeedWalk;
-                break;
-            default:
-                break;
-        }
-    }
-
-    SetSpeedRate(mtype, speed * ratio, forced);
-}
-
-float Unit::GetSpeed(UnitMoveType mtype) const
-{
-    return m_speed_rate[mtype] * baseMoveSpeed[mtype];
-}
-
-struct SetSpeedRateHelper
-{
-    explicit SetSpeedRateHelper(UnitMoveType _mtype, bool _forced) : mtype(_mtype), forced(_forced) {}
-    void operator()(Unit* unit) const { unit->UpdateSpeed(mtype, forced); }
-    UnitMoveType mtype;
-    bool forced;
-};
-
-void Unit::SetSpeedRate(UnitMoveType mtype, float rate, bool forced)
-{
-    rate = std::max(rate, 0.01f);
-
-    // Update speed only on change
-    if (m_speed_rate[mtype] != rate)
-    {
-        m_speed_rate[mtype] = rate;
-        propagateSpeedChange();
-
-        typedef const Opcodes SpeedOpcodePair[2];
-        SpeedOpcodePair SetSpeed2Opc_table[MAX_MOVE_TYPE] =
-        {
-            {SMSG_FORCE_WALK_SPEED_CHANGE,        SMSG_SPLINE_SET_WALK_SPEED},
-            {SMSG_FORCE_RUN_SPEED_CHANGE,         SMSG_SPLINE_SET_RUN_SPEED},
-            {SMSG_FORCE_RUN_BACK_SPEED_CHANGE,    SMSG_SPLINE_SET_RUN_BACK_SPEED},
-            {SMSG_FORCE_SWIM_SPEED_CHANGE,        SMSG_SPLINE_SET_SWIM_SPEED},
-            {SMSG_FORCE_SWIM_BACK_SPEED_CHANGE,   SMSG_SPLINE_SET_SWIM_BACK_SPEED},
-            {SMSG_FORCE_TURN_RATE_CHANGE,         SMSG_SPLINE_SET_TURN_RATE},
-            {SMSG_FORCE_FLIGHT_SPEED_CHANGE,      SMSG_SPLINE_SET_FLIGHT_SPEED},
-            {SMSG_FORCE_FLIGHT_BACK_SPEED_CHANGE, SMSG_SPLINE_SET_FLIGHT_BACK_SPEED},
-        };
-
-        const SpeedOpcodePair& speedOpcodes = SetSpeed2Opc_table[mtype];
-        
-        if (forced && GetTypeId() == TYPEID_PLAYER)
-        {
-            // register forced speed changes for WorldSession::HandleForceSpeedChangeAck
-            // and do it only for real sent packets and use run for run/mounted as client expected
-            ++((Player*)this)->m_forced_speed_changes[mtype];
-
-            WorldPacket data(speedOpcodes[0], 18);
-            data << GetPackGUID();
-            data << (uint32)0;                              // moveEvent, NUM_PMOVE_EVTS = 0x39
-            if (mtype == MOVE_RUN)
-                data << uint8(0);                           // new 2.1.0
-            data << float(GetSpeed(mtype));
-            ((Player*)this)->GetSession()->SendPacket(data);
-        }
-        WorldPacket data(speedOpcodes[1], 12);
-        data << GetPackGUID();
-        data << float(GetSpeed(mtype));
-        SendMessageToSet(data, false);
-    }
-
-    CallForAllControlledUnits(SetSpeedRateHelper(mtype, forced), CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_CHARM | CONTROLLED_MINIPET);
-}
-
-void Unit::SetDeathState(DeathState s)
-{
-    if (s == JUST_DIED)
-    {
-        RemoveAllAurasOnDeath();
-        RemoveGuardians();
-        UnsummonAllTotems();
-
-        StopMoving();
-        i_motionMaster.Clear(false, true);
-        i_motionMaster.MoveIdle();
-
-        ModifyAuraState(AURA_STATE_HEALTHLESS_20_PERCENT, false);
-        ModifyAuraState(AURA_STATE_HEALTHLESS_35_PERCENT, false);
-        // remove aurastates allowing special moves
-        ClearAllReactives();
-        ClearDiminishings();
-    }
-    else if (s == JUST_ALIVED)
-    {
-        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SKINNABLE);  // clear skinnable for creature and player (at battleground)
-    }
-
-    if (s != ALIVE && s != JUST_ALIVED)
-    {
-        CombatStop();
-        DeleteThreatList();
-        ClearComboPointHolders();                           // any combo points pointed to unit lost at it death
-
-        if (IsNonMeleeSpellCasted(false))
-            InterruptNonMeleeSpells(false);
-    }
-
-    // TODO:: what is/was that?
-    /*if (m_deathState != ALIVE && s == ALIVE)
-    {
-        //_ApplyAllAuraMods();
-    }*/
-    m_deathState = s;
-}
-
-/*########################################
-########                          ########
-########       AGGRO SYSTEM       ########
-########                          ########
-########################################*/
-
-// Check if this unit is controlled by provided controller or by one of its friendly faction
-bool Unit::IsTargetUnderControl(Unit const& target) const
-{
-    ObjectGuid charmerGuid = GetCharmerGuid();
-
-    if (!charmerGuid)
-        return false;
-    
-    if (target.GetCharmerGuid() == charmerGuid)
-        return true;
-
-    // also check if this unit is controlled by another creature from friendly faction
-    if (Unit const* charmer = GetMap()->GetUnit(charmerGuid))
-    {
-        FactionTemplateEntry const* charmerFactionEntry = charmer->getFactionTemplateEntry();
-        FactionTemplateEntry const* controllerFactionEntry = target.getFactionTemplateEntry();
-        if (controllerFactionEntry && charmerFactionEntry && !controllerFactionEntry->IsHostileTo(*controllerFactionEntry))
-            return true;
-    }
-
-    return false;
-}
-
-bool Unit::CanHaveThreatList(bool ignoreAliveState/*=false*/) const
-{
-    // only creatures can have threat list
-    if (GetTypeId() != TYPEID_UNIT)
-        return false;
-
-    // only alive units can have threat list
-    if (!isAlive() && !ignoreAliveState)
-        return false;
-
-    Creature const* creature = ((Creature const*)this);
-
-    // totems can not have threat list
-    if (creature->IsTotem())
-        return false;
-
-    // pets can not have a threat list, unless they are controlled by a creature
-    if (creature->IsPet() && creature->GetOwnerGuid().IsPlayer())
-    {
-        Pet const* pet = static_cast<Pet const*>(creature);
-        if (pet->getPetType() == GUARDIAN_PET)
-            return true;
-        return false;
-    }
-
-    // charmed units can not have a threat list if charmed by player
-    if (creature->GetCharmerGuid().IsPlayer())
-        return false;
-
-    return true;
-}
-
-//======================================================================
-
-float Unit::ApplyTotalThreatModifier(float threat, SpellSchoolMask schoolMask)
-{
-    if (!HasAuraType(SPELL_AURA_MOD_THREAT))
-        return threat;
-
-    if (schoolMask == SPELL_SCHOOL_MASK_NONE)
-        return threat;
-
-    SpellSchools school = GetFirstSchoolInMask(schoolMask);
-
-    return threat * m_threatModifier[school];
-}
-
-//======================================================================
-
-void Unit::AddThreat(Unit* pVictim, float threat /*= 0.0f*/, bool crit /*= false*/, SpellSchoolMask schoolMask /*= SPELL_SCHOOL_MASK_NONE*/, SpellEntry const* threatSpell /*= nullptr*/)
-{
-    // Only mobs can manage threat lists
-    if (CanHaveThreatList())
-        getThreatManager().addThreat(pVictim, threat, crit, schoolMask, threatSpell);
-}
-
-//======================================================================
-
-void Unit::DeleteThreatList()
-{
-    getThreatManager().clearReferences();
-}
-
-//======================================================================
-
-void Unit::TauntApply(Unit* taunter)
-{
-    MANGOS_ASSERT(GetTypeId() == TYPEID_UNIT);
-
-    if (!taunter || (taunter->GetTypeId() == TYPEID_PLAYER && ((Player*)taunter)->isGameMaster()))
-        return;
-
-    if (!CanHaveThreatList())
-        return;
-
-    Unit* target = getVictim();
-
-    if (target && target == taunter)
-        return;
-
-    // Only attack taunter if this is a valid target
-    if (CanReactInCombat() && !IsSecondChoiceTarget(taunter, true, true))
-    {
-        if (GetTargetGuid() || !target)
-            SetInFront(taunter);
-
-        if (AI())
-            AI()->AttackStart(taunter);
-    }
-
-    getThreatManager().tauntApply(taunter);
-}
-
-//======================================================================
-
-void Unit::TauntFadeOut(Unit* taunter)
-{
-    MANGOS_ASSERT(GetTypeId() == TYPEID_UNIT);
-
-    if (!taunter || (taunter->GetTypeId() == TYPEID_PLAYER && ((Player*)taunter)->isGameMaster()))
-        return;
-
-    if (!CanHaveThreatList())
-        return;
-
-    Unit* target = getVictim();
-
-    if (!target || target != taunter)
-        return;
-
-    if (getThreatManager().isThreatListEmpty())
-    {
-        m_fixateTargetGuid.Clear();
-
-        if (AI())
-            AI()->EnterEvadeMode();
-
-        if (InstanceData* mapInstance = GetInstanceData())
-            mapInstance->OnCreatureEvade((Creature*)this);
-
-        if (m_isCreatureLinkingTrigger)
-            GetMap()->GetCreatureLinkingHolder()->DoCreatureLinkingEvent(LINKING_EVENT_EVADE, (Creature*)this);
-
-        return;
-    }
-
-    getThreatManager().tauntFadeOut(taunter);
-    target = getThreatManager().getHostileTarget();
-
-    if (target && target != taunter)
-    {
-        if (GetTargetGuid())
-            SetInFront(target);
-
-        if (AI())
-            AI()->AttackStart(target);
-    }
-}
-
-//======================================================================
-/// if pVictim is given, the npc will fixate onto pVictim, if nullptr it will remove current fixation
-void Unit::FixateTarget(Unit* pVictim)
-{
-    if (!pVictim)                                           // Remove Fixation
-        m_fixateTargetGuid.Clear();
-    else if (pVictim->isTargetableForAttack())              // Apply Fixation
-        m_fixateTargetGuid = pVictim->GetObjectGuid();
-
-    // Start attacking the fixated target or the next proper one
-    SelectHostileTarget();
-}
-
-//======================================================================
-
-bool Unit::IsSecondChoiceTarget(Unit* pTarget, bool taunt, bool checkThreatArea)
-{
-    MANGOS_ASSERT(pTarget);
-
-    // little hack before handling threatarea in unit instead of creature as charmed players will act like creature
-    const Creature* thisCreature = GetTypeId() == TYPEID_UNIT ? static_cast<const Creature*>(this) : nullptr;
-
-    return
-        pTarget->IsTargetUnderControl(*this) ||
-        (!taunt && pTarget->IsImmuneToDamage(GetMeleeDamageSchoolMask())) ||
-        pTarget->hasNegativeAuraWithInterruptFlag(AURA_INTERRUPT_FLAG_DAMAGE) ||
-        (thisCreature && checkThreatArea && thisCreature->IsOutOfThreatArea(pTarget));
-}
-
-//======================================================================
-
-bool Unit::SelectHostileTarget()
-{
-    // function provides main threat functionality
-    // next-victim-selection algorithm and evade mode are called
-    // threat list sorting etc.
-
-    MANGOS_ASSERT(GetTypeId() == TYPEID_UNIT);
-
-    if (!this->isAlive())
-        return false;
-
-    // This function only useful once AI has been initialized
-    if (!AI())
-        return false;
-
-    Unit* target = nullptr;
-    Unit* oldTarget = getVictim();
-
-    // first check if we should fixate a target
-    if (m_fixateTargetGuid)
-    {
-        if (oldTarget && oldTarget->GetObjectGuid() == m_fixateTargetGuid)
-            target = oldTarget;
-        else
-        {
-            Unit* pFixateTarget = GetMap()->GetUnit(m_fixateTargetGuid);
-            if (pFixateTarget && pFixateTarget->isAlive() && !IsSecondChoiceTarget(pFixateTarget, false, true))
-                target = pFixateTarget;
-        }
-    }
-    // then checking if we have some taunt on us
-    if (!target)
-    {
-        const AuraList& tauntAuras = GetAurasByType(SPELL_AURA_MOD_TAUNT);
-        Unit* caster;
-
-        // Find first available taunter target
-        // Auras are pushed_back, last caster will be on the end
-        for (AuraList::const_reverse_iterator aura = tauntAuras.rbegin(); aura != tauntAuras.rend(); ++aura)
-        {
-            if ((caster = (*aura)->GetCaster()) && caster->IsInMap(this) &&
-                    caster->isTargetableForAttack() && caster->isInAccessablePlaceFor((Creature*)this) &&
-                    !IsSecondChoiceTarget(caster, true, true))
-            {
-                target = caster;
-                break;
-            }
-        }
-    }
-
-    // No valid fixate target, taunt aura or taunt aura caster is dead, standard target selection
-    if (!target && !getThreatManager().isThreatListEmpty())
-        target = getThreatManager().getHostileTarget();
-
-    if (target)
-    {
-        if (CanReactInCombat())
-        {
-            SetInFront(target);
-            if (oldTarget != target)
-                AI()->AttackStart(target);
-
-            // check if currently selected target is reachable
-            // NOTE: path alrteady generated from AttackStart()
-            if (!GetMotionMaster()->GetCurrent()->IsReachable())
-            {
-                // remove all taunts
-                RemoveSpellsCausingAura(SPELL_AURA_MOD_TAUNT);
-
-                if (getThreatManager().getThreatList().size() < 2)
-                {
-                    // only one target in list, we have to evade after timer
-                    // TODO: make timer - inside Creature class
-                    AI()->EnterEvadeMode();
-                }
-                else
-                {
-                    // remove unreachable target from our threat list
-                    // next iteration we will select next possible target
-                    getHostileRefManager().deleteReference(target);
-                    getThreatManager().modifyThreatPercent(target, -101);
-                    // remove target from current attacker, do not exit combat settings
-                    AttackStop(true);
-                }
-
-                return false;
-            }
-        }
-        return true;
-    }
-
-    // no target but something prevent go to evade mode
-    if (!isInCombat() || HasAuraType(SPELL_AURA_MOD_TAUNT))
-        return false;
-
-    // last case when creature don't must go to evade mode:
-    // it in combat but attacker not make any damage and not enter to aggro radius to have record in threat list
-    // for example at owner command to pet attack some far away creature
-    // Note: creature not have targeted movement generator but have attacker in this case
-    if (GetMotionMaster()->GetCurrentMovementGeneratorType() != CHASE_MOTION_TYPE)
-    {
-        for (AttackerSet::const_iterator itr = m_attackers.begin(); itr != m_attackers.end(); ++itr)
-        {
-            if ((*itr)->IsInMap(this) && (*itr)->isTargetableForAttack() && (*itr)->isInAccessablePlaceFor((Creature*)this))
-                return false;
-        }
-    }
-
-    // enter in evade mode in other case
-    m_fixateTargetGuid.Clear();
-    AI()->EnterEvadeMode();
-
-    if (InstanceData* mapInstance = GetInstanceData())
-        mapInstance->OnCreatureEvade((Creature*)this);
-
-    if (m_isCreatureLinkingTrigger)
-        GetMap()->GetCreatureLinkingHolder()->DoCreatureLinkingEvent(LINKING_EVENT_EVADE, (Creature*)this);
-
-    return false;
-}
-
-//======================================================================
-//======================================================================
-//======================================================================
-
-int32 Unit::CalculateSpellDamage(Unit const* target, SpellEntry const* spellProto, SpellEffectIndex effect_index, int32 const* effBasePoints)
-{
-    Player* unitPlayer = (GetTypeId() == TYPEID_PLAYER) ? (Player*)this : nullptr;
-
-    uint8 comboPoints = unitPlayer ? unitPlayer->GetComboPoints() : 0;
-
-    int32 level = int32(getLevel());
-    if (level > (int32)spellProto->maxLevel && spellProto->maxLevel > 0)
-        level = (int32)spellProto->maxLevel;
-    else if (level < (int32)spellProto->baseLevel)
-        level = (int32)spellProto->baseLevel;
-    level -= (int32)spellProto->spellLevel;
-
-    int32 baseDice = int32(spellProto->EffectBaseDice[effect_index]);
-    float basePointsPerLevel = spellProto->EffectRealPointsPerLevel[effect_index];
-    float randomPointsPerLevel = spellProto->EffectDicePerLevel[effect_index];
-    int32 basePoints = effBasePoints
-                       ? *effBasePoints - baseDice
-                       : spellProto->EffectBasePoints[effect_index];
-
-    basePoints += int32(level * basePointsPerLevel);
-    int32 randomPoints = int32(spellProto->EffectDieSides[effect_index] + level * randomPointsPerLevel);
-    float comboDamage = spellProto->EffectPointsPerComboPoint[effect_index];
-
-    switch (randomPoints)
-    {
-        case 0:
-        case 1: basePoints += baseDice; break;              // range 1..1
-        default:
-        {
-            // range can have positive (1..rand) and negative (rand..1) values, so order its for irand
-            int32 randvalue = baseDice >= randomPoints
-                              ? irand(randomPoints, baseDice)
-                              : irand(baseDice, randomPoints);
-
-            basePoints += randvalue;
-            break;
-        }
-    }
-
-    int32 value = basePoints;
-
-    // random damage
-    if (comboDamage != 0.0f && unitPlayer && target && (target->GetObjectGuid() == unitPlayer->GetComboTargetGuid() || IsOnlySelfTargeting(spellProto)))
-        value += (int32)(comboDamage * comboPoints);
-
-    if (Player* modOwner = GetSpellModOwner())
-    {
-        modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_ALL_EFFECTS, value);
-
-        switch (effect_index)
-        {
-            case EFFECT_INDEX_0:
-                modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_EFFECT1, value);
-                break;
-            case EFFECT_INDEX_1:
-                modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_EFFECT2, value);
-                break;
-            case EFFECT_INDEX_2:
-                modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_EFFECT3, value);
-                break;
-        }
-    }
-
-    if (spellProto->HasAttribute(SPELL_ATTR_LEVEL_DAMAGE_CALCULATION) && spellProto->spellLevel)
-    {
-        if (spellProto->EffectApplyAuraName[effect_index])
-            value += int32(std::max(0, int32(getLevel() - spellProto->maxLevel)) * basePointsPerLevel);
-        else if (spellProto->Effect[effect_index] != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE &&
-                 spellProto->Effect[effect_index] != SPELL_EFFECT_KNOCK_BACK &&
-                 !IsControlledByPlayer())
-        {
-            GtNPCManaCostScalerEntry const* spellScaler = sGtNPCManaCostScalerStore.LookupEntry(spellProto->spellLevel - 1);
-            GtNPCManaCostScalerEntry const* casterScaler = sGtNPCManaCostScalerStore.LookupEntry(this->getLevel() - 1);
-            if (spellScaler && casterScaler)
-                value *= casterScaler->ratio / spellScaler->ratio;
-        }
-    }
-
-    return value;
-}
-
-int32 Unit::CalculateAuraDuration(SpellEntry const* spellProto, uint32 effectMask, int32 duration, Unit const* caster)
-{
-    if (duration <= 0)
-        return duration;
-
-    int32 mechanicMod = 0;
-    uint32 mechanicMask = GetSpellMechanicMask(spellProto, effectMask);
-
-    for (int32 mechanic = FIRST_MECHANIC; mechanic < MAX_MECHANIC; ++mechanic)
-    {
-        if (!(mechanicMask & (1 << (mechanic - 1))))
-            continue;
-
-        int32 stackingMod = GetTotalAuraModifierByMiscValue(SPELL_AURA_MECHANIC_DURATION_MOD, mechanic);
-        int32 nonStackingMod = GetMaxNegativeAuraModifierByMiscValue(SPELL_AURA_MECHANIC_DURATION_MOD_NOT_STACK, mechanic);
-
-        mechanicMod = std::min(mechanicMod, std::min(stackingMod, nonStackingMod));
-    }
-
-    int32 durationMod = mechanicMod;
-
-    if (durationMod != 0)
-    {
-        duration = int32(int64(duration) * (100 + durationMod) / 100);
-
-        if (duration < 0)
-            duration = 0;
-    }
-
-    return duration;
-}
-
-DiminishingLevels Unit::GetDiminishing(DiminishingGroup group)
-{
-    for (Diminishing::iterator i = m_Diminishing.begin(); i != m_Diminishing.end(); ++i)
-    {
-        if (i->DRGroup != group)
-            continue;
-
-        if (!i->hitCount)
-            return DIMINISHING_LEVEL_1;
-
-        if (!i->hitTime)
-            return DIMINISHING_LEVEL_1;
-
-        // If last spell was casted more than 15 seconds ago - reset the count.
-        if (i->stack == 0 && WorldTimer::getMSTimeDiff(i->hitTime, WorldTimer::getMSTime()) > 15 * IN_MILLISECONDS)
-        {
-            i->hitCount = DIMINISHING_LEVEL_1;
-            return DIMINISHING_LEVEL_1;
-        }
-        // or else increase the count.
-        else
-        {
-            return DiminishingLevels(i->hitCount);
-        }
-    }
-    return DIMINISHING_LEVEL_1;
-}
-
-void Unit::IncrDiminishing(DiminishingGroup group)
-{
-    // Checking for existing in the table
-    for (Diminishing::iterator i = m_Diminishing.begin(); i != m_Diminishing.end(); ++i)
-    {
-        if (i->DRGroup != group)
-            continue;
-        if (i->hitCount < DIMINISHING_LEVEL_IMMUNE)
-            i->hitCount += 1;
-        return;
-    }
-    m_Diminishing.push_back(DiminishingReturn(group, WorldTimer::getMSTime(), DIMINISHING_LEVEL_2));
-}
-
-void Unit::ApplyDiminishingToDuration(DiminishingGroup group, int32& duration, Unit* caster, DiminishingLevels Level, bool isReflected)
-{
-    if (duration == -1 || group == DIMINISHING_NONE || (!isReflected && caster->IsFriendlyTo(this)))
-        return;
-
-    // Duration of crowd control abilities on pvp target is limited by 10 sec. (2.2.0)
-    if (duration > 10000 && IsDiminishingReturnsGroupDurationLimited(group))
-    {
-        // test pet/charm masters instead pets/charmeds
-        Unit const* targetOwner = GetCharmerOrOwner();
-        Unit const* casterOwner = caster->GetCharmerOrOwner();
-
-        Unit const* target = targetOwner ? targetOwner : this;
-        Unit const* source = casterOwner ? casterOwner : caster;
-
-        if (target->GetTypeId() == TYPEID_PLAYER && source->GetTypeId() == TYPEID_PLAYER)
-            duration = 10000;
-    }
-
-    float mod = 1.0f;
-
-    // Some diminishings applies to mobs too (for example, Stun)
-    if ((GetDiminishingReturnsGroupType(group) == DRTYPE_PLAYER && GetTypeId() == TYPEID_PLAYER) || GetDiminishingReturnsGroupType(group) == DRTYPE_ALL)
-    {
-        DiminishingLevels diminish = Level;
-        switch (diminish)
-        {
-            case DIMINISHING_LEVEL_1: break;
-            case DIMINISHING_LEVEL_2: mod = 0.5f; break;
-            case DIMINISHING_LEVEL_3: mod = 0.25f; break;
-            case DIMINISHING_LEVEL_IMMUNE: mod = 0.0f; break;
-            default: break;
-        }
-    }
-
-    duration = int32(duration * mod);
-}
-
-void Unit::ApplyDiminishingAura(DiminishingGroup group, bool apply)
-{
-    // Checking for existing in the table
-    for (Diminishing::iterator i = m_Diminishing.begin(); i != m_Diminishing.end(); ++i)
-    {
-        if (i->DRGroup != group)
-            continue;
-
-        if (apply)
-            i->stack += 1;
-        else if (i->stack)
-        {
-            i->stack -= 1;
-            // Remember time after last aura from group removed
-            if (i->stack == 0)
-                i->hitTime = WorldTimer::getMSTime();
-        }
-        break;
-    }
-}
-
-bool Unit::isVisibleForInState(Player const* u, WorldObject const* viewPoint, bool inVisibleList) const
-{
-    return isVisibleForOrDetect(u, viewPoint, false, inVisibleList, false);
-}
-
-/// returns true if creature can't be seen by alive units
-bool Unit::isInvisibleForAlive() const
-{
-    if (m_AuraFlags & UNIT_AURAFLAG_ALIVE_INVISIBLE)
-        return true;
-    // TODO: maybe spiritservices also have just an aura
-    return isSpiritService();
-}
-
-uint32 Unit::GetCreatureType() const
-{
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        SpellShapeshiftFormEntry const* ssEntry = sSpellShapeshiftFormStore.LookupEntry(GetShapeshiftForm());
-        if (ssEntry && ssEntry->creatureType > 0)
-            return ssEntry->creatureType;
-        else
-            return CREATURE_TYPE_HUMANOID;
-    }
-    else
-        return ((Creature*)this)->GetCreatureInfo()->CreatureType;
-}
-
-/*#######################################
-########                         ########
-########       STAT SYSTEM       ########
-########                         ########
-#######################################*/
-
-bool Unit::HandleStatModifier(UnitMods unitMod, UnitModifierType modifierType, float amount, bool apply)
-{
-    if (unitMod >= UNIT_MOD_END || modifierType >= MODIFIER_TYPE_END)
-    {
-        sLog.outError("ERROR in HandleStatModifier(): nonexistent UnitMods or wrong UnitModifierType!");
-        return false;
-    }
-
-    float val;
-
-    switch (modifierType)
-    {
-        case BASE_VALUE:
-        case BASE_EXCLUSIVE:
-        case TOTAL_VALUE:
-            m_auraModifiersGroup[unitMod][modifierType] += apply ? amount : -amount;
-            break;
-        case BASE_PCT:
-        case TOTAL_PCT:
-            if (amount <= -100.0f)                          // small hack-fix for -100% modifiers
-                amount = -200.0f;
-
-            val = (100.0f + amount) / 100.0f;
-            m_auraModifiersGroup[unitMod][modifierType] *= apply ? val : (1.0f / val);
-            break;
-
-        default:
-            break;
-    }
-
-    if (!CanModifyStats())
-        return false;
-
-    switch (unitMod)
-    {
-        case UNIT_MOD_STAT_STRENGTH:
-        case UNIT_MOD_STAT_AGILITY:
-        case UNIT_MOD_STAT_STAMINA:
-        case UNIT_MOD_STAT_INTELLECT:
-        case UNIT_MOD_STAT_SPIRIT:         UpdateStats(GetStatByAuraGroup(unitMod));  break;
-
-        case UNIT_MOD_ARMOR:               UpdateArmor();           break;
-        case UNIT_MOD_HEALTH:              UpdateMaxHealth();       break;
-
-        case UNIT_MOD_MANA:
-        case UNIT_MOD_RAGE:
-        case UNIT_MOD_FOCUS:
-        case UNIT_MOD_ENERGY:
-        case UNIT_MOD_HAPPINESS:           UpdateMaxPower(GetPowerTypeByAuraGroup(unitMod)); break;
-
-        case UNIT_MOD_RESISTANCE_HOLY:
-        case UNIT_MOD_RESISTANCE_FIRE:
-        case UNIT_MOD_RESISTANCE_NATURE:
-        case UNIT_MOD_RESISTANCE_FROST:
-        case UNIT_MOD_RESISTANCE_SHADOW:
-        case UNIT_MOD_RESISTANCE_ARCANE:   UpdateResistances(GetSpellSchoolByAuraGroup(unitMod)); break;
-
-        case UNIT_MOD_ATTACK_POWER:        UpdateAttackPowerAndDamage();         break;
-        case UNIT_MOD_ATTACK_POWER_RANGED: UpdateAttackPowerAndDamage(true);     break;
-
-        case UNIT_MOD_DAMAGE_MAINHAND:     UpdateDamagePhysical(BASE_ATTACK);    break;
-        case UNIT_MOD_DAMAGE_OFFHAND:      UpdateDamagePhysical(OFF_ATTACK);     break;
-        case UNIT_MOD_DAMAGE_RANGED:       UpdateDamagePhysical(RANGED_ATTACK);  break;
-
-        default:
-            break;
-    }
-
-    return true;
-}
-
-float Unit::GetModifierValue(UnitMods unitMod, UnitModifierType modifierType) const
-{
-    if (unitMod >= UNIT_MOD_END || modifierType >= MODIFIER_TYPE_END)
-    {
-        sLog.outError("attempt to access nonexistent modifier value from UnitMods!");
-        return 0.0f;
-    }
-
-    if (modifierType == TOTAL_PCT && m_auraModifiersGroup[unitMod][modifierType] <= 0.0f)
-        return 0.0f;
-
-    return m_auraModifiersGroup[unitMod][modifierType];
-}
-
-float Unit::GetTotalStatValue(Stats stat) const
-{
-    UnitMods unitMod = UnitMods(UNIT_MOD_STAT_START + stat);
-
-    if (m_auraModifiersGroup[unitMod][TOTAL_PCT] <= 0.0f)
-        return 0.0f;
-
-    // value = ((base_value * base_pct) + total_value) * total_pct
-    float value  = m_auraModifiersGroup[unitMod][BASE_VALUE] + GetCreateStat(stat);
-    value *= m_auraModifiersGroup[unitMod][BASE_PCT];
-    value += m_auraModifiersGroup[unitMod][TOTAL_VALUE];
-    value *= m_auraModifiersGroup[unitMod][TOTAL_PCT];
-
-    return value;
-}
-
-float Unit::GetTotalAuraModValue(UnitMods unitMod) const
-{
-    if (unitMod >= UNIT_MOD_END)
-    {
-        sLog.outError("attempt to access nonexistent UnitMods in GetTotalAuraModValue()!");
-        return 0.0f;
-    }
-
-    if (m_auraModifiersGroup[unitMod][TOTAL_PCT] <= 0.0f)
-        return 0.0f;
-
-    float value  = m_auraModifiersGroup[unitMod][BASE_VALUE];
-    value += m_auraModifiersGroup[unitMod][BASE_EXCLUSIVE];
-    value *= m_auraModifiersGroup[unitMod][BASE_PCT];
-    value += m_auraModifiersGroup[unitMod][TOTAL_VALUE];
-    value *= m_auraModifiersGroup[unitMod][TOTAL_PCT];
-
-    return value;
-}
-
-SpellSchools Unit::GetSpellSchoolByAuraGroup(UnitMods unitMod) const
-{
-    SpellSchools school = SPELL_SCHOOL_NORMAL;
-
-    switch (unitMod)
-    {
-        case UNIT_MOD_RESISTANCE_HOLY:     school = SPELL_SCHOOL_HOLY;          break;
-        case UNIT_MOD_RESISTANCE_FIRE:     school = SPELL_SCHOOL_FIRE;          break;
-        case UNIT_MOD_RESISTANCE_NATURE:   school = SPELL_SCHOOL_NATURE;        break;
-        case UNIT_MOD_RESISTANCE_FROST:    school = SPELL_SCHOOL_FROST;         break;
-        case UNIT_MOD_RESISTANCE_SHADOW:   school = SPELL_SCHOOL_SHADOW;        break;
-        case UNIT_MOD_RESISTANCE_ARCANE:   school = SPELL_SCHOOL_ARCANE;        break;
-
-        default:
-            break;
-    }
-
-    return school;
-}
-
-Stats Unit::GetStatByAuraGroup(UnitMods unitMod) const
-{
-    Stats stat = STAT_STRENGTH;
-
-    switch (unitMod)
-    {
-        case UNIT_MOD_STAT_STRENGTH:    stat = STAT_STRENGTH;      break;
-        case UNIT_MOD_STAT_AGILITY:     stat = STAT_AGILITY;       break;
-        case UNIT_MOD_STAT_STAMINA:     stat = STAT_STAMINA;       break;
-        case UNIT_MOD_STAT_INTELLECT:   stat = STAT_INTELLECT;     break;
-        case UNIT_MOD_STAT_SPIRIT:      stat = STAT_SPIRIT;        break;
-
-        default:
-            break;
-    }
-
-    return stat;
-}
-
-Powers Unit::GetPowerTypeByAuraGroup(UnitMods unitMod) const
-{
-    switch (unitMod)
-    {
-        case UNIT_MOD_MANA:       return POWER_MANA;
-        case UNIT_MOD_RAGE:       return POWER_RAGE;
-        case UNIT_MOD_FOCUS:      return POWER_FOCUS;
-        case UNIT_MOD_ENERGY:     return POWER_ENERGY;
-        case UNIT_MOD_HAPPINESS:  return POWER_HAPPINESS;
-        default:                  return POWER_MANA;
-    }
-}
-
-float Unit::GetTotalAttackPowerValue(WeaponAttackType attType) const
-{
-    if (attType == RANGED_ATTACK)
-    {
-        int32 ap = GetInt32Value(UNIT_FIELD_RANGED_ATTACK_POWER) + GetInt32Value(UNIT_FIELD_RANGED_ATTACK_POWER_MODS);
-        if (ap < 0)
-            return 0.0f;
-        return ap * (1.0f + GetFloatValue(UNIT_FIELD_RANGED_ATTACK_POWER_MULTIPLIER));
-    }
-    else
-    {
-        int32 ap = GetInt32Value(UNIT_FIELD_ATTACK_POWER) + GetInt32Value(UNIT_FIELD_ATTACK_POWER_MODS);
-        if (ap < 0)
-            return 0.0f;
-        return ap * (1.0f + GetFloatValue(UNIT_FIELD_ATTACK_POWER_MULTIPLIER));
-    }
-}
-
-float Unit::GetWeaponDamageRange(WeaponAttackType attType , WeaponDamageRange type) const
-{
-    if (attType == OFF_ATTACK && !haveOffhandWeapon())
-        return 0.0f;
-
-    return m_weaponDamage[attType][type];
-}
-
-void Unit::SetLevel(uint32 lvl)
-{
-    SetUInt32Value(UNIT_FIELD_LEVEL, lvl);
-
-    // group update
-    if ((GetTypeId() == TYPEID_PLAYER) && ((Player*)this)->GetGroup())
-        ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_LEVEL);
-}
-
-void Unit::SetHealth(uint32 val)
-{
-    uint32 maxHealth = GetMaxHealth();
-    if (maxHealth < val)
-        val = maxHealth;
-
-    SetUInt32Value(UNIT_FIELD_HEALTH, val);
-
-    // group update
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        if (((Player*)this)->GetGroup())
-            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_CUR_HP);
-    }
-    else if (((Creature*)this)->IsPet())
-    {
-        Pet* pet = ((Pet*)this);
-        if (pet->isControlled())
-        {
-            Unit* owner = GetOwner();
-            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
-                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_CUR_HP);
-        }
-    }
-}
-
-void Unit::SetMaxHealth(uint32 val)
-{
-    uint32 health = GetHealth();
-    SetUInt32Value(UNIT_FIELD_MAXHEALTH, val);
-
-    // group update
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        if (((Player*)this)->GetGroup())
-            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_MAX_HP);
-    }
-    else if (((Creature*)this)->IsPet())
-    {
-        Pet* pet = ((Pet*)this);
-        if (pet->isControlled())
-        {
-            Unit* owner = GetOwner();
-            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
-                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_MAX_HP);
-        }
-    }
-
-    if (val < health)
-        SetHealth(val);
-}
-
-void Unit::SetHealthPercent(float percent)
-{
-    uint32 newHealth = GetMaxHealth() * percent / 100.0f;
-    SetHealth(newHealth);
-}
-
-void Unit::SetPower(Powers power, uint32 val)
-{
-    if (GetPower(power) == val)
-        return;
-
-    uint32 maxPower = GetMaxPower(power);
-    if (maxPower < val)
-        val = maxPower;
-
-    SetStatInt32Value(UNIT_FIELD_POWER1 + power, val);
-
-    // group update
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        if (((Player*)this)->GetGroup())
-            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_CUR_POWER);
-    }
-    else if (((Creature*)this)->IsPet())
-    {
-        Pet* pet = ((Pet*)this);
-        if (pet->isControlled())
-        {
-            Unit* owner = GetOwner();
-            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
-                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_CUR_POWER);
-        }
-
-        // Update the pet's character sheet with happiness damage bonus
-        if (pet->getPetType() == HUNTER_PET && power == POWER_HAPPINESS)
-            pet->UpdateDamagePhysical(BASE_ATTACK);
-    }
-}
-
-void Unit::SetMaxPower(Powers power, uint32 val)
-{
-    uint32 cur_power = GetPower(power);
-    SetStatInt32Value(UNIT_FIELD_MAXPOWER1 + power, val);
-
-    // group update
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        if (((Player*)this)->GetGroup())
-            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_MAX_POWER);
-    }
-    else if (((Creature*)this)->IsPet())
-    {
-        Pet* pet = ((Pet*)this);
-        if (pet->isControlled())
-        {
-            Unit* owner = GetOwner();
-            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
-                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_MAX_POWER);
-        }
-    }
-
-    if (val < cur_power)
-        SetPower(power, val);
-}
-
-void Unit::ApplyPowerMod(Powers power, uint32 val, bool apply)
-{
-    ApplyModUInt32Value(UNIT_FIELD_POWER1 + power, val, apply);
-
-    // group update
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        if (((Player*)this)->GetGroup())
-            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_CUR_POWER);
-    }
-    else if (((Creature*)this)->IsPet())
-    {
-        Pet* pet = ((Pet*)this);
-        if (pet->isControlled())
-        {
-            Unit* owner = GetOwner();
-            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
-                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_CUR_POWER);
-        }
-    }
-}
-
-void Unit::ApplyMaxPowerMod(Powers power, uint32 val, bool apply)
-{
-    ApplyModUInt32Value(UNIT_FIELD_MAXPOWER1 + power, val, apply);
-
-    // group update
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        if (((Player*)this)->GetGroup())
-            ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_MAX_POWER);
-    }
-    else if (((Creature*)this)->IsPet())
-    {
-        Pet* pet = ((Pet*)this);
-        if (pet->isControlled())
-        {
-            Unit* owner = GetOwner();
-            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
-                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_MAX_POWER);
-        }
-    }
-}
-
-void Unit::ApplyAuraProcTriggerDamage(Aura* aura, bool apply)
-{
-    AuraList& tAuraProcTriggerDamage = m_modAuras[SPELL_AURA_PROC_TRIGGER_DAMAGE];
-    if (apply)
-        tAuraProcTriggerDamage.push_back(aura);
-    else
-        tAuraProcTriggerDamage.remove(aura);
-}
-
-uint32 Unit::GetCreatePowers(Powers power) const
-{
-    switch (power)
-    {
-        case POWER_HEALTH:      return 0;                   // is it really should be here?
-        case POWER_MANA:        return GetCreateMana();
-        case POWER_RAGE:        return POWER_RAGE_DEFAULT;
-        case POWER_FOCUS:       return (GetTypeId() == TYPEID_PLAYER || !((Creature const*)this)->IsPet() || ((Pet const*)this)->getPetType() != HUNTER_PET ? 0 : POWER_FOCUS_DEFAULT);
-        case POWER_ENERGY:      return POWER_ENERGY_DEFAULT;
-        case POWER_HAPPINESS:   return (GetTypeId() == TYPEID_PLAYER || !((Creature const*)this)->IsPet() || ((Pet const*)this)->getPetType() != HUNTER_PET ? 0 : POWER_HAPPINESS_DEFAULT);
-    }
-
-    return 0;
-}
-
-void Unit::AddToWorld()
-{
-    Object::AddToWorld();
-    ScheduleAINotify(0);
-}
-
-void Unit::RemoveFromWorld()
-{
-    // cleanup
-    if (IsInWorld())
-    {
-        Uncharm();
-        RemoveNotOwnTrackedTargetAuras();
-        RemoveGuardians();
-        RemoveAllGameObjects();
-        RemoveAllDynObjects();
-        CleanupDeletedAuras();
-        GetViewPoint().Event_RemovedFromWorld();
-    }
-
-    Object::RemoveFromWorld();
-}
-
-void Unit::CleanupsBeforeDelete()
-{
-    if (m_uint32Values)                                     // only for fully created object
-    {
-        InterruptNonMeleeSpells(true);
-        m_Events.KillAllEvents(false);                      // non-delatable (currently casted spells) will not deleted now but it will deleted at call in Map::RemoveAllObjectsInRemoveList
-        CombatStop();
-        ClearComboPointHolders();
-        DeleteThreatList();
-        if (GetTypeId() == TYPEID_PLAYER)
-            getHostileRefManager().setOnlineOfflineState(false);
-        else
-            getHostileRefManager().deleteReferences();
-        RemoveAllAuras(AURA_REMOVE_BY_DELETE);
-    }
-    WorldObject::CleanupsBeforeDelete();
-}
-
-CharmInfo* Unit::InitCharmInfo(Unit* charm)
-{
-    delete m_charmInfo;
-    m_charmInfo = new CharmInfo(charm);
-
-    return m_charmInfo;
-}
-
-CharmInfo::CharmInfo(Unit* unit) :
-    m_unit(unit), m_ai(nullptr), m_combatData(nullptr),
-    m_CommandState(COMMAND_FOLLOW), m_reactState(REACT_PASSIVE),
-    m_petnumber(0), m_retreating(false), m_stayPosSet(false),
-    m_stayPosX(0), m_stayPosY(0), m_stayPosZ(0), m_stayPosO(0),
-    m_opener(0), m_openerMinRange(0), m_openerMaxRange(0),
-    m_unitFieldBytes2_1(0)
-{
-    for (int i = 0; i < CREATURE_MAX_SPELLS; ++i)
-        m_charmspells[i].SetActionAndType(0, ACT_DISABLED);
-}
-
-CharmInfo::~CharmInfo()
-{
-    delete m_combatData;
-    delete m_ai;
-}
-
-void CharmInfo::SetCharmState(std::string const & ainame /*= "PetAI"*/, bool withNewThreatList /*= true*/)
-{
-    if (!ainame.empty())
-        m_ai = FactorySelector::GetSpecificAI(m_unit, ainame);
-    else
-        m_ai = FactorySelector::GetSpecificAI(m_unit, "PetAI");
-
-    if (withNewThreatList)
-        m_combatData = new CombatData(m_unit);
-
-    m_unitFieldBytes2_1 = m_unit->GetByteValue(UNIT_FIELD_BYTES_2, 1);
-}
-
-void CharmInfo::ResetCharmState()
-{
-    m_unit->SetByteValue(UNIT_FIELD_BYTES_2, 1, m_unitFieldBytes2_1);
-}
-
-
-void CharmInfo::InitPetActionBar()
-{
-    // the first 3 SpellOrActions are attack, follow and stay
-    for (uint32 i = 0; i < ACTION_BAR_INDEX_PET_SPELL_START - ACTION_BAR_INDEX_START; ++i)
-        SetActionBar(ACTION_BAR_INDEX_START + i, COMMAND_ATTACK - i, ACT_COMMAND);
-
-    // middle 4 SpellOrActions are spells/special attacks/abilities
-    for (uint32 i = 0; i < ACTION_BAR_INDEX_PET_SPELL_END - ACTION_BAR_INDEX_PET_SPELL_START; ++i)
-        SetActionBar(ACTION_BAR_INDEX_PET_SPELL_START + i, 0, ACT_DISABLED);
-
-    // last 3 SpellOrActions are reactions
-    for (uint32 i = 0; i < ACTION_BAR_INDEX_END - ACTION_BAR_INDEX_PET_SPELL_END; ++i)
-        SetActionBar(ACTION_BAR_INDEX_PET_SPELL_END + i, COMMAND_ATTACK - i, ACT_REACTION);
-}
-
-void CharmInfo::InitEmptyActionBar()
-{
-    for (uint32 x = ACTION_BAR_INDEX_START + 1; x < ACTION_BAR_INDEX_END; ++x)
-        SetActionBar(x, 0, ACT_PASSIVE);
-}
-
-void CharmInfo::InitPossessCreateSpells()
-{
-    InitEmptyActionBar();                                   // charm action bar
-
-    SetActionBar(ACTION_BAR_INDEX_START, COMMAND_ATTACK, ACT_COMMAND);
-
-    if (m_unit->GetTypeId() == TYPEID_PLAYER)               // possessed players don't have spells, keep the action bar empty
-        return;
-
-    for (uint32 x = 0; x < CREATURE_MAX_SPELLS; ++x)
-    {
-        if (IsPassiveSpell(((Creature*)m_unit)->m_spells[x]))
-            m_unit->CastSpell(m_unit, ((Creature*)m_unit)->m_spells[x], TRIGGERED_OLD_TRIGGERED);
-        else
-            AddSpellToActionBar(((Creature*)m_unit)->m_spells[x], ACT_PASSIVE);
-    }
-}
-
-void CharmInfo::InitCharmCreateSpells()
-{
-    InitPetActionBar();
-
-    SetActionBar(ACTION_BAR_INDEX_START, COMMAND_ATTACK, ACT_COMMAND);
-
-    if (m_unit->GetTypeId() == TYPEID_PLAYER)               // charmed players don't have spells
-        return;
-
-    for (uint32 x = 0; x < CREATURE_MAX_SPELLS; ++x)
-    {
-        uint32 spellId = ((Creature*)m_unit)->m_spells[x];
-
-        if (!spellId)
-        {
-            m_charmspells[x].SetActionAndType(spellId, ACT_DISABLED);
-            continue;
-        }
-
-        if (IsPassiveSpell(spellId))
-        {
-            m_unit->CastSpell(m_unit, spellId, TRIGGERED_OLD_TRIGGERED);
-            m_charmspells[x].SetActionAndType(spellId, ACT_PASSIVE);
-        }
-        else
-        {
-            m_charmspells[x].SetActionAndType(spellId, ACT_DISABLED);
-
-            ActiveStates newstate;
-            bool onlyselfcast = true;
-            SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
-
-            for (uint32 i = 0; i < 3 && onlyselfcast; ++i)  // nonexistent spell will not make any problems as onlyselfcast would be false -> break right away
-            {
-                if (spellInfo->EffectImplicitTargetA[i] != TARGET_SELF && spellInfo->EffectImplicitTargetA[i] != 0)
-                    onlyselfcast = false;
-            }
-
-            if (onlyselfcast || !IsPositiveSpell(spellId))  // only self cast and spells versus enemies are autocastable
-                newstate = ACT_DISABLED;
-            else
-                newstate = ACT_PASSIVE;
-
-            AddSpellToActionBar(spellId, newstate);
-        }
-    }
-}
-
-bool CharmInfo::AddSpellToActionBar(uint32 spellId, ActiveStates newstate)
-{
-    uint32 first_id = sSpellMgr.GetFirstSpellInChain(spellId);
-
-    // new spell rank can be already listed
-    for (uint8 i = 0; i < MAX_UNIT_ACTION_BAR_INDEX; ++i)
-    {
-        if (uint32 action = PetActionBar[i].GetAction())
-        {
-            if (PetActionBar[i].IsActionBarForSpell() && sSpellMgr.GetFirstSpellInChain(action) == first_id)
-            {
-                PetActionBar[i].SetAction(spellId);
-                return true;
-            }
-        }
-    }
-
-    // or use empty slot in other case
-    for (uint8 i = 0; i < MAX_UNIT_ACTION_BAR_INDEX; ++i)
-    {
-        if (!PetActionBar[i].GetAction() && PetActionBar[i].IsActionBarForSpell())
-        {
-            SetActionBar(i, spellId, newstate == ACT_DECIDE ? IsAutocastable(spellId) ? ACT_DISABLED : ACT_PASSIVE : newstate);
-            return true;
-        }
-    }
-    return false;
-}
-
-bool CharmInfo::RemoveSpellFromActionBar(uint32 spell_id)
-{
-    uint32 first_id = sSpellMgr.GetFirstSpellInChain(spell_id);
-
-    for (uint8 i = 0; i < MAX_UNIT_ACTION_BAR_INDEX; ++i)
-    {
-        if (uint32 action = PetActionBar[i].GetAction())
-        {
-            if (PetActionBar[i].IsActionBarForSpell() && sSpellMgr.GetFirstSpellInChain(action) == first_id)
-            {
-                SetActionBar(i, 0, ACT_DISABLED);
-                return true;
-            }
-        }
-    }
-
-    return false;
-}
-
-void CharmInfo::ToggleCreatureAutocast(uint32 spellid, bool apply)
-{
-    if (IsPassiveSpell(spellid))
-        return;
-
-    for (uint32 x = 0; x < CREATURE_MAX_SPELLS; ++x)
-        if (spellid == m_charmspells[x].GetAction())
-            m_charmspells[x].SetType(apply ? ACT_ENABLED : ACT_DISABLED);
-}
-
-void CharmInfo::SetPetNumber(uint32 petnumber, bool statwindow)
-{
-    m_petnumber = petnumber;
-    if (statwindow)
-        m_unit->SetUInt32Value(UNIT_FIELD_PETNUMBER, m_petnumber);
-    else
-        m_unit->SetUInt32Value(UNIT_FIELD_PETNUMBER, 0);
-}
-
-void CharmInfo::SetCommandState(CommandStates st)
-{
-    m_CommandState = st;
-
-    switch (st)
-    {
-        case COMMAND_STAY:
-            SetIsRetreating();
-            SetStayPosition(true);
-            SetSpellOpener();
-            break;
-
-        case COMMAND_FOLLOW:
-            SetStayPosition();
-            SetSpellOpener();
-            break;
-
-        default:
-            break;
-    }
-}
-
-void CharmInfo::LoadPetActionBar(const std::string& data)
-{
-    InitPetActionBar();
-
-    Tokens tokens = StrSplit(data, " ");
-
-    if (tokens.size() != (ACTION_BAR_INDEX_END - ACTION_BAR_INDEX_START) * 2)
-        return;                                             // non critical, will reset to default
-
-    int index;
-    Tokens::iterator iter;
-    for (iter = tokens.begin(), index = ACTION_BAR_INDEX_START; index < ACTION_BAR_INDEX_END; ++iter, ++index)
-    {
-        // use unsigned cast to avoid sign negative format use at long-> ActiveStates (int) conversion
-        uint8 type  = (uint8)std::stoul((*iter).c_str());
-        ++iter;
-        uint32 action = std::stoul((*iter).c_str());
-
-        PetActionBar[index].SetActionAndType(action, ActiveStates(type));
-
-        // check correctness
-        if (PetActionBar[index].IsActionBarForSpell())
-        {
-            SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(PetActionBar[index].GetAction());
-            if (!spellInfo)
-                SetActionBar(index, 0, ACT_DISABLED);
-            else if (!IsAutocastable(spellInfo))
-                SetActionBar(index, PetActionBar[index].GetAction(), ACT_PASSIVE);
-        }
-    }
-}
-
-void CharmInfo::BuildActionBar(WorldPacket& data) const
-{
-    for (uint32 i = 0; i < MAX_UNIT_ACTION_BAR_INDEX; ++i)
-        data << uint32(PetActionBar[i].packedData);
-}
-
-void CharmInfo::SetSpellAutocast(uint32 spell_id, bool state)
-{
-    for (int i = 0; i < MAX_UNIT_ACTION_BAR_INDEX; ++i)
-    {
-        if (spell_id == PetActionBar[i].GetAction() && PetActionBar[i].IsActionBarForSpell())
-        {
-            PetActionBar[i].SetType(state ? ACT_ENABLED : ACT_DISABLED);
-            break;
-        }
-    }
-}
-
-void CharmInfo::SetStayPosition(bool stay)
-{
-    if (stay)
-    {
-        m_stayPosX = m_unit->GetPositionX();
-        m_stayPosY = m_unit->GetPositionY();
-        m_stayPosZ = m_unit->GetPositionZ();
-        m_stayPosO = m_unit->GetOrientation();
-    }
-    else
-    {
-        m_stayPosX = 0;
-        m_stayPosY = 0;
-        m_stayPosZ = 0;
-        m_stayPosO = 0;
-    }
-
-    m_stayPosSet = stay;
-}
-
-bool Unit::isFrozen() const
-{
-    return HasAuraState(AURA_STATE_FROZEN);
-}
-
-struct ProcTriggeredData
-{
-    ProcTriggeredData(SpellProcEventEntry const* _spellProcEvent, SpellAuraHolder* _triggeredByHolder)
-        : spellProcEvent(_spellProcEvent), triggeredByHolder(_triggeredByHolder)
-    {}
-    SpellProcEventEntry const* spellProcEvent;
-    SpellAuraHolder* triggeredByHolder;
-};
-
-typedef std::list< ProcTriggeredData > ProcTriggeredList;
-typedef std::list< uint32> RemoveSpellList;
-
-uint32 createProcExtendMask(SpellNonMeleeDamage* damageInfo, SpellMissInfo missCondition)
-{
-    uint32 procEx = PROC_EX_NONE;
-    // Check victim state
-    if (missCondition != SPELL_MISS_NONE)
-        switch (missCondition)
-        {
-            case SPELL_MISS_MISS:    procEx |= PROC_EX_MISS;   break;
-            case SPELL_MISS_RESIST:  procEx |= PROC_EX_RESIST; break;
-            case SPELL_MISS_DODGE:   procEx |= PROC_EX_DODGE;  break;
-            case SPELL_MISS_PARRY:   procEx |= PROC_EX_PARRY;  break;
-            case SPELL_MISS_BLOCK:   procEx |= PROC_EX_BLOCK;  break;
-            case SPELL_MISS_EVADE:   procEx |= PROC_EX_EVADE;  break;
-            case SPELL_MISS_IMMUNE:  procEx |= PROC_EX_IMMUNE; break;
-            case SPELL_MISS_IMMUNE2: procEx |= PROC_EX_IMMUNE; break;
-            case SPELL_MISS_DEFLECT: procEx |= PROC_EX_DEFLECT; break;
-            case SPELL_MISS_ABSORB:  procEx |= PROC_EX_ABSORB; break;
-            case SPELL_MISS_REFLECT: procEx |= PROC_EX_REFLECT; break;
-            default:
-                break;
-        }
-    else
-    {
-        // On block
-        if (damageInfo->blocked)
-            procEx |= PROC_EX_BLOCK;
-        // On absorb
-        if (damageInfo->absorb)
-            procEx |= PROC_EX_ABSORB;
-        // On crit
-        if (damageInfo->HitInfo & SPELL_HIT_TYPE_CRIT)
-            procEx |= PROC_EX_CRITICAL_HIT;
-        else
-            procEx |= PROC_EX_NORMAL_HIT;
-    }
-    return procEx;
-}
-
-void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* pTarget, uint32 procFlag, uint32 procExtra, WeaponAttackType attType, SpellEntry const* procSpell, uint32 damage)
-{
-    // For melee/ranged based attack need update skills and set some Aura states
-    if (procFlag & MELEE_BASED_TRIGGER_MASK)
-    {
-        // Update skills here for players
-        if (GetTypeId() == TYPEID_PLAYER)
-        {
-            // On melee based hit/miss/resist need update skill (for victim and attacker)
-            if (procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_MISS | PROC_EX_RESIST))
-            {
-                if (pTarget->GetTypeId() != TYPEID_PLAYER && pTarget->GetCreatureType() != CREATURE_TYPE_CRITTER)
-                    ((Player*)this)->UpdateCombatSkills(pTarget, attType, isVictim);
-            }
-            // Update defence if player is victim and parry/dodge/block
-            if (isVictim && procExtra & (PROC_EX_DODGE | PROC_EX_PARRY | PROC_EX_BLOCK))
-                ((Player*)this)->UpdateDefense();
-        }
-        // If exist crit/parry/dodge/block need update aura state (for victim and attacker)
-        if (procExtra & (PROC_EX_CRITICAL_HIT | PROC_EX_PARRY | PROC_EX_DODGE | PROC_EX_BLOCK))
-        {
-            // for victim
-            if (isVictim)
-            {
-                // if victim and dodge attack
-                if (procExtra & PROC_EX_DODGE)
-                {
-                    // Update AURA_STATE on dodge
-                    if (getClass() != CLASS_ROGUE) // skip Rogue Riposte
-                    {
-                        ModifyAuraState(AURA_STATE_DEFENSE, true);
-                        StartReactiveTimer(REACTIVE_DEFENSE);
-                    }
-                }
-                // if victim and parry attack
-                if (procExtra & PROC_EX_PARRY)
-                {
-                    // For Hunters only Counterattack (skip Mongoose bite)
-                    if (getClass() == CLASS_HUNTER)
-                    {
-                        ModifyAuraState(AURA_STATE_HUNTER_PARRY, true);
-                        StartReactiveTimer(REACTIVE_HUNTER_PARRY);
-                    }
-                    else
-                    {
-                        ModifyAuraState(AURA_STATE_DEFENSE, true);
-                        StartReactiveTimer(REACTIVE_DEFENSE);
-                    }
-                }
-                // if and victim block attack
-                if (procExtra & PROC_EX_BLOCK)
-                {
-                    ModifyAuraState(AURA_STATE_DEFENSE, true);
-                    StartReactiveTimer(REACTIVE_DEFENSE);
-                }
-            }
-            else // For attacker
-            {
-                // Overpower on victim dodge
-                if (procExtra & PROC_EX_DODGE && GetTypeId() == TYPEID_PLAYER && getClass() == CLASS_WARRIOR)
-                {
-                    ((Player*)this)->AddComboPoints(pTarget, 1);
-                    StartReactiveTimer(REACTIVE_OVERPOWER);
-                }
-                // Enable AURA_STATE_CRIT on crit
-                if (procExtra & PROC_EX_CRITICAL_HIT)
-                {
-                    ModifyAuraState(AURA_STATE_CRIT, true);
-                    StartReactiveTimer(REACTIVE_CRIT);
-                    if (getClass() == CLASS_HUNTER)
-                    {
-                        ModifyAuraState(AURA_STATE_HUNTER_CRIT_STRIKE, true);
-                        StartReactiveTimer(REACTIVE_HUNTER_CRIT);
-                    }
-                }
-            }
-        }
-    }
-
-    RemoveSpellList removedSpells;
-    ProcTriggeredList procTriggered;
-    // Fill procTriggered list
-    for (SpellAuraHolderMap::const_iterator itr = GetSpellAuraHolderMap().begin(); itr != GetSpellAuraHolderMap().end(); ++itr)
-    {
-        // skip deleted auras (possible at recursive triggered call
-        if (itr->second->GetState() != SPELLAURAHOLDER_STATE_READY || itr->second->IsDeleted())
-            continue;
-
-        SpellProcEventEntry const* spellProcEvent = nullptr;
-        if (!IsTriggeredAtSpellProcEvent(pTarget, itr->second, procSpell, procFlag, procExtra, attType, isVictim, spellProcEvent))
-            continue;
-
-        itr->second->SetInUse(true);                        // prevent holder deletion
-        procTriggered.push_back(ProcTriggeredData(spellProcEvent, itr->second));
-    }
-
-    // Nothing found
-    if (procTriggered.empty())
-        return;
-
-    // Handle effects proceed this time
-    for (ProcTriggeredList::const_iterator itr = procTriggered.begin(); itr != procTriggered.end(); ++itr)
-    {
-        // Some auras can be deleted in function called in this loop (except first, ofc)
-        SpellAuraHolder* triggeredByHolder = itr->triggeredByHolder;
-        if (triggeredByHolder->IsDeleted())
-            continue;
-
-        SpellProcEventEntry const* spellProcEvent = itr->spellProcEvent;
-        bool useCharges = triggeredByHolder->GetAuraCharges() > 0;
-        bool procSuccess = true;
-        bool anyAuraProc = false;
-
-        // For players set spell cooldown if need
-        uint32 cooldown = 0;
-        if (GetTypeId() == TYPEID_PLAYER && spellProcEvent && spellProcEvent->cooldown)
-            cooldown = spellProcEvent->cooldown;
-
-        for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
-        {
-            Aura* triggeredByAura = triggeredByHolder->GetAuraByEffectIndex(SpellEffectIndex(i));
-            if (!triggeredByAura)
-                continue;
-
-            Modifier* auraModifier = triggeredByAura->GetModifier();
-
-            if (procSpell)
-            {
-                if (spellProcEvent)
-                {
-                    if (spellProcEvent->spellFamilyMask[i])
-                    {
-                        if (!procSpell->IsFitToFamilyMask(spellProcEvent->spellFamilyMask[i]))
-                            continue;
-                    }
-                    // don't check dbc FamilyFlags if schoolMask exists
-                    else if (!triggeredByAura->CanProcFrom(procSpell, spellProcEvent->procEx, procExtra, damage != 0, !spellProcEvent->schoolMask))
-                        continue;
-                }
-                else if (!triggeredByAura->CanProcFrom(procSpell, PROC_EX_NONE, procExtra, damage != 0, true))
-                    continue;
-            }
-
-            SpellAuraProcResult procResult = (*this.*AuraProcHandler[auraModifier->m_auraname])(pTarget, damage, triggeredByAura, procSpell, procFlag, procExtra, cooldown);
-            switch (procResult)
-            {
-                case SPELL_AURA_PROC_CANT_TRIGGER:
-                    continue;
-                case SPELL_AURA_PROC_FAILED:
-                    procSuccess = false;
-                    break;
-                case SPELL_AURA_PROC_OK:
-                    break;
-            }
-
-            anyAuraProc = true;
-        }
-
-        // Remove charge (aura can be removed by triggers)
-        if (useCharges && procSuccess && anyAuraProc && !triggeredByHolder->IsDeleted())
-        {
-            // If last charge dropped add spell to remove list
-            if (triggeredByHolder->DropAuraCharge())
-                removedSpells.push_back(triggeredByHolder->GetId());
-        }
-
-        triggeredByHolder->SetInUse(false);
-    }
-
-    if (!removedSpells.empty())
-    {
-        // Sort spells and remove duplicates
-        removedSpells.sort();
-        removedSpells.unique();
-        // Remove auras from removedAuras
-        for (RemoveSpellList::const_iterator i = removedSpells.begin(); i != removedSpells.end(); ++i)
-            RemoveAurasDueToSpell(*i);
-    }
-}
-
-SpellSchoolMask Unit::GetMeleeDamageSchoolMask() const
-{
-    return SPELL_SCHOOL_MASK_NORMAL;
-}
-
-Player* Unit::GetSpellModOwner() const
-{
-    if (GetTypeId() == TYPEID_PLAYER)
-        return (Player*)this;
-    if (((Creature*)this)->IsPet() || ((Creature*)this)->IsTotem())
-    {
-        Unit* owner = GetOwner();
-        if (owner && owner->GetTypeId() == TYPEID_PLAYER)
-            return (Player*)owner;
-    }
-    return nullptr;
-}
-
-///----------Pet responses methods-----------------
-void Unit::SendPetActionFeedback(uint8 msg) const
-{
-    Unit* owner = GetOwner();
-    if (!owner || owner->GetTypeId() != TYPEID_PLAYER)
-        return;
-
-    WorldPacket data(SMSG_PET_ACTION_FEEDBACK, 1);
-    data << uint8(msg);
-    ((Player*)owner)->GetSession()->SendPacket(data);
-}
-
-void Unit::SendPetTalk(uint32 pettalk) const
-{
-    Unit* owner = GetOwner();
-    if (!owner || owner->GetTypeId() != TYPEID_PLAYER)
-        return;
-
-    WorldPacket data(SMSG_PET_ACTION_SOUND, 8 + 4);
-    data << GetObjectGuid();
-    data << uint32(pettalk);
-    ((Player*)owner)->GetSession()->SendPacket(data);
-}
-
-void Unit::SendPetAIReaction() const
-{
-    Unit* owner = GetOwner();
-    if (!owner || owner->GetTypeId() != TYPEID_PLAYER)
-        return;
-
-    WorldPacket data(SMSG_AI_REACTION, 8 + 4);
-    data << GetObjectGuid();
-    data << uint32(AI_REACTION_HOSTILE);
-    ((Player*)owner)->GetSession()->SendPacket(data);
-}
-
-///----------End of Pet responses methods----------
-
-void Unit::StopMoving(bool forceSendStop /*=false*/)
-{
-    if (IsStopped() && !forceSendStop)
-        return;
-
-    clearUnitState(UNIT_STAT_MOVING);
-
-    // not need send any packets if not in world
-    if (!IsInWorld())
-        return;
-
-    Movement::MoveSplineInit init(*this);
-    init.Stop(forceSendStop);
-}
-
-void Unit::InterruptMoving(bool forceSendStop /*=false*/)
-{
-    bool isMoving = false;
-
-    if (!movespline->Finalized())
-    {
-        Movement::Location loc = movespline->ComputePosition();
-        movespline->_Interrupt();
-        Relocate(loc.x, loc.y, loc.z, loc.orientation);
-        isMoving = true;
-    }
-
-    StopMoving(forceSendStop || isMoving);
-}
-
-void Unit::SetImmobilizedState(bool apply, bool stun)
-{
-    const uint32 immobilized = (UNIT_STAT_ROOT | UNIT_STAT_STUNNED);
-    const uint32 state = stun ? UNIT_STAT_STUNNED : UNIT_STAT_ROOT;
-    const Unit* charmer = GetCharmer();
-    const bool player = ((charmer ? charmer : this)->GetTypeId() == TYPEID_PLAYER);
-    if (apply)
-    {
-        addUnitState(state);
-        if (!player)
-            StopMoving();
-        else
-        {
-            // Clear unit movement flags
-            m_movementInfo.SetMovementFlags(MOVEFLAG_NONE);
-            if (stun)
-                SetStandState(UNIT_STAND_STATE_STAND); // in 1.5 client
-            SetRoot(true);
-        }
-    }
-    else
-    {
-        clearUnitState(state);
-        // Prevent giving ability to move if more immobilizers are active
-        if (!hasUnitState(immobilized) && (player || m_movementInfo.HasMovementFlag(MOVEFLAG_ROOT)))
-            SetRoot(false);
-    }
-}
-
-void Unit::SetFeared(bool apply, ObjectGuid casterGuid, uint32 spellID, uint32 time)
-{
-    SetIncapacitatedState(apply, UNIT_FLAG_FLEEING, casterGuid, spellID, time);
-}
-
-void Unit::SetConfused(bool apply, ObjectGuid casterGuid, uint32 spellID)
-{
-    SetIncapacitatedState(apply, UNIT_FLAG_CONFUSED, casterGuid, spellID);
-}
-
-void Unit::SetStunned(bool apply, ObjectGuid casterGuid, uint32 spellID)
-{
-    SetIncapacitatedState(apply, UNIT_FLAG_STUNNED, casterGuid, spellID);
-}
-
-void Unit::SetIncapacitatedState(bool apply, uint32 state, ObjectGuid casterGuid, uint32 spellID, uint32 time)
-{
-    // We are interested only in a particular subset of flags:
-    const uint32 filter = (UNIT_FLAG_STUNNED | UNIT_FLAG_CONFUSED | UNIT_FLAG_FLEEING);
-    if (!state || !(state & filter) || (state & ~filter))
-        return;
-
-    Player* controller = GetCharmerOrOwnerPlayerOrPlayerItself();
-    const bool control = controller ? controller->IsClientControl(this) : false;
-    const bool movement = (state != UNIT_FLAG_STUNNED);
-    const bool stun = !!(state & UNIT_FLAG_STUNNED);
-    const bool fleeing = !!(state & UNIT_FLAG_FLEEING);
-
-    if (apply)
-    {
-        if (fleeing && HasAuraType(SPELL_AURA_PREVENTS_FLEEING))
-        {
-            if (state == UNIT_FLAG_FLEEING)
-                return;
-            else
-                state &= ~UNIT_FLAG_FLEEING;
-        }
-        SetFlag(UNIT_FIELD_FLAGS, state);
-    }
-    else
-        RemoveFlag(UNIT_FIELD_FLAGS, state);
-
-    if (movement)
-        GetMotionMaster()->MovementExpired(false);
-    if (apply)
-        CastStop(GetObjectGuid() == casterGuid ? spellID : 0);
-
-    if (GetTypeId() == TYPEID_UNIT)
-    {
-        if (HasFlag(UNIT_FIELD_FLAGS, filter))
-        {
-            if (!GetTargetGuid().IsEmpty()) // Incapacitated creature loses its target
-                SetTargetGuid(ObjectGuid());
-        }
-        else if (isAlive())
-        {
-            if (Unit* victim = getVictim())
-            {
-                SetTargetGuid(victim->GetObjectGuid());  // Restore target
-                if (movement)
-                    GetMotionMaster()->MoveChase(victim); // Restore movement generator
-            }
-            else if (movement)
-                GetMotionMaster()->Initialize(); // Reset movement generator
-
-            if (!apply && fleeing)
-            {
-                // Attack the caster if can on fear expiration
-                if (Unit* caster = IsInWorld() ? GetMap()->GetUnit(casterGuid) : nullptr)
-                    ((Creature*)this)->AttackedBy(caster);
-            }
-        }
-    }
-
-    // Update stun if required:
-    if (stun)
-        SetImmobilizedState(apply, true);
-
-    if (!movement)
-        return;
-
-    // Check if we should return or remove player control after change
-    if (controller)
-    {
-        const bool remove = !controller->IsClientControl(this);
-        if (control && remove)
-            controller->SetClientControl(this, 0);
-        else if (!control && !remove)
-            controller->SetClientControl(this, 1);
-    }
-
-    // Update incapacitated movement if required:
-    if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_CONFUSED))
-    {
-        StopMoving(true);
-        GetMotionMaster()->MoveConfused();
-    }
-    else if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_FLEEING))
-    {
-        StopMoving(true);
-        GetMotionMaster()->MoveFleeing(IsInWorld() ?  GetMap()->GetUnit(casterGuid) : nullptr, time);
-    }
-}
-
-void Unit::SetFeignDeath(bool apply, ObjectGuid casterGuid /*= ObjectGuid()*/)
-{
-    if (apply)
-    {
-        /*
-        WorldPacket data(SMSG_FEIGN_DEATH_RESISTED, 9);
-        data<<GetGUID();
-        data<<uint8(0);
-        SendMessageToSet(data,true);
-        */
-
-        if (GetTypeId() != TYPEID_PLAYER)
-            StopMoving();
-        else
-            ((Player*)this)->m_movementInfo.SetMovementFlags(MOVEFLAG_NONE);
-
-        // blizz like 2.0.x
-        SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNK_29);
-        // blizz like 2.0.x
-        SetFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
-        // blizz like 2.0.x
-        SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
-
-        addUnitState(UNIT_STAT_DIED);
-        CombatStop();
-        RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_IMMUNE_OR_LOST_SELECTION);
-
-        // prevent interrupt message
-        if (casterGuid == GetObjectGuid())
-            FinishSpell(CURRENT_GENERIC_SPELL, false);
-        InterruptNonMeleeSpells(true);
-        getHostileRefManager().deleteReferences();
-    }
-    else
-    {
-        /*
-        WorldPacket data(SMSG_FEIGN_DEATH_RESISTED, 9);
-        data<<GetGUID();
-        data<<uint8(1);
-        SendMessageToSet(data,true);
-        */
-        // blizz like 2.0.x
-        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNK_29);
-        // blizz like 2.0.x
-        RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
-        // blizz like 2.0.x
-        RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
-
-        clearUnitState(UNIT_STAT_DIED);
-
-        if (GetTypeId() != TYPEID_PLAYER && isAlive())
-        {
-            // restore appropriate movement generator
-            if (getVictim())
-                GetMotionMaster()->MoveChase(getVictim());
-            else
-                GetMotionMaster()->Initialize();
-        }
-    }
-}
-
-bool Unit::IsSitState() const
-{
-    uint8 s = getStandState();
-    return
-        s == UNIT_STAND_STATE_SIT_CHAIR        || s == UNIT_STAND_STATE_SIT_LOW_CHAIR  ||
-        s == UNIT_STAND_STATE_SIT_MEDIUM_CHAIR || s == UNIT_STAND_STATE_SIT_HIGH_CHAIR ||
-        s == UNIT_STAND_STATE_SIT;
-}
-
-bool Unit::IsStandState() const
-{
-    uint8 s = getStandState();
-    return !IsSitState() && s != UNIT_STAND_STATE_SLEEP && s != UNIT_STAND_STATE_KNEEL;
-}
-
-void Unit::SetStandState(uint8 state)
-{
-    SetByteValue(UNIT_FIELD_BYTES_1, 0, state);
-
-    if (IsStandState())
-        RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_SEATED);
-
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        WorldPacket data(SMSG_STANDSTATE_UPDATE, 1);
-        data << (uint8)state;
-        ((Player*)this)->GetSession()->SendPacket(data);
-    }
-}
-
-bool Unit::IsPolymorphed() const
-{
-    return IsSpellMagePolymorph(getTransForm());
-}
-
-void Unit::SetDisplayId(uint32 modelId)
-{
-    SetUInt32Value(UNIT_FIELD_DISPLAYID, modelId);
-
-    UpdateModelData();
-
-    if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsPet())
-    {
-        Pet* pet = ((Pet*)this);
-        if (!pet->isControlled())
-            return;
-        Unit* owner = GetOwner();
-        if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
-            ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_MODEL_ID);
-    }
-}
-
-void Unit::UpdateModelData()
-{
-    if (CreatureModelInfo const* modelInfo = sObjectMgr.GetCreatureModelInfo(GetDisplayId()))
-    {
-        // we expect values in database to be relative to scale = 1.0
-        SetFloatValue(UNIT_FIELD_BOUNDINGRADIUS, GetObjectScale() * modelInfo->bounding_radius);
-
-        // never actually update combat_reach for player, it's always the same. Below player case is for initialization
-        if (GetTypeId() == TYPEID_PLAYER)
-            SetFloatValue(UNIT_FIELD_COMBATREACH, 1.5f);
-        else
-            SetFloatValue(UNIT_FIELD_COMBATREACH, GetObjectScale() * modelInfo->combat_reach);
-    }
-}
-
-void Unit::ClearComboPointHolders()
-{
-    while (!m_ComboPointHolders.empty())
-    {
-        uint32 lowguid = *m_ComboPointHolders.begin();
-
-        Player* plr = sObjectMgr.GetPlayer(ObjectGuid(HIGHGUID_PLAYER, lowguid));
-        if (plr && plr->GetComboTargetGuid() == GetObjectGuid())// recheck for safe
-            plr->ClearComboPoints();                        // remove also guid from m_ComboPointHolders;
-        else
-            m_ComboPointHolders.erase(lowguid);             // or remove manually
-    }
-}
-
-void Unit::ClearAllReactives()
-{
-    for (int i = 0; i < MAX_REACTIVE; ++i)
-        m_reactiveTimer[i] = 0;
-
-    if (HasAuraState(AURA_STATE_DEFENSE))
-        ModifyAuraState(AURA_STATE_DEFENSE, false);
-    if (getClass() == CLASS_HUNTER && HasAuraState(AURA_STATE_HUNTER_PARRY))
-        ModifyAuraState(AURA_STATE_HUNTER_PARRY, false);
-    if (HasAuraState(AURA_STATE_CRIT))
-        ModifyAuraState(AURA_STATE_CRIT, false);
-    if (getClass() == CLASS_HUNTER && HasAuraState(AURA_STATE_HUNTER_CRIT_STRIKE))
-        ModifyAuraState(AURA_STATE_HUNTER_CRIT_STRIKE, false);
-
-    if (getClass() == CLASS_WARRIOR && GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->ClearComboPoints();
-}
-
-void Unit::UpdateReactives(uint32 p_time)
-{
-    for (int i = 0; i < MAX_REACTIVE; ++i)
-    {
-        ReactiveType reactive = ReactiveType(i);
-
-        if (!m_reactiveTimer[reactive])
-            continue;
-
-        if (m_reactiveTimer[reactive] <= p_time)
-        {
-            m_reactiveTimer[reactive] = 0;
-
-            switch (reactive)
-            {
-                case REACTIVE_DEFENSE:
-                    if (HasAuraState(AURA_STATE_DEFENSE))
-                        ModifyAuraState(AURA_STATE_DEFENSE, false);
-                    break;
-                case REACTIVE_HUNTER_PARRY:
-                    if (getClass() == CLASS_HUNTER && HasAuraState(AURA_STATE_HUNTER_PARRY))
-                        ModifyAuraState(AURA_STATE_HUNTER_PARRY, false);
-                    break;
-                case REACTIVE_CRIT:
-                    if (HasAuraState(AURA_STATE_CRIT))
-                        ModifyAuraState(AURA_STATE_CRIT, false);
-                    break;
-                case REACTIVE_HUNTER_CRIT:
-                    if (getClass() == CLASS_HUNTER && HasAuraState(AURA_STATE_HUNTER_CRIT_STRIKE))
-                        ModifyAuraState(AURA_STATE_HUNTER_CRIT_STRIKE, false);
-                    break;
-                case REACTIVE_OVERPOWER:
-                    if (getClass() == CLASS_WARRIOR && GetTypeId() == TYPEID_PLAYER)
-                        ((Player*)this)->ClearComboPoints();
-                    break;
-                default:
-                    break;
-            }
-        }
-        else
-        {
-            m_reactiveTimer[reactive] -= p_time;
-        }
-    }
-}
-
-Unit* Unit::SelectRandomUnfriendlyTarget(Unit* except /*= nullptr*/, float radius /*= ATTACK_DISTANCE*/) const
-{
-    std::list<Unit*> targets;
-
-    MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck u_check(this, radius);
-    MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(targets, u_check);
-    Cell::VisitAllObjects(this, searcher, radius);
-
-    // remove current target
-    if (except)
-        targets.remove(except);
-
-    // remove not LoS targets
-    for (std::list<Unit*>::iterator tIter = targets.begin(); tIter != targets.end();)
-    {
-        if (!IsWithinLOSInMap(*tIter))
-        {
-            std::list<Unit*>::iterator tIter2 = tIter;
-            ++tIter;
-            targets.erase(tIter2);
-        }
-        else
-            ++tIter;
-    }
-
-    // no appropriate targets
-    if (targets.empty())
-        return nullptr;
-
-    // select random
-    uint32 rIdx = urand(0, targets.size() - 1);
-    std::list<Unit*>::const_iterator tcIter = targets.begin();
-    for (uint32 i = 0; i < rIdx; ++i)
-        ++tcIter;
-
-    return *tcIter;
-}
-
-Unit* Unit::SelectRandomFriendlyTarget(Unit* except /*= nullptr*/, float radius /*= ATTACK_DISTANCE*/) const
-{
-    std::list<Unit*> targets;
-
-    MaNGOS::AnyFriendlyUnitInObjectRangeCheck u_check(this, radius);
-    MaNGOS::UnitListSearcher<MaNGOS::AnyFriendlyUnitInObjectRangeCheck> searcher(targets, u_check);
-
-    Cell::VisitAllObjects(this, searcher, radius);
-
-    // remove current target
-    if (except)
-        targets.remove(except);
-
-    // remove not LoS targets
-    for (std::list<Unit*>::iterator tIter = targets.begin(); tIter != targets.end();)
-    {
-        if (!IsWithinLOSInMap(*tIter))
-        {
-            std::list<Unit*>::iterator tIter2 = tIter;
-            ++tIter;
-            targets.erase(tIter2);
-        }
-        else
-            ++tIter;
-    }
-
-    // no appropriate targets
-    if (targets.empty())
-        return nullptr;
-
-    // select random
-    uint32 rIdx = urand(0, targets.size() - 1);
-    std::list<Unit*>::const_iterator tcIter = targets.begin();
-    for (uint32 i = 0; i < rIdx; ++i)
-        ++tcIter;
-
-    return *tcIter;
-}
-
-bool Unit::hasNegativeAuraWithInterruptFlag(uint32 flag) const
-{
-    for (SpellAuraHolderMap::const_iterator iter = m_spellAuraHolders.begin(); iter != m_spellAuraHolders.end(); ++iter)
-    {
-        if (!iter->second->IsPositive() && iter->second->GetSpellProto()->AuraInterruptFlags & flag)
-            return true;
-    }
-    return false;
-}
-
-void Unit::ApplyAttackTimePercentMod(WeaponAttackType att, float val, bool apply)
-{
-    if (val > 0)
-    {
-        ApplyPercentModFloatVar(m_modAttackSpeedPct[att], val, !apply);
-        ApplyPercentModFloatValue(UNIT_FIELD_BASEATTACKTIME + att, val, !apply);
-    }
-    else
-    {
-        ApplyPercentModFloatVar(m_modAttackSpeedPct[att], -val, apply);
-        ApplyPercentModFloatValue(UNIT_FIELD_BASEATTACKTIME + att, -val, apply);
-    }
-}
-
-void Unit::ApplyCastTimePercentMod(float val, bool apply)
-{
-    if (val > 0)
-        ApplyPercentModFloatValue(UNIT_MOD_CAST_SPEED, val, !apply);
-    else
-        ApplyPercentModFloatValue(UNIT_MOD_CAST_SPEED, -val, apply);
-}
-
-void Unit::UpdateAuraForGroup(uint8 slot)
-{
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        Player* player = (Player*)this;
-        if (player->GetGroup())
-        {
-            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_AURAS);
-            player->SetAuraUpdateMask(slot);
-        }
-    }
-    else if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsPet())
-    {
-        Pet* pet = ((Pet*)this);
-        if (pet->isControlled())
-        {
-            Unit* owner = GetOwner();
-            if (owner && (owner->GetTypeId() == TYPEID_PLAYER) && ((Player*)owner)->GetGroup())
-            {
-                ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_AURAS);
-                pet->SetAuraUpdateMask(slot);
-            }
-        }
-    }
-}
-
-float Unit::GetAPMultiplier(WeaponAttackType attType, bool normalized)
-{
-    if (!normalized || GetTypeId() != TYPEID_PLAYER)
-        return float(GetAttackTime(attType)) / 1000.0f;
-
-    Item* Weapon = ((Player*)this)->GetWeaponForAttack(attType, true, false);
-    if (!Weapon)
-        return 2.4f;                                        // fist attack
-
-    switch (Weapon->GetProto()->InventoryType)
-    {
-        case INVTYPE_2HWEAPON:
-            return 3.3f;
-        case INVTYPE_RANGED:
-        case INVTYPE_RANGEDRIGHT:
-        case INVTYPE_THROWN:
-            return 2.8f;
-        case INVTYPE_WEAPON:
-        case INVTYPE_WEAPONMAINHAND:
-        case INVTYPE_WEAPONOFFHAND:
-        default:
-            return Weapon->GetProto()->SubClass == ITEM_SUBCLASS_WEAPON_DAGGER ? 1.7f : 2.4f;
-    }
-}
-
-Aura* Unit::GetDummyAura(uint32 spell_id) const
-{
-    Unit::AuraList const& mDummy = GetAurasByType(SPELL_AURA_DUMMY);
-    for (Unit::AuraList::const_iterator itr = mDummy.begin(); itr != mDummy.end(); ++itr)
-        if ((*itr)->GetId() == spell_id)
-            return *itr;
-
-    return nullptr;
-}
-
-void Unit::SetContestedPvP(Player* attackedPlayer)
-{
-    Player* player = GetCharmerOrOwnerPlayerOrPlayerItself();
-
-    if (!player || (attackedPlayer && (attackedPlayer == player || player->IsInDuelWith(attackedPlayer))))
-        return;
-
-    player->SetContestedPvPTimer(30000);
-
-    if (!player->hasUnitState(UNIT_STAT_ATTACK_PLAYER))
-    {
-        player->addUnitState(UNIT_STAT_ATTACK_PLAYER);
-        player->SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_CONTESTED_PVP);
-        // call MoveInLineOfSight for nearby contested guards
-        UpdateVisibilityAndView();
-    }
-
-    if (!hasUnitState(UNIT_STAT_ATTACK_PLAYER))
-    {
-        addUnitState(UNIT_STAT_ATTACK_PLAYER);
-        // call MoveInLineOfSight for nearby contested guards
-        UpdateVisibilityAndView();
-    }
-}
-
-void Unit::AddPetAura(PetAura const* petSpell)
-{
-    m_petAuras.insert(petSpell);
-    if (Pet* pet = GetPet())
-        pet->CastPetAura(petSpell);
-}
-
-void Unit::RemovePetAura(PetAura const* petSpell)
-{
-    m_petAuras.erase(petSpell);
-    if (Pet* pet = GetPet())
-        pet->RemoveAurasDueToSpell(petSpell->GetAura(pet->GetEntry()));
-}
-
-void Unit::RemoveAurasAtMechanicImmunity(uint32 mechMask, uint32 exceptSpellId, bool non_positive /*= false*/)
-{
-    Unit::SpellAuraHolderMap& auras = GetSpellAuraHolderMap();
-    for (Unit::SpellAuraHolderMap::iterator iter = auras.begin(); iter != auras.end();)
-    {
-        SpellEntry const* spell = iter->second->GetSpellProto();
-        if (spell->Id == exceptSpellId)
-            ++iter;
-        else if (non_positive && iter->second->IsPositive())
-            ++iter;
-        else if (spell->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY))
-            ++iter;
-        else if (iter->second->HasMechanicMask(mechMask))
-        {
-            RemoveAurasDueToSpell(spell->Id);
-
-            if (auras.empty())
-                break;
-            else
-                iter = auras.begin();
-        }
-        else
-            ++iter;
-    }
-}
-
-void Unit::NearTeleportTo(float x, float y, float z, float orientation, bool casting /*= false*/)
-{
-    DisableSpline();
-
-    if (GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->TeleportTo(GetMapId(), x, y, z, orientation, TELE_TO_NOT_LEAVE_TRANSPORT | TELE_TO_NOT_LEAVE_COMBAT | TELE_TO_NOT_UNSUMMON_PET | (casting ? TELE_TO_SPELL : 0));
-    else
-    {
-        Creature* c = (Creature*)this;
-        // Creature relocation acts like instant movement generator, so current generator expects interrupt/reset calls to react properly
-        if (!c->GetMotionMaster()->empty())
-            if (MovementGenerator* movgen = c->GetMotionMaster()->top())
-                movgen->Interrupt(*c);
-
-        GetMap()->CreatureRelocation((Creature*)this, x, y, z, orientation);
-
-        SendHeartBeat();
-
-        // finished relocation, movegen can different from top before creature relocation,
-        // but apply Reset expected to be safe in any case
-        if (!c->GetMotionMaster()->empty())
-            if (MovementGenerator* movgen = c->GetMotionMaster()->top())
-                movgen->Reset(*c);
-    }
-}
-
-void Unit::MonsterMoveWithSpeed(float x, float y, float z, float speed, bool generatePath, bool forceDestination)
-{
-    Movement::MoveSplineInit init(*this);
-    init.MoveTo(x, y, z, generatePath, forceDestination);
-    init.SetVelocity(speed);
-    init.Launch();
-}
-
-struct SetPvPHelper
-{
-    explicit SetPvPHelper(bool _state) : state(_state) {}
-    void operator()(Unit* unit) const { unit->SetPvP(state); }
-    bool state;
-};
-
-void Unit::SetPvP(bool state)
-{
-    if (state)
-        SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP);
-    else
-        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP);
-
-    if (GetTypeId() == TYPEID_PLAYER && ((Player*)this)->GetGroup())
-        ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
-
-    CallForAllControlledUnits(SetPvPHelper(state), CONTROLLED_PET | CONTROLLED_TOTEMS | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
-}
-
-void Unit::RestoreOriginalFaction()
-{
-    if (GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->setFactionForRace(getRace());
-    else
-    {
-        Creature* creature = (Creature*)this;
-
-        if (creature->IsPet() || creature->IsTotem())
-        {
-            if (Unit* owner = GetOwner())
-                setFaction(owner->getFaction());
-        }
-        else
-            setFaction(creature->GetCreatureInfo()->FactionAlliance);
-    }
-}
-
-float Unit::GetCombatRatingReduction(CombatRating cr) const
-{
-    if (GetTypeId() == TYPEID_PLAYER)
-        return ((Player const*)this)->GetRatingBonusValue(cr);
-
-    return 0.0f;
-}
-
-uint32 Unit::GetCombatRatingDamageReduction(CombatRating cr, float rate, float cap, uint32 damage) const
-{
-    float percent = GetCombatRatingReduction(cr) * rate;
-    if (percent > cap)
-        percent = cap;
-    return uint32(percent * damage / 100.0f);
-}
-
-struct StopAttackFactionHelper
-{
-    explicit StopAttackFactionHelper(uint32 _faction_id) : faction_id(_faction_id) {}
-    void operator()(Unit* unit) const { unit->StopAttackFaction(faction_id); }
-    uint32 faction_id;
-};
-
-void Unit::StopAttackFaction(uint32 faction_id)
-{
-    if (Unit* victim = getVictim())
-    {
-        if (victim->getFactionTemplateEntry()->faction == faction_id)
-        {
-            AttackStop();
-            if (IsNonMeleeSpellCasted(false))
-                InterruptNonMeleeSpells(false);
-
-            // melee and ranged forced attack cancel
-            if (GetTypeId() == TYPEID_PLAYER)
-                ((Player*)this)->SendAttackSwingCancelAttack();
-        }
-    }
-
-    AttackerSet const& attackers = getAttackers();
-    for (AttackerSet::const_iterator itr = attackers.begin(); itr != attackers.end();)
-    {
-        if ((*itr)->getFactionTemplateEntry()->faction == faction_id)
-        {
-            (*itr)->AttackStop();
-            itr = attackers.begin();
-        }
-        else
-            ++itr;
-    }
-
-    getHostileRefManager().deleteReferencesForFaction(faction_id);
-
-    CallForAllControlledUnits(StopAttackFactionHelper(faction_id), CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
-}
-
-void Unit::CleanupDeletedAuras()
-{
-    for (SpellAuraHolderList::const_iterator iter = m_deletedHolders.begin(); iter != m_deletedHolders.end(); ++iter)
-        delete *iter;
-    m_deletedHolders.clear();
-
-    // really delete auras "deleted" while processing its ApplyModify code
-    for (AuraList::const_iterator itr = m_deletedAuras.begin(); itr != m_deletedAuras.end(); ++itr)
-        delete *itr;
-    m_deletedAuras.clear();
-}
-
-bool Unit::CheckAndIncreaseCastCounter()
-{
-    uint32 maxCasts = sWorld.getConfig(CONFIG_UINT32_MAX_SPELL_CASTS_IN_CHAIN);
-
-    if (maxCasts && m_castCounter >= maxCasts)
-        return false;
-
-    ++m_castCounter;
-    return true;
-}
-
-SpellAuraHolder* Unit::GetSpellAuraHolder(uint32 spellid) const
-{
-    SpellAuraHolderMap::const_iterator itr = m_spellAuraHolders.find(spellid);
-    return itr != m_spellAuraHolders.end() ? itr->second : nullptr;
-}
-
-SpellAuraHolder* Unit::GetSpellAuraHolder(uint32 spellid, ObjectGuid casterGuid) const
-{
-    SpellAuraHolderConstBounds bounds = GetSpellAuraHolderBounds(spellid);
-    for (SpellAuraHolderMap::const_iterator iter = bounds.first; iter != bounds.second; ++iter)
-        if (iter->second->GetCasterGuid() == casterGuid)
-            return iter->second;
-
-    return nullptr;
-}
-
-bool Unit::IsAllowedDamageInArea(Unit* pVictim) const
-{
-    // can damage self anywhere
-    if (pVictim == this)
-        return true;
-
-    // can damage own pet anywhere
-    if (pVictim->GetOwnerGuid() == GetObjectGuid())
-        return true;
-
-    // non player controlled unit can damage anywhere
-    Player const* pOwner = GetCharmerOrOwnerPlayerOrPlayerItself();
-    if (!pOwner)
-        return true;
-
-    // can damage non player controlled victim anywhere
-    Player const* vOwner = pVictim->GetCharmerOrOwnerPlayerOrPlayerItself();
-    if (!vOwner)
-        return true;
-
-    // can damage opponent in duel
-    if (pOwner->IsInDuelWith(vOwner))
-        return true;
-
-    // can't damage player controlled unit by player controlled unit in sanctuary
-    AreaTableEntry const* area = GetAreaEntryByAreaID(pVictim->GetAreaId());
-    if (area && area->flags & AREA_FLAG_SANCTUARY)
-        return false;
-
-    return true;
-}
-
-class RelocationNotifyEvent : public BasicEvent
-{
-    public:
-        RelocationNotifyEvent(Unit& owner) : BasicEvent(), m_owner(owner)
-        {
-            m_owner._SetAINotifyScheduled(true);
-        }
-
-        bool Execute(uint64 /*e_time*/, uint32 /*p_time*/)
-        {
-            float radius = MAX_CREATURE_ATTACK_RADIUS * sWorld.getConfig(CONFIG_FLOAT_RATE_CREATURE_AGGRO);
-            if (m_owner.GetTypeId() == TYPEID_PLAYER)
-            {
-                MaNGOS::PlayerRelocationNotifier notify((Player&)m_owner);
-                Cell::VisitAllObjects(&m_owner, notify, radius);
-            }
-            else // if(m_owner.GetTypeId() == TYPEID_UNIT)
-            {
-                MaNGOS::CreatureRelocationNotifier notify((Creature&)m_owner);
-                Cell::VisitAllObjects(&m_owner, notify, radius);
-            }
-            m_owner._SetAINotifyScheduled(false);
-            return true;
-        }
-
-        void Abort(uint64)
-        {
-            m_owner._SetAINotifyScheduled(false);
-        }
-
-    private:
-        Unit& m_owner;
-};
-
-void Unit::ScheduleAINotify(uint32 delay)
-{
-    if (!IsAINotifyScheduled())
-        m_Events.AddEvent(new RelocationNotifyEvent(*this), m_Events.CalculateTime(delay));
-}
-
-void Unit::OnRelocated()
-{
-    // switch to use G3D::Vector3 is good idea, maybe
-    float dx = m_last_notified_position.x - GetPositionX();
-    float dy = m_last_notified_position.y - GetPositionY();
-    float dz = m_last_notified_position.z - GetPositionZ();
-    float distsq = dx * dx + dy * dy + dz * dz;
-    if (distsq > World::GetRelocationLowerLimitSq())
-    {
-        m_last_notified_position.x = GetPositionX();
-        m_last_notified_position.y = GetPositionY();
-        m_last_notified_position.z = GetPositionZ();
-
-        GetViewPoint().Call_UpdateVisibilityForOwner();
-        UpdateObjectVisibility();
-    }
-    ScheduleAINotify(World::GetRelocationAINotifyDelay());
-}
-
-void Unit::UpdateSplineMovement(uint32 t_diff)
-{
-    enum
-    {
-        POSITION_UPDATE_DELAY = 400,
-    };
-
-    if (movespline->Finalized())
-        return;
-
-    movespline->updateState(t_diff);
-    bool arrived = movespline->Finalized();
-
-    if (arrived)
-        DisableSpline();
-
-    m_movesplineTimer.Update(t_diff);
-    if (m_movesplineTimer.Passed() || arrived)
-    {
-        m_movesplineTimer.Reset(POSITION_UPDATE_DELAY);
-        Movement::Location loc = movespline->ComputePosition();
-
-        if (GetTypeId() == TYPEID_PLAYER)
-            ((Player*)this)->SetPosition(loc.x, loc.y, loc.z, loc.orientation);
-        else
-            GetMap()->CreatureRelocation((Creature*)this, loc.x, loc.y, loc.z, loc.orientation);
-    }
-}
-
-void Unit::DisableSpline()
-{
-    m_movementInfo.RemoveMovementFlag(MovementFlags(MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_FORWARD));
-    movespline->_Interrupt();
-}
-
-// This will create a new creature and set the current unit as the controller of that new creature
-Unit* Unit::TakePossessOf(SpellEntry const* spellEntry, SummonPropertiesEntry const* summonProp, uint32 effIdx, float x, float y, float z, float ang)
-{
-    int32 const& creatureEntry = spellEntry->EffectMiscValue[effIdx];
-    CreatureInfo const* cinfo = ObjectMgr::GetCreatureTemplate(creatureEntry);
-    if (!cinfo)
-    {
-        sLog.outErrorDb("WorldObject::SummonCreature: Creature (Entry: %u) not existed for summoner: %s. ", creatureEntry, GetGuidStr().c_str());
-        return nullptr;
-    }
-
-    if (GetCharm())
-    {
-        sLog.outError("Unit::TakePossessOf> There is already a charmed creature for %s its : %s. ", GetGuidStr().c_str(), GetCharm()->GetGuidStr().c_str());
-        return nullptr;
-    }
-
-    TemporarySummon* pCreature = new TemporarySummon(GetObjectGuid());
-
-    CreatureCreatePos pos(GetMap(), x, y, z, ang);
-
-    if (x == 0.0f && y == 0.0f && z == 0.0f)
-        pos = CreatureCreatePos(this, GetOrientation(), CONTACT_DISTANCE, ang);
-
-    if (!pCreature->Create(GetMap()->GenerateLocalLowGuid(cinfo->GetHighGuid()), pos, cinfo))
-    {
-        delete pCreature;
-        return nullptr;
-    }
-
-    Player* player = GetTypeId() == TYPEID_PLAYER ? static_cast<Player*>(this) : nullptr;
-
-    pCreature->SetFactionTemporary(getFaction(), TEMPFACTION_NONE);     // set same faction than player
-    pCreature->SetRespawnCoord(pos);                                    // set spawn coord
-    pCreature->SetCharmerGuid(GetObjectGuid());                         // save guid of the charmer
-    pCreature->SetUInt32Value(UNIT_CREATED_BY_SPELL, spellEntry->Id);   // set the spell id used to create this (may be used for removing corresponding aura
-    pCreature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED);  // set flag for client that mean this unit is controlled by a player
-    pCreature->addUnitState(UNIT_STAT_CONTROLLED);                      // also set internal unit state flag
-    pCreature->SelectLevel(getLevel());                                 // set level to same level than summoner TODO:: not sure its always the case...
-    pCreature->SetLinkedToOwnerAura(TEMPSUMMON_LINKED_AURA_OWNER_CHECK | TEMPSUMMON_LINKED_AURA_REMOVE_OWNER); // set what to do if linked aura is removed or the creature is dead.
-    pCreature->SetWalk(IsWalking(), true);                              // sync the walking state with the summoner
-
-                                                                        // important before adding to the map!
-    SetCharmGuid(pCreature->GetObjectGuid());                           // save guid of charmed creature
-
-    pCreature->SetSummonProperties(TEMPSUMMON_CORPSE_TIMED_DESPAWN, 5000); // set 5s corpse decay
-    GetMap()->Add(static_cast<Creature*>(pCreature));                   // create the creature in the client
-    pCreature->AIM_Initialize();                                        // even if this will be replaced it need to be initialized to take care of spawn spells
-
-                                                                        // Give the control to the player
-    if (player)
-    {
-        player->GetCamera().SetView(pCreature);                         // modify camera view to the creature view
-        player->SetClientControl(pCreature, 1);                         // transfer client control to the creature
-        player->SetMover(pCreature);                                    // set mover so now we know that creature is "moved" by this unit
-        player->SendForcedObjectUpdate();                               // we have to update client data here to avoid problem with the "release spirit" windows reappear.
-
-        pCreature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP_ATTACKABLE); // this seem to be needed for controlled creature (else cannot attack neutral creature)
-
-        // player pet is unsumoned while possessing
-        player->UnsummonPetTemporaryIfAny();
-    }
-
-    // init CharmInfo class that will hold charm data
-    CharmInfo* charmInfo = pCreature->InitCharmInfo(pCreature);
-
-    // set temp possess ai (creature will not be able to react by itself)
-    charmInfo->SetCharmState("PossessedAI");
-
-    if (player)
-    {
-        // Initialize pet bar
-        if (CharmInfo* charmInfo = pCreature->InitCharmInfo(pCreature))
-            charmInfo->InitPossessCreateSpells();
-        player->PossessSpellInitialize();
-    }
-
-    // Creature Linking, Initial load is handled like respawn
-    if (pCreature->IsLinkingEventTrigger())
-        GetMap()->GetCreatureLinkingHolder()->DoCreatureLinkingEvent(LINKING_EVENT_RESPAWN, pCreature);
-
-    // return the creature therewith the summoner has access to it
-    return pCreature;
-}
-
-bool Unit::TakePossessOf(Unit* possessed)
-{
-    Player* player = nullptr;
-    if (GetTypeId() == TYPEID_PLAYER)
-        player = static_cast<Player *>(this);
-
-    // stop combat but keep threat list
-    possessed->AttackStop(true, true);
-    possessed->ClearInCombat();
-
-    possessed->addUnitState(UNIT_STAT_CONTROLLED);
-    possessed->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED);
-    possessed->SetCharmerGuid(GetObjectGuid());
-
-    SetCharm(possessed);
-
-    Creature* possessedCreature = nullptr;
-    Player* possessedPlayer = nullptr;
-    CharmInfo* charmInfo = possessed->InitCharmInfo(possessed);
-
-    // stop any generated movement TODO:: this may not be correct! what about possessing a feared creature?
-    possessed->GetMotionMaster()->Clear();
-    possessed->GetMotionMaster()->MoveIdle();
-    possessed->StopMoving(true);
-
-    if (possessed->GetTypeId() == TYPEID_UNIT)
-    {
-        possessedCreature = static_cast<Creature *>(possessed);
-        possessedCreature->SetFactionTemporary(getFaction(), TEMPFACTION_NONE);
-        possessedCreature->SetWalk(IsWalking(), true);
-        charmInfo->SetCharmState("PossessedAI");
-        getHostileRefManager().deleteReference(possessedCreature);
-
-        // this seem to be needed for controlled creature (else cannot attack neutral creature)
-        if (player)
-            possessed->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP_ATTACKABLE);
-    }
-    else if (possessed->GetTypeId() == TYPEID_PLAYER)
-    {
-        possessedPlayer = static_cast<Player *>(possessed);
-
-        if (player && player->IsInDuelWith(possessedPlayer))
-            possessedPlayer->SetUInt32Value(PLAYER_DUEL_TEAM, player->GetUInt32Value(PLAYER_DUEL_TEAM));
-        else
-            possessedPlayer->setFaction(getFaction());
-    }
-
-    if (player)
-    {
-        player->GetCamera().SetView(possessed);
-        player->SetClientControl(possessed, player->IsClientControl(possessed));
-        player->SetMover(possessed);
-        player->SendForcedObjectUpdate();
-
-        if (possessedCreature)
-        {
-            if (possessedCreature->IsPet() && possessedCreature->GetObjectGuid() == GetPetGuid())
-            {
-                // possessing own pet, pet bar already initialized
-                return true;
-            }
-        }
-
-        // player pet is unsmumoned while possessing
-        player->UnsummonPetTemporaryIfAny();
-
-        charmInfo->InitPossessCreateSpells();
-        charmInfo->SetReactState(REACT_PASSIVE);
-        charmInfo->SetCommandState(COMMAND_STAY);
-        player->PossessSpellInitialize();
-    }
-
-    if (possessedPlayer)
-        possessedPlayer->SetClientControl(possessed, 0);
-
-    return true;
+    return SPELL_AURA_PROC_OK;
 }
 
-bool Unit::TakeCharmOf(Unit* charmed)
+SpellAuraProcResult Unit::HandleModResistanceAuraProc(Unit* /*pVictim*/, uint32 damage, Aura* triggeredByAura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/)
 {
-
-    Player* charmerPlayer = nullptr;
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        charmerPlayer = static_cast<Player *>(this);
-
-        // player pet is unsmumoned while possessing
-        charmerPlayer->UnsummonPetTemporaryIfAny();
-    }
-
-    // stop combat but keep threat list
-    charmed->AttackStop(true, true);
-    charmed->ClearInCombat();
-
-    charmed->SetCharmerGuid(GetObjectGuid());
-    SetCharm(charmed);
-
-    CharmInfo* charmInfo = charmed->InitCharmInfo(charmed);
-
-    if (charmed->GetTypeId() == TYPEID_PLAYER)
-    {
-        Player* charmedPlayer = static_cast<Player *>(charmed);
-        if (charmerPlayer && charmerPlayer->IsInDuelWith(charmedPlayer))
-            charmedPlayer->SetUInt32Value(PLAYER_DUEL_TEAM, charmerPlayer->GetUInt32Value(PLAYER_DUEL_TEAM));
-        else
-            charmedPlayer->setFaction(getFaction());
-
-        charmInfo->SetCharmState("PetAI");
-        charmed->SetByteValue(UNIT_FIELD_BYTES_2, 1, UNIT_BYTE2_FLAG_SUPPORTABLE | UNIT_BYTE2_FLAG_AURAS); // important have to be after charminfo initialization
-                                                                                                           //charmedPlayer->SetWalk(IsWalking(), true);
+    SpellEntry const* spellInfo = triggeredByAura->GetSpellProto();
 
-        charmInfo->InitCharmCreateSpells();
-        charmInfo->SetReactState(REACT_DEFENSIVE);
-        charmInfo->SetCommandState(COMMAND_FOLLOW);
-        charmInfo->SetIsRetreating(true);
-
-        charmedPlayer->SetClientControl(charmedPlayer, 0);
-        charmedPlayer->SendForcedObjectUpdate();
-    }
-    else if (charmed->GetTypeId() == TYPEID_UNIT)
+    // Inner Fire
+    if (spellInfo->IsFitToFamily(SPELLFAMILY_PRIEST, uint64(0x0000000000002)))
     {
-        Creature* charmedCreature = static_cast<Creature *>(charmed);
-        charmInfo->SetCharmState("PetAI");
-        getHostileRefManager().deleteReference(charmedCreature);
-        charmedCreature->SetFactionTemporary(getFaction(), TEMPFACTION_NONE);
-        charmedCreature->SetWalk(IsWalking(), true);
-
-        charmInfo->InitCharmCreateSpells();
-        charmInfo->SetReactState(REACT_DEFENSIVE);
-        charmInfo->SetCommandState(COMMAND_FOLLOW);
-        charmInfo->SetIsRetreating(true);
-
-        if (charmerPlayer)
-        {
-            // without this charmed unit will not be able to attack neutral target
-            charmed->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP_ATTACKABLE);
-
-            if (getClass() == CLASS_WARLOCK)
-            {
-                CreatureInfo const* cinfo = charmedCreature->GetCreatureInfo();
-                if (cinfo && cinfo->CreatureType == CREATURE_TYPE_DEMON)
-                {
-                    // creature with pet number expected have class set
-                    if (charmedCreature->GetByteValue(UNIT_FIELD_BYTES_0, 1) == 0)
-                    {
-                        if (cinfo->UnitClass == 0)
-                            sLog.outErrorDb("Creature (Entry: %u) have UnitClass = 0 but used in charmed spell, that will be result client crash.", cinfo->Entry);
-                        else
-                            sLog.outError("Creature (Entry: %u) have UnitClass = %u but at charming have class 0!!! that will be result client crash.", cinfo->Entry, cinfo->UnitClass);
-
-                        charmedCreature->SetByteValue(UNIT_FIELD_BYTES_0, 1, CLASS_MAGE);
-                    }
-
-                    // just to enable stat window
-                    charmInfo->SetPetNumber(sObjectMgr.GeneratePetNumber(), true);
-                    // if charmed two demons the same session, the 2nd gets the 1st one's name
-                    charmedCreature->SetUInt32Value(UNIT_FIELD_PET_NAME_TIMESTAMP, uint32(time(nullptr)));
-                }
-            }
-        }
+        // only at real damage
+        if (!damage)
+            return SPELL_AURA_PROC_FAILED;
     }
-
-    if (charmerPlayer)
-        charmerPlayer->CharmSpellInitialize();
 
-    return true;
+    return SPELL_AURA_PROC_OK;
 }
 
-void Unit::ResetControlState(bool attackCharmer /*= true*/)
+SpellAuraProcResult Unit::HandleRemoveByDamageChanceProc(Unit* pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 procFlag, uint32 procEx, uint32 cooldown)
 {
-    Player* player = nullptr;
-    if (GetTypeId() == TYPEID_PLAYER)
-        player = static_cast<Player *>(this);
-
-    Unit* possessed = GetCharm();
-
-    if (!possessed)
-    {
-        if (player)
-        {
-            player->GetCamera().ResetView();
-            player->SetClientControl(player, player->IsClientControl(player));
-            player->SetMover(nullptr);
-        }
-        return;
-    }
-
-    possessed->clearUnitState(UNIT_STAT_CONTROLLED);
-    possessed->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED);
-    possessed->SetCharmerGuid(ObjectGuid());
-
-    // may be not correct we have to remove only some generator taking account of the current situation
-    possessed->StopMoving(true);
-    possessed->GetMotionMaster()->Clear();
-
-    SetCharmGuid(ObjectGuid());
-    Creature* possessedCreature = nullptr;
-    CharmInfo* charmInfo = possessed->GetCharmInfo();
-
-    if (possessed->GetTypeId() == TYPEID_UNIT)
+    // The chance to dispel an aura depends on the damage taken with respect to the casters level.
+    uint32 max_dmg = getLevel() > 8 ? 25 * getLevel() - 150 : 50;
+    float chance = float(damage) / max_dmg * 100.0f;
+    if (roll_chance_f(chance))
     {
-        // now we have to clean threat list to be able to restore normal creature behavior
-        FactionTemplateEntry const* factionEntry = possessed->getFactionTemplateEntry();
-
-        possessedCreature = static_cast<Creature *>(possessed);
-        if (!possessedCreature->IsPet())
-        {
-            possessedCreature->ClearTemporaryFaction();
-
-            // first find friendly target (stopping combat here is not recommended because m_attackers will be modified)
-            AttackerSet friendlyTargets;
-            for (Unit::AttackerSet::const_iterator itr = possessed->getAttackers().begin(); itr != possessed->getAttackers().end(); ++itr)
-            {
-                Unit* attacker = (*itr);
-                if (attacker->GetTypeId() != TYPEID_UNIT)
-                    continue;
-
-                if (!factionEntry->IsHostileTo(*attacker->getFactionTemplateEntry()))
-                    friendlyTargets.insert(attacker);
-            }
-
-            // now stop attackers combat and transfer threat generated from this to owner, also get the total generated threat
-            for (Unit::AttackerSet::iterator itr = friendlyTargets.begin(); itr != friendlyTargets.end(); ++itr)
-            {
-                Unit* attacker = (*itr);
-                attacker->AttackStop(true, true);
-                attacker->m_Events.KillAllEvents(true);
-                attacker->getThreatManager().modifyThreatPercent(possessed, -101);     // only remove the possessed creature from threat list because it can be filled by other players
-                attacker->AddThreat(this);
-            }
-
-            possessed->AttackStop(true, true);
-            possessed->m_Events.KillAllEvents(true);
-
-            charmInfo->ResetCharmState();
-            possessed->DeleteCharmInfo();
-
-            // we have to restore initial MotionMaster
-            while (possessed->GetMotionMaster()->GetCurrentMovementGeneratorType() == FOLLOW_MOTION_TYPE)
-                possessed->GetMotionMaster()->MovementExpired(true);
-
-            if (possessed->isAlive())
-            {
-                possessedCreature->SetCombatStartPosition(GetPositionX(), GetPositionY(), GetPositionZ()); // needed for creature not yet entered in combat or SelectHostileTarget() will fail
-
-                                                                                                           // TODO:: iam not sure we need that faction check
-                if (!factionEntry->IsFriendlyTo(*getFactionTemplateEntry()))
-                    possessed->getThreatManager().addThreat(this, GetMaxHealth());     // generating threat by max life amount best way i found to make it realistic
-            }
-            else
-                possessed->GetCombatData()->threatManager.clearReferences();
-
-            // we can remove that flag if its set, that is supposed to be only for creature controlled by player
-            // however player's pet should keep it
-            possessed->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP_ATTACKABLE);
-        }
-        else
-        {
-            possessed->setFaction(possessedCreature->GetOwner()->getFaction());
-
-            charmInfo->ResetCharmState();
-
-            // as possessed is a pet we have to restore original charminfo so Pet::DeleteCharmInfo will take care of that
-            possessed->DeleteCharmInfo();
-        }
-    }
-    else if (possessed->GetTypeId() == TYPEID_PLAYER)
-    {
-        possessed->AttackStop(true, true);
-
-        Player* possessedPlayer = static_cast<Player *>(possessed);
-
-        if (player && player->IsInDuelWith(possessedPlayer))
-            possessedPlayer->SetUInt32Value(PLAYER_DUEL_TEAM, player->GetUInt32Value(PLAYER_DUEL_TEAM) == 1 ? 2 : 1);
-        else
-            possessedPlayer->setFactionForRace(possessedPlayer->getRace());
-
-        possessedPlayer->SetClientControl(possessedPlayer, possessedPlayer->IsClientControl(possessedPlayer));
-        charmInfo->ResetCharmState();
-        possessedPlayer->DeleteCharmInfo();
-
-        while (possessedPlayer->GetMotionMaster()->GetCurrentMovementGeneratorType() == FOLLOW_MOTION_TYPE)
-            possessedPlayer->GetMotionMaster()->MovementExpired(true);
-    }
-
-    if (player)
-    {
-        player->SetClientControl(possessed, 0);
-        player->SetMover(nullptr);
-        player->GetCamera().ResetView();
-
-        // player pet can be re summoned here
-        player->ResummonPetTemporaryUnSummonedIfAny();
-
-        // remove pet bar only if no pet
-        if (!player->GetPet())
-            player->RemovePetActionBar();
-        else
-            player->PetSpellInitialize();   // reset spell on pet bar
+        triggeredByAura->SetInUse(true);
+        RemoveAurasByCasterSpell(triggeredByAura->GetId(), triggeredByAura->GetCasterGuid());
+        triggeredByAura->SetInUse(false);
+        return SPELL_AURA_PROC_OK;
     }
 
-    // be sure all those change will be made for clients
-    SendForcedObjectUpdate();
+    return SPELL_AURA_PROC_FAILED;
 }
 
-float Unit::GetAttackDistance(Unit const* pl) const
+SpellAuraProcResult Unit::HandleInvisibilityAuraProc(Unit* pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const* procSpell, uint32 procFlag, uint32 procEx, uint32 cooldown)
 {
-    float aggroRate = sWorld.getConfig(CONFIG_FLOAT_RATE_CREATURE_AGGRO);
-    if (aggroRate == 0)
-        return 0.0f;
-
-    uint32 playerlevel = pl->GetLevelForTarget(this);
-    uint32 creaturelevel = GetLevelForTarget(pl);
-
-    int32 leveldif = int32(playerlevel) - int32(creaturelevel);
-
-    // "The maximum Aggro Radius has a cap of 25 levels under. Example: A level 30 char has the same Aggro Radius of a level 5 char on a level 60 mob."
-    if (leveldif < -25)
-        leveldif = -25;
-
-    // "The aggro radius of a mob having the same level as the player is roughly 20 yards"
-    float RetDistance = 20;
-
-    // "Aggro Radius varies with level difference at a rate of roughly 1 yard/level"
-    // radius grow if playlevel < creaturelevel
-    RetDistance -= (float)leveldif;
-
-    if (creaturelevel + 5 <= sWorld.getConfig(CONFIG_UINT32_MAX_PLAYER_LEVEL))
-    {
-        // detect range auras
-        RetDistance += GetTotalAuraModifier(SPELL_AURA_MOD_DETECT_RANGE);
-
-        // detected range auras
-        RetDistance += pl->GetTotalAuraModifier(SPELL_AURA_MOD_DETECTED_RANGE);
-    }
-
-    // "Minimum Aggro Radius for a mob seems to be combat range (5 yards)"
-    if (RetDistance < 5)
-        RetDistance = 5;
+    if (triggeredByAura->GetSpellProto()->HasAttribute(SPELL_ATTR_PASSIVE) || triggeredByAura->GetSpellProto()->HasAttribute(SPELL_ATTR_NEGATIVE))
+        return SPELL_AURA_PROC_FAILED;
 
-    return (RetDistance * aggroRate);
+    RemoveAurasDueToSpell(triggeredByAura->GetId());
+    return SPELL_AURA_PROC_OK;
 }

--- a/src/scriptdev2/scripts/eastern_kingdoms/sunwell_plateau/boss_eredar_twins.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/sunwell_plateau/boss_eredar_twins.cpp
@@ -75,8 +75,8 @@ enum
     SPELL_FLAME_SEAR                        = 46771,        // A few random targets debuff
     SPELL_CONFLAGRATION_UNK                 = 45333,        // Unknown
 
-    DARK_FLAME_AURA_ALYTHESS                = 45343,        // Aura buff that make flame touched spell proc - for Alythess
-    DARK_FLAME_AURA_SCAROLASH               = 47300,        // Aura buff that make dark touched spell proc  - for Scarolash
+    DARK_FLAME_AURA_ALYTHESS                = 47300,        // Aura buff that make flame touched spell proc - for Alythess
+    DARK_FLAME_AURA_SCAROLASH               = 45343,        // Aura buff that make dark touched spell proc  - for Scarolash
 };
 
 static const DialogueEntry aIntroDialogue[] =
@@ -188,6 +188,7 @@ struct boss_alythessAI : public ScriptedAI
                     m_creature->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
                     DoScriptText(SAY_SACROLASH_EMPOWER, pSacrolash);
                     pSacrolash->InterruptNonMeleeSpells(true);
+                    pSacrolash->CastSpell(pSacrolash, DARK_FLAME_AURA_ALYTHESS, TRIGGERED_NONE);
                     pSacrolash->CastSpell(pSacrolash, SPELL_EMPOWER, TRIGGERED_NONE);
                 }
             }
@@ -343,6 +344,7 @@ struct boss_sacrolashAI : public ScriptedAI
                     m_creature->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
                     DoScriptText(SAY_ALYTHESS_EMPOWER, pAlythess);
                     pAlythess->InterruptNonMeleeSpells(true);
+                    pAlythess->CastSpell(pAlythess, DARK_FLAME_AURA_SCAROLASH, TRIGGERED_NONE);
                     pAlythess->CastSpell(pAlythess, SPELL_EMPOWER, TRIGGERED_NONE);
                 }
             }

--- a/src/scriptdev2/scripts/eastern_kingdoms/sunwell_plateau/boss_eredar_twins.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/sunwell_plateau/boss_eredar_twins.cpp
@@ -74,6 +74,9 @@ enum
     SPELL_BLAZE                             = 45235,        // On main target every 3 secs; should trigger 45236 which leaves a fire on the ground
     SPELL_FLAME_SEAR                        = 46771,        // A few random targets debuff
     SPELL_CONFLAGRATION_UNK                 = 45333,        // Unknown
+
+    DARK_FLAME_AURA_ALYTHESS                = 45343,        // Aura buff that make flame touched spell proc - for Alythess
+    DARK_FLAME_AURA_SCAROLASH               = 47300,        // Aura buff that make dark touched spell proc  - for Scarolash
 };
 
 static const DialogueEntry aIntroDialogue[] =
@@ -88,6 +91,7 @@ static const DialogueEntry aIntroDialogue[] =
     {SAY_INTRO_8, NPC_ALYTHESS,  0},
     {0, 0, 0},
 };
+
 
 /*######
 ## boss_alythess
@@ -121,6 +125,7 @@ struct boss_alythessAI : public ScriptedAI
         m_uiBlazeTimer          = 1000;
         m_uiFlameSearTimer      = 5000;
         m_bDidIntro = false;
+        DoCastSpellIfCan(m_creature, DARK_FLAME_AURA_ALYTHESS);
     }
 
     void JustReachedHome() override
@@ -189,33 +194,6 @@ struct boss_alythessAI : public ScriptedAI
         }
     }
 
-    void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
-    {
-        if (pTarget->HasAura(SPELL_DARK_FLAME))
-            return;
-
-        if (pSpell->SchoolMask == SPELL_SCHOOL_MASK_FIRE)
-        {
-            if (pTarget->HasAura(SPELL_DARK_TOUCHED))
-            {
-                pTarget->RemoveAurasDueToSpell(SPELL_DARK_TOUCHED);
-                pTarget->CastSpell(pTarget, SPELL_DARK_FLAME, TRIGGERED_OLD_TRIGGERED);
-            }
-            else
-                pTarget->CastSpell(pTarget, SPELL_FLAME_TOUCHED, TRIGGERED_OLD_TRIGGERED);
-        }
-        else if (pSpell->SchoolMask == SPELL_SCHOOL_MASK_SHADOW)
-        {
-            if (pTarget->HasAura(SPELL_FLAME_TOUCHED))
-            {
-                pTarget->RemoveAurasDueToSpell(SPELL_FLAME_TOUCHED);
-                pTarget->CastSpell(pTarget, SPELL_DARK_FLAME, TRIGGERED_OLD_TRIGGERED);
-            }
-            else
-                pTarget->CastSpell(pTarget, SPELL_DARK_TOUCHED, TRIGGERED_OLD_TRIGGERED);
-        }
-    }
-
     void UpdateAI(const uint32 uiDiff) override
     {
         if (m_pInstance && m_pInstance->GetData(TYPE_EREDAR_TWINS) == SPECIAL)
@@ -273,6 +251,7 @@ struct boss_alythessAI : public ScriptedAI
         {
             if (DoCastSpellIfCan(m_creature, SPELL_FLAME_SEAR) == CAST_OK)
                 m_uiFlameSearTimer = 10000;
+
         }
         else
             m_uiFlameSearTimer -= uiDiff;
@@ -314,6 +293,7 @@ struct boss_sacrolashAI : public ScriptedAI
         m_uiConfoundingBlowTimer = 30000;
         m_uiShadowBladesTimer    = 15000;
         m_uiSummonShadowImage    = 10000;
+        DoCastSpellIfCan(m_creature, DARK_FLAME_AURA_SCAROLASH);
     }
 
     void JustReachedHome() override
@@ -366,33 +346,6 @@ struct boss_sacrolashAI : public ScriptedAI
                     pAlythess->CastSpell(pAlythess, SPELL_EMPOWER, TRIGGERED_NONE);
                 }
             }
-        }
-    }
-
-    void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
-    {
-        if (pTarget->HasAura(SPELL_DARK_FLAME))
-            return;
-
-        if (pSpell->SchoolMask == SPELL_SCHOOL_MASK_FIRE)
-        {
-            if (pTarget->HasAura(SPELL_DARK_TOUCHED))
-            {
-                pTarget->RemoveAurasDueToSpell(SPELL_DARK_TOUCHED);
-                pTarget->CastSpell(pTarget, SPELL_DARK_FLAME, TRIGGERED_OLD_TRIGGERED);
-            }
-            else
-                pTarget->CastSpell(pTarget, SPELL_FLAME_TOUCHED, TRIGGERED_OLD_TRIGGERED);
-        }
-        else if (pSpell->SchoolMask == SPELL_SCHOOL_MASK_SHADOW)
-        {
-            if (pTarget->HasAura(SPELL_FLAME_TOUCHED))
-            {
-                pTarget->RemoveAurasDueToSpell(SPELL_FLAME_TOUCHED);
-                pTarget->CastSpell(pTarget, SPELL_DARK_FLAME, TRIGGERED_OLD_TRIGGERED);
-            }
-            else
-                pTarget->CastSpell(pTarget, SPELL_DARK_TOUCHED, TRIGGERED_OLD_TRIGGERED);
         }
     }
 


### PR DESCRIPTION
The Eredar twins from Sunwell Plateau.

Flame sear dots should add stacks of Flame Touched debuff.

In the current state of mangos, it only applies an initial flame touched when it lands, but not on DoT ticks. (Can provide youtube video if requiered).

The flame sear dot lasts for 6 second ticking every 500ms. But on youtube video we clearly see it stack one flame touched per second, for a total of 6 stacks. I assume there is a hiden cooldown mechanic that should maybe be managed with the dark flame auras.

