### PR TITLE
Fix Travis CI for Linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ git:
 # make use of the new container based infrastructure at travis to improve performance (we don't need sudo)
 sudo: false
 
+# Use buntu 14.04
+dist: trusty
+
 # don't re-build for tags so that [publish binary] is not re-run
 # https://github.com/travis-ci/travis-ci/issues/1532
 branches:


### PR DESCRIPTION
By using Ubuntu 14.04 as building Linux dist we get a newer CMake which is required now.

EDIT: The trusty version is in beta, but my thoughts are "as long as it builds, it builds".