### PR TITLE
#1177 double login account fix

### DIFF
--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -288,20 +288,13 @@ bool WorldSession::Update(PacketFilter& updater)
         }
     }
 
-    // check if we are safe to proceed with logout
-    // logout procedure should happen only in World::UpdateSessions() method!!!
-    if (updater.ProcessLogout())
-    {
-        ///- If necessary, log the player out
-        const time_t currTime = time(nullptr);
+    // process logout if needed
+	if (m_Socket->IsClosed() || (ShouldLogOut() && !m_playerLoading))
+		LogoutPlayer(true);
 
-        if (m_Socket->IsClosed() || (ShouldLogOut(currTime) && !m_playerLoading))
-            LogoutPlayer(true);
-
-        // finalize the session if disconnected.
-        if (m_Socket->IsClosed())
-            return false;
-    }
+	// finalize the session if disconnected.
+	if (m_Socket->IsClosed())
+		return false;
 
     return true;
 }

--- a/src/game/WorldSession.h
+++ b/src/game/WorldSession.h
@@ -117,7 +117,6 @@ class PacketFilter
         virtual ~PacketFilter() {}
 
         virtual bool Process(WorldPacket const& /*packet*/) const { return true; }
-        virtual bool ProcessLogout() const { return true; }
 
     protected:
         WorldSession* const m_pSession;
@@ -131,8 +130,6 @@ class MapSessionFilter : public PacketFilter
         ~MapSessionFilter() {}
 
         virtual bool Process(WorldPacket const& packet) const override;
-        // in Map::Update() we do not process player logout!
-        virtual bool ProcessLogout() const override { return false; }
 };
 
 // class used to filer only thread-unsafe packets from queue
@@ -193,9 +190,9 @@ class MANGOS_DLL_SPEC WorldSession
         }
 
         /// Is logout cooldown expired?
-        bool ShouldLogOut(time_t currTime) const
+        bool ShouldLogOut() const
         {
-            return (_logoutTime > 0 && currTime >= _logoutTime + 20);
+            return (_logoutTime > 0 && time(nullptr) >= _logoutTime + 20);
         }
 
         void LogoutPlayer(bool Save);


### PR DESCRIPTION
# #1177 double login account fix

This fixes the issues https://github.com/cmangos/issues/issues/1177 and https://github.com/cmangos/issues/issues/1252

Please note that i moved

`const time_t currTime = time(nullptr);`

into 

```
bool ShouldLogOut() const
{
      return (_logoutTime > 0 && time(nullptr) >= _logoutTime + 20);
}
```

and therefore changed the api of ShouldLogOut. I did that to prevent a call to time(nullptr) every Update Cycle. This way its only called when _logoutTime is > 0.

Also i removed the ProcessLogout() from the PacketFilter. This causes Map::Update() to handle Playerlogouts, which seems to be a bad idea regarding this comment.

`// in Map::Update() we do not process player logout!`

This PR fixes the Problems with the double-login and connection loss. Anyhow im not able to tell if there is a Problem with Map::Update - might be problematic due to threatsafety and/or performance.

I need an expert to look at this @killerwife @cyberium 