### PR TITLE
#1084 & #1283 - fix server hang on shutdown due to fgets is blocking

### DIFF
--- a/src/mangosd/CliRunnable.cpp
+++ b/src/mangosd/CliRunnable.cpp
@@ -606,7 +606,15 @@ void CliRunnable::run()
     // print this here the first time
     // later it will be printed after command queue updates
     printf("mangos>");
-
+    
+#ifdef linux
+    //Set stdin IO to nonblocking - prevent Server from hanging in shutdown process till enter is pressed
+    int fd = fileno(stdin);  
+    int flags = fcntl(fd, F_GETFL, 0); 
+    flags |= O_NONBLOCK; 
+    fcntl(fd, F_SETFL, flags);
+#endif
+    
     ///- As long as the World is running (no World::m_stopEvent), get the command line and handle it
     while (!World::IsStopped())
     {


### PR DESCRIPTION
# fix server hang on shutdown due to fgets is blocking

This fixes the Issues https://github.com/cmangos/issues/issues/1084 and https://github.com/cmangos/issues/issues/1283 on Linux.

Im unsure and unable to test if this bug is present in Windows.

The reason for the Server hanging is the blocking character of fgets() on stdin. Therefore changing the stdin to non-blocking is a solution to the Problem.

Please look at this @Cyberium