### PR TITLE
Don't take fall damage if SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED is present

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -20211,7 +20211,7 @@ void Player::HandleFall(MovementInfo const& movementInfo)
     // 14.57 can be calculated by resolving damageperc formula below to 0
     if (z_diff >= 14.57f && !isDead() && !isGameMaster() && !HasMovementFlag(MOVEFLAG_ONTRANSPORT) &&
             !HasAuraType(SPELL_AURA_HOVER) && !HasAuraType(SPELL_AURA_FEATHER_FALL) &&
-            !HasAuraType(SPELL_AURA_FLY) && !IsImmuneToDamage(SPELL_SCHOOL_MASK_NORMAL))
+            !IsFreeFlying() && !IsImmuneToDamage(SPELL_SCHOOL_MASK_NORMAL))
     {
         // Safe fall, fall height reduction
         int32 safe_fall = GetTotalAuraModifier(SPELL_AURA_SAFE_FALL);


### PR DESCRIPTION
Flying mounts use SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED, which calls
SetCanFly. This means that activating instant flying mounts, like Flying
Broom and Swift Flying Broom, causes you to take fall damage in the air.

To reproduce the issue this fixes:

1. .additem 33176
2. Use Flying Broom
3. Fly up for a while
4. Remove the Flying Broom buff
5. Use Flying Broom again after a few seconds, but before hitting the ground
6. Die