### PR TITLE
Unify fleeing for assistance and normal fleeing

### DIFF
--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -132,7 +132,7 @@ Creature::Creature(CreatureSubtype subtype) : Unit(),
     m_lootStatus(CREATURE_LOOT_STATUS_NONE),
     m_corpseDecayTimer(0), m_respawnTime(0), m_respawnDelay(25), m_corpseDelay(60), m_aggroDelay(0), m_respawnradius(5.0f),
     m_subtype(subtype), m_defaultMovementType(IDLE_MOTION_TYPE), m_equipmentId(0),
-    m_AlreadyCallAssistance(false), m_AlreadySearchedAssistance(false),
+    m_AlreadyCallAssistance(false), m_AlreadySearchedAssistance(false), m_AllowCallAssistance(true),
     m_isDeadByDefault(false), m_temporaryFactionFlags(TEMPFACTION_NONE),
     m_meleeDamageSchoolMask(SPELL_SCHOOL_MASK_NORMAL), m_originalEntry(0),
     m_creatureInfo(nullptr), m_ai(nullptr), m_gameEventVendorId(0)
@@ -728,6 +728,9 @@ void Creature::RegenerateHealth()
 void Creature::DoFleeToGetAssistance()
 {
     if (!getVictim())
+        return;
+
+    if (HasAuraType(SPELL_AURA_PREVENTS_FLEEING))
         return;
 
     float radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_FLEE_ASSISTANCE_RADIUS);
@@ -1831,7 +1834,7 @@ void Creature::SendAIReaction(AiReaction reactionType)
 void Creature::CallAssistance()
 {
     // FIXME: should player pets call for assistance?
-    if (!m_AlreadyCallAssistance && getVictim() && !isCharmed())
+    if (!m_AlreadyCallAssistance && AllowCallAssistance() && getVictim() && !isCharmed())
     {
         SetNoCallAssistance(true);
 

--- a/src/game/Creature.h
+++ b/src/game/Creature.h
@@ -671,7 +671,9 @@ class MANGOS_DLL_SPEC Creature : public Unit
         void CallAssistance();
         void SetNoCallAssistance(bool val) { m_AlreadyCallAssistance = val; }
         void SetNoSearchAssistance(bool val) { m_AlreadySearchedAssistance = val; }
+        void SetAllowCallAssistance(bool val) { m_AllowCallAssistance = val; }
         bool HasSearchedAssistance() const { return m_AlreadySearchedAssistance; }
+        bool AllowCallAssistance() const { return m_AllowCallAssistance; }
         bool CanAssistTo(const Unit* u, const Unit* enemy, bool checkfaction = true) const;
         bool CanInitiateAttack() const;
 
@@ -778,6 +780,7 @@ class MANGOS_DLL_SPEC Creature : public Unit
         // below fields has potential for optimization
         bool m_AlreadyCallAssistance;
         bool m_AlreadySearchedAssistance;
+        bool m_AllowCallAssistance;
         bool m_isDeadByDefault;
         uint32 m_temporaryFactionFlags;                     // used for real faction changes (not auras etc)
 

--- a/src/game/FleeingMovementGenerator.cpp
+++ b/src/game/FleeingMovementGenerator.cpp
@@ -47,7 +47,7 @@ void FleeingMovementGenerator<T>::_setTargetLocation(T& owner)
     PathFinder path(&owner);
     path.setPathLengthLimit(30.0f);
     path.calculate(x, y, z);
-    if (path.getPathType() & PATHFIND_NOPATH)
+    if (path.getPathType() & (PATHFIND_NOPATH | PATHFIND_SHORT))
     {
         // path not found recheck later
         i_nextCheckTime.Reset(50);

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -9596,7 +9596,7 @@ void Unit::SetIncapacitatedState(bool apply, uint32 state, ObjectGuid casterGuid
 
     Player* controller = GetCharmerOrOwnerPlayerOrPlayerItself();
     const bool control = controller ? controller->IsClientControl(this) : false;
-    const bool movement = (state != UNIT_FLAG_STUNNED);
+    const bool movement = (state != UNIT_FLAG_STUNNED) || !apply;
     const bool stun = !!(state & UNIT_FLAG_STUNNED);
     const bool fleeing = !!(state & UNIT_FLAG_FLEEING);
 


### PR DESCRIPTION
This PR attempts to unify the behaviors of fleeing for assistance and normal fleeing. This is done by using the same movement generator and the same flags for both behaviors. It also fixes some bugs related to fleeing.

This should fix the following errors:

- Units will no longer keep autoattacking when fleeing for assistance. Previously they would attack you even though they were not targeting you.
- Units fleeing for assistance will now revert to normal fleeing if they can't find a path to their target.
- UNIT_FLAG_FLEEING should now properly be cleared after the unit stops fleeing. Previously it would just stay set, even after exiting combat.
- Fleeing enemies should no longer completely ignore pathfinding in some cases. At least one case of this happened because the generated paths were too short, so I have added a check for PATHFIND_SHORT in FleeingMovementGenerator. This does lead to enemies sometimes standing still for a while, since all generated paths are invalid, but it's probably better than them running through walls.
- Enemies fleeing for assistance will no longer ignore effects that prevent fleeing, like Curse of Recklessness.

Opinions?