### PR TITLE
dbscripts_on_relay and randomization

### DIFF
--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -151,7 +151,7 @@ For all ACTION_T_RANDOM Actions, When a Particular Param is selected for the Eve
 42   ACTION_T_SET_INVINCIBILITY_HP_LEVEL    HP_Level, HP_Percent            Set min. health level for creature that can be set at damage as flat value or percent from max health
 43   ACTION_T_MOUNT_TO_ENTRY_OR_MODEL       CreatureEntry, ModelId          Set mount model from creature_template.entry (Param1) OR explicit modelId (Param2). If (Param1) AND (Param2) are both 0, unmount.
 44   ACTION_T_CHANCED_TEXT  - deprecated use 54 Chance, -TextId1, -TextId2      Displays by Chance (1..100) the specified -TextId. When -TextId2 is specified, the selection will be randomized. Text types are defined, along with other options for the text, in a table below. Param2 and Param3 needs to be negative.
-45   ACTION_T_THROW_AI_EVENT                EventType, Radius               Throws an AIEvent of type (Param1) to nearby friendly Npcs in range of (Param2)
+45   ACTION_T_THROW_AI_EVENT                EventType, Radius, Target       Throws an AIEvent of type (Param1) to nearby friendly Npcs in range of (Param2), Invoker of event is Target
 46   ACTION_T_SET_THROW_MASK                EventTypeMask                   Marks for which AIEvents the npc will throw AIEvents on its own.
 47   ACTION_T_SET_STAND_STATE               StandState                      Set the unit stand state (Param1) of the current creature.
 48   ACTION_T_CHANGE_MOVEMENT               MovementType, WanderDistance    Change the unit movement type (Param1). If the movement type is Random Movement (1), the WanderDistance (Param2) must be provided. If the movement type is Waypoint Movement (2), Param2 is PathId.
@@ -901,6 +901,9 @@ Read at bottom for documentation of creature_ai_texts-table.
 -----------------------------
 Parameter 1: EventType - What AIEvent to throw, supported types see CreatureAI.h enum AIEventType
 Parameter 2: Radius    - Throw the AIEvent to nearby friendly creatures within this range
+Parameter 3: Target    - The thrown AIEvent uses selected target as Invoker
+Each event, be it C++ or DB has 3 parties, Sender, Receiver and Invoker. Sender is EAI creature owner, Receiver is creatures found in radius, and Invoker is the one who triggered the event. Invoker can be specified
+regardless of Sender/Receiver and this enables relaying target.
 
 -----------------------------
 46 = ACTION_T_SET_THROW_MASK:

--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -107,8 +107,8 @@ For all ACTION_T_RANDOM Actions, When a Particular Param is selected for the Eve
 #    Internal name                          Param usage                     Description
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 0    ACTION_T_NONE                          No Action                       Does nothing.
-1    ACTION_T_TEXT                          -TextId1, -TextId2, -TextId3    Displays the specified -TextId. When -TextId2 and -TextId3 are specified, the selection will be Randomized between 1,2 or 3. Text ID's are defined, along with other options for the text, in creature_ai_texts table. Below is detailed Text Information. All text ID values for EventAI MUST be negative.
-2    ACTION_T_SET_FACTION                   FactionId, Flags                Changes faction for a creature. When param1 is zero, creature will revert to it's default faction. Flags will determine when faction is restored to default (evade, respawn etc)
+1    ACTION_T_TEXT - deprecated use 54      -TextId1, -TextId2, -TextId3    Displays the specified -TextId. When -TextId2 and -TextId3 are specified, the selection will be Randomized between 1,2 or 3. Text ID's are defined, along with other options for the text, in creature_ai_texts table. Below is detailed Text Information. All text ID values for EventAI MUST be negative.
+2    ACTION_T_SET_FACTION                   FactionId, Flags              Changes faction for a creature. When param1 is zero, creature will revert to it's default faction. Flags will determine when faction is restored to default (evade, respawn etc)
 3    ACTION_T_MORPH_TO_ENTRY_OR_MODEL       CreatureEntry, ModelId          Sets either model from creature_template.entry (Param1) OR explicit modelId (Param2) for the NPC. If (Param1) AND (Param2) are both 0, NPC will demorph and revert to the default model (as specified in creature_template).
 4    ACTION_T_SOUND                         SoundId                         NPC Plays a specified Sound ID.
 5    ACTION_T_EMOTE                         EmoteId                         NPC Does a specified Emote ID.
@@ -150,7 +150,7 @@ For all ACTION_T_RANDOM Actions, When a Particular Param is selected for the Eve
 41   ACTION_T_FORCE_DESPAWN                 Delay                           Despawns the creature, if delay = 0 immediate otherwise will despawn after delay time set in Param1 (in ms).
 42   ACTION_T_SET_INVINCIBILITY_HP_LEVEL    HP_Level, HP_Percent            Set min. health level for creature that can be set at damage as flat value or percent from max health
 43   ACTION_T_MOUNT_TO_ENTRY_OR_MODEL       CreatureEntry, ModelId          Set mount model from creature_template.entry (Param1) OR explicit modelId (Param2). If (Param1) AND (Param2) are both 0, unmount.
-44   ACTION_T_CHANCED_TEXT                  Chance, -TextId1, -TextId2      Displays by Chance (1..100) the specified -TextId. When -TextId2 is specified, the selection will be randomized. Text types are defined, along with other options for the text, in a table below. Param2 and Param3 needs to be negative.
+44   ACTION_T_CHANCED_TEXT  - deprecated use 54 Chance, -TextId1, -TextId2      Displays by Chance (1..100) the specified -TextId. When -TextId2 is specified, the selection will be randomized. Text types are defined, along with other options for the text, in a table below. Param2 and Param3 needs to be negative.
 45   ACTION_T_THROW_AI_EVENT                EventType, Radius               Throws an AIEvent of type (Param1) to nearby friendly Npcs in range of (Param2)
 46   ACTION_T_SET_THROW_MASK                EventTypeMask                   Marks for which AIEvents the npc will throw AIEvents on its own.
 47   ACTION_T_SET_STAND_STATE               StandState                      Set the unit stand state (Param1) of the current creature.
@@ -159,6 +159,8 @@ For all ACTION_T_RANDOM Actions, When a Particular Param is selected for the Eve
 50   ACTION_T_SET_REACT_STATE               ReactState                      Change react state of the creature
 51   ACTION_T_PAUSE_WAYPOINTS               DoPause                         Pause waypoints of creature
 52   ACTION_T_INTERRUPT_SPELL               SpellType - CurrentSpellTypes   Interrupt spell in given slot for creature
+53   ACTION_T_START_RELAY_SCRIPT            RelayIDorTemplate, Target       Launches dbscripts_on_relay script, either static one, or when param1 is < 0 then random one chosen from dbscript_random_templates
+54   ACTION_T_TEXT_NEW                      TextId, Target, TemplateId      Displays text, either static one or when param3 != 0, then random one chosen from dbscript_random_templates
 
 * = Use -1 where the param is expected to do nothing. Random constant is generated for each event, so if you have a random yell and a random sound, they will be linked up with each other (ie. param2 with param2).
 
@@ -949,6 +951,23 @@ CURRENT_AUTOREPEAT_SPELL        = 2
 CURRENT_CHANNELED_SPELL         = 3
 Melee spells, generic spells and autorepeat spells have their interruptability based on interrupt flags, albeit this flag is wrongly missing for some spells.
 Main purpose of this command is to research and find channeled spells, which do not interrupt as a result of not having found an interrupt flag.
+
+---------------------------------
+53 = ACTION_T_START_RELAY_SCRIPT:
+---------------------------------
+Parameter 1: dbscripts_on_relay ID if > 0, if < 0 dbscript_random_template relay template
+Parameter 2: Target which will determine the source of the script
+Launches a dbscripts_on_relay (either static or random one) with selected target as source and creature as target
+
+-----------------------
+54 = ACTION_T_TEXT_NEW:
+-----------------------
+Parameter 1: Text ID that the creature should say
+Parameter 2: Target at which the creature will speak
+Parameter 3: dbscript_random_template text template
+Says a text at given target, deprecates TEXT and CHANCED_TEXT actions, due to superior capabilities. Is a mirror of dbscripts capabilities.
+The text IDs are checked against creature_ai_texts for both Parameter 1 and random template in Parameter 3
+NOTE: if Parameter 3 is set, it always takes precedence over Parameter 1, random template has a higher priority. (as such, only one of them needs to be set)
 
 =========================================
 Target Types

--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -161,6 +161,7 @@ For all ACTION_T_RANDOM Actions, When a Particular Param is selected for the Eve
 52   ACTION_T_INTERRUPT_SPELL               SpellType - CurrentSpellTypes   Interrupt spell in given slot for creature
 53   ACTION_T_START_RELAY_SCRIPT            RelayIDorTemplate, Target       Launches dbscripts_on_relay script, either static one, or when param1 is < 0 then random one chosen from dbscript_random_templates
 54   ACTION_T_TEXT_NEW                      TextId, Target, TemplateId      Displays text, either static one or when param3 != 0, then random one chosen from dbscript_random_templates
+55   ACTION_T_ATTACK_START                  Target                          Attacks targeted creature
 
 * = Use -1 where the param is expected to do nothing. Random constant is generated for each event, so if you have a random yell and a random sound, they will be linked up with each other (ie. param2 with param2).
 
@@ -968,6 +969,12 @@ Parameter 3: dbscript_random_template text template
 Says a text at given target, deprecates TEXT and CHANCED_TEXT actions, due to superior capabilities. Is a mirror of dbscripts capabilities.
 The text IDs are checked against creature_ai_texts for both Parameter 1 and random template in Parameter 3
 NOTE: if Parameter 3 is set, it always takes precedence over Parameter 1, random template has a higher priority. (as such, only one of them needs to be set)
+
+---------------------------
+55 = ACTION_T_ATTACK_START:
+---------------------------
+Parameter 1: Target at which the creature will attack
+Attacks targeted creature. This has particular use when we want to attack specific target received through ACTION_T_THROW_AI_EVENT for example. Can also be used to attack summoner at spawn for example.
 
 =========================================
 Target Types

--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -162,6 +162,7 @@ For all ACTION_T_RANDOM Actions, When a Particular Param is selected for the Eve
 53   ACTION_T_START_RELAY_SCRIPT            RelayIDorTemplate, Target       Launches dbscripts_on_relay script, either static one, or when param1 is < 0 then random one chosen from dbscript_random_templates
 54   ACTION_T_TEXT_NEW                      TextId, Target, TemplateId      Displays text, either static one or when param3 != 0, then random one chosen from dbscript_random_templates
 55   ACTION_T_ATTACK_START                  Target                          Attacks targeted creature
+56   ACTION_T_DESPAWN_GUARDIANS             EntryId                         Despawns guardian with specified entry, or if 0 despawns all guardians
 
 * = Use -1 where the param is expected to do nothing. Random constant is generated for each event, so if you have a random yell and a random sound, they will be linked up with each other (ie. param2 with param2).
 
@@ -975,6 +976,12 @@ NOTE: if Parameter 3 is set, it always takes precedence over Parameter 1, random
 ---------------------------
 Parameter 1: Target at which the creature will attack
 Attacks targeted creature. This has particular use when we want to attack specific target received through ACTION_T_THROW_AI_EVENT for example. Can also be used to attack summoner at spawn for example.
+
+--------------------------------
+56 = ACTION_T_DESPAWN_GUARDIANS:
+--------------------------------
+Parameter 1: Entry ID of guardian to be despawned (can also be 0)
+If a given entry is valid and found, despawns guardian with given entry. If parameter 1 is 0, despawns all guardians (which is the more common script action).
 
 =========================================
 Target Types

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -17,6 +17,7 @@ dbscripts_on_gossip                 DB project self defined id
 dbscripts_on_quest_end              DB project self defined id (generally quest entry)
 dbscripts_on_quest_start            DB project self defined id (generally quest entry)
 dbscripts_on_spell                  Spell id
+dbscripts_on_relay                  DB project self defined id, Id is used in dbscripts, EAI or SD2 to launch it
 
 -- --------------------------
 ## delay
@@ -153,8 +154,8 @@ Where "A  ->  B" means that the command is executed from A with B as target.
 -- --------------------------
 
  0 SCRIPT_COMMAND_TALK                      resultingSource = WorldObject, resultingTarget = Unit/none
-                                            * datalong = dbscript_string_template ID - will randomize between all db_script_strings in given template
-                                            * dataint = text entry from db_script_string -table. dataint2-dataint4 optionally, for random selection of text
+                                            * datalong = dbscript_string_template ID - will randomize between all db_script_strings in given template, ids from template are checked against dbscript_string table
+                                            * dataint = text entry from dbscript_string -table. dataint2-dataint4 optionally, for random selection of text
 
  1 SCRIPT_COMMAND_EMOTE                     resultingSource = Unit, resultingTarget = Unit/none
                                             * datalong = emote_id
@@ -342,3 +343,7 @@ Where "A  ->  B" means that the command is executed from A with B as target.
                                             * resultingSource = Creature
                                             * datalong = new creature entry. Must be different than the current one
                                             * datalong2 = faction for which the entry is updated. 0 = Alliance, 1 = Horde
+45 SCRIPT_COMMAND_START_RELAY_SCRIPT        Launch dbscripts_on_relay script, either static one, or randomly chosen one from dbscript_random_templates
+                                            * source and target of command define source and target of launched dbscript
+                                            * datalong = dbscripts_on_relay id
+                                            * datalong2 = dbscript_random_templates id

--- a/sql/updates/mangos/05DbscriptOnRelay.sql
+++ b/sql/updates/mangos/05DbscriptOnRelay.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS `dbscripts_on_relay`;
+CREATE TABLE `dbscripts_on_relay` (
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `delay` int(10) unsigned NOT NULL DEFAULT '0',
+  `command` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong2` int(10) unsigned NOT NULL DEFAULT '0',
+  `datalong3` int(11) unsigned NOT NULL DEFAULT '0',
+  `buddy_entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `search_radius` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `data_flags` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `dataint` int(11) NOT NULL DEFAULT '0',
+  `dataint2` int(11) NOT NULL DEFAULT '0',
+  `dataint3` int(11) NOT NULL DEFAULT '0',
+  `dataint4` int(11) NOT NULL DEFAULT '0',
+  `x` float NOT NULL DEFAULT '0',
+  `y` float NOT NULL DEFAULT '0',
+  `z` float NOT NULL DEFAULT '0',
+  `o` float NOT NULL DEFAULT '0',
+  `comments` varchar(255) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+

--- a/sql/updates/mangos/06Dbscript_random_template.sql
+++ b/sql/updates/mangos/06Dbscript_random_template.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS `dbscript_random_templates`;
+CREATE TABLE `dbscript_random_templates` (
+  `id` int(11) unsigned NOT NULL COMMENT 'Id of template',
+  `type` int(11) unsigned NOT NULL COMMENT 'Type of template',
+  `target_id` int(11) NOT NULL DEFAULT '0' COMMENT 'Id of chanced element',
+  `chance` int(11) NOT NULL DEFAULT '0' COMMENT 'Chance for element to occur in %',
+  PRIMARY KEY (`id`,`type`,`target_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPACT COMMENT='DBScript system';
+
+-- type 0 - strings
+-- type 1 - relay dbscript
+
+INSERT INTO dbscript_random_templates(id,type,target_id,chance) SELECT id,'0',string_id,'0' FROM dbscript_string_template;
+
+DROP TABLE IF EXISTS dbscript_string_template;
+
+

--- a/sql/updates/mangos/07Dbscript_string_rename.sql
+++ b/sql/updates/mangos/07Dbscript_string_rename.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS `dbscript_string`;
+RENAME TABLE `db_script_string` TO `dbscript_string`;
+
+ALTER TABLE conditions
+ADD comments varchar(300) AFTER value2;
+
+

--- a/src/game/AI/BaseAI/CreatureAI.cpp
+++ b/src/game/AI/BaseAI/CreatureAI.cpp
@@ -180,10 +180,13 @@ void CreatureAI::SetCombatMovement(bool enable, bool stopOrStartMovement /*=fals
 
     if (stopOrStartMovement && m_unit->getVictim())     // Only change current movement while in combat
     {
-        if (enable)
-            m_unit->GetMotionMaster()->MoveChase(m_unit->getVictim(), m_attackDistance, m_attackAngle);
-        else if (m_unit->GetMotionMaster()->GetCurrentMovementGeneratorType() == CHASE_MOTION_TYPE)
-            m_unit->StopMoving();
+        if (!m_unit->IsIncapacitated())
+        {
+            if (enable)
+                m_unit->GetMotionMaster()->MoveChase(m_unit->getVictim(), m_attackDistance, m_attackAngle, false);
+            else if (m_unit->GetMotionMaster()->GetCurrentMovementGeneratorType() == CHASE_MOTION_TYPE)
+                m_unit->StopMoving();
+        }
     }
 }
 

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -1112,7 +1112,40 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                 return;
             }
 
-            m_creature->GetMap()->ScriptsStart(sRelayScripts, action.relayScript.relayId, target, nullptr);
+            if (action.relayScript.relayId < 0)
+            {
+                uint32 relayId = sScriptMgr.GetRandomRelayDbscriptFromTemplate(uint32(-action.relayScript.relayId));
+                if (relayId == 0)
+                    break;
+                m_creature->GetMap()->ScriptsStart(sRelayScripts, relayId, target, nullptr);
+            }
+            else
+                m_creature->GetMap()->ScriptsStart(sRelayScripts, action.relayScript.relayId, target, nullptr);
+            break;
+        }
+        case ACTION_T_TEXT_NEW:
+        {
+            Unit* target = GetTargetByType(action.textNew.target, pActionInvoker, pAIEventSender, reportTargetError);
+            if (!target)
+            {
+                if (reportTargetError)
+                    sLog.outErrorEventAI("Event %d attempt to start relay script but Target == nullptr. Creature %d", EventId, m_creature->GetEntry());
+                return;
+            }
+
+            int32 textId = 0;
+
+            if (action.textNew.templateId)
+            {
+                textId = sScriptMgr.GetRandomScriptStringFromTemplate(action.textNew.templateId);
+                if (textId == 0)
+                    break;
+            }
+            else
+                textId = action.textNew.textId;
+
+            if (!DoDisplayText(m_creature, textId, target))
+                sLog.outErrorEventAI("Error attempting to display text %i, used by script %u", textId, EventId);
             break;
         }
         default:

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -1148,6 +1148,18 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                 sLog.outErrorEventAI("Error attempting to display text %i, used by script %u", textId, EventId);
             break;
         }
+        case ACTION_T_ATTACK_START:
+        {
+            Unit* target = GetTargetByType(action.attackStart.target, pActionInvoker, pAIEventSender, reportTargetError);
+            if (!target)
+            {
+                if (reportTargetError)
+                    sLog.outErrorEventAI("Event %d attempt to start relay script but Target == nullptr. Creature %d", EventId, m_creature->GetEntry());
+                return;
+            }
+            AttackStart(target);
+            break;
+        }
         default:
             sLog.outError("CreatureEventAi::ProcessAction(): action(%u) not implemented", static_cast<uint32>(action.type));
             break;

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -685,6 +685,8 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                 {
                     if (m_DynamicMovement)
                     {
+                        SetCombatMovement(false, true);
+
                         SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
 
                         if (spellInfo && !(spellInfo->rangeIndex == SPELL_RANGE_IDX_COMBAT || spellInfo->rangeIndex == SPELL_RANGE_IDX_SELF_ONLY) && target != m_creature)
@@ -1262,6 +1264,12 @@ void CreatureEventAI::JustReachedHome()
 
 void CreatureEventAI::EnterEvadeMode()
 {
+    if (m_DynamicMovement)
+    {
+        m_DynamicMovement = false;
+        SetCombatMovement(!m_DynamicMovement);
+    }
+
     m_creature->RemoveAllAurasOnEvade();
     m_creature->DeleteThreatList();
     m_creature->CombatStop(true);
@@ -1514,8 +1522,12 @@ void CreatureEventAI::UpdateAI(const uint32 diff)
         {
             if (m_creature->IsWithinLOSInMap(victim))
             {
-                if (m_LastSpellMaxRange && m_creature->IsInRange(victim, 0, (m_LastSpellMaxRange / 1.5f)))
-                    SetCombatMovement(false, true);
+                if (m_LastSpellMaxRange && m_creature->IsInRange(victim, 0, (m_LastSpellMaxRange / 1.5f)) &&
+                    m_creature->GetMotionMaster()->GetCurrentMovementGeneratorType() == CHASE_MOTION_TYPE)
+                {
+                    if(IsCombatMovement())
+                        SetCombatMovement(false, true);
+                }
                 else
                     SetCombatMovement(true, true);
             }

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -1102,6 +1102,19 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             m_creature->InterruptSpell((CurrentSpellTypes)action.interruptSpell.currentSpellType);
             break;
         }
+        case ACTION_T_START_RELAY_SCRIPT:
+        {
+            Unit* target = GetTargetByType(action.relayScript.target, pActionInvoker, pAIEventSender, reportTargetError);
+            if (!target)
+            {
+                if (reportTargetError)
+                    sLog.outErrorEventAI("Event %d attempt to start relay script but Target == nullptr. Creature %d", EventId, m_creature->GetEntry());
+                return;
+            }
+
+            m_creature->GetMap()->ScriptsStart(sRelayScripts, action.relayScript.relayId, target, nullptr);
+            break;
+        }
         default:
             sLog.outError("CreatureEventAi::ProcessAction(): action(%u) not implemented", static_cast<uint32>(action.type));
             break;

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -1160,6 +1160,21 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             AttackStart(target);
             break;
         }
+        case ACTION_T_DESPAWN_GUARDIANS:
+        {
+            if (action.despawnGuardians.entryId)
+            {
+                if (Pet* guardian = m_creature->FindGuardianWithEntry(action.despawnGuardians.entryId))
+                {
+                    guardian->Unsummon(PET_SAVE_AS_DELETED, m_creature); // can remove pet guid from m_guardianPets
+                    m_creature->RemoveGuardian(guardian);
+                }
+                // not throwing error otherwise because guardian might as well be dead
+            }
+            else
+                m_creature->RemoveGuardians();
+            break;
+        }
         default:
             sLog.outError("CreatureEventAi::ProcessAction(): action(%u) not implemented", static_cast<uint32>(action.type));
             break;

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -1045,7 +1045,14 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
         }
         case ACTION_T_THROW_AI_EVENT:
         {
-            SendAIEventAround(AIEventType(action.throwEvent.eventType), pActionInvoker, 0, action.throwEvent.radius);
+            Unit* target = GetTargetByType(action.throwEvent.target, pActionInvoker, pAIEventSender, reportTargetError);
+            if (!target)
+            {
+                if (reportTargetError)
+                    sLog.outErrorEventAI("Event %d attempt to start relay script but Target == nullptr. Creature %d", EventId, m_creature->GetEntry());
+                return;
+            }
+            SendAIEventAround(AIEventType(action.throwEvent.eventType), target, 0, action.throwEvent.radius);
             break;
         }
         case ACTION_T_SET_THROW_MASK:

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -121,7 +121,7 @@ enum EventAI_ActionType
     ACTION_T_SET_INVINCIBILITY_HP_LEVEL = 42,               // MinHpValue, format(0-flat,1-percent from max health)
     ACTION_T_MOUNT_TO_ENTRY_OR_MODEL    = 43,               // Creature_template entry(param1) OR ModelId (param2) (or 0 for both to unmount)
     ACTION_T_CHANCED_TEXT               = 44,               // Chance to display the text, TextId1, optionally TextId2. If more than just -TextId1 is defined, randomize. Negative values.
-    ACTION_T_THROW_AI_EVENT             = 45,               // EventType, Radius, unused
+    ACTION_T_THROW_AI_EVENT             = 45,               // EventType, Radius, Target
     ACTION_T_SET_THROW_MASK             = 46,               // EventTypeMask, unused, unused
     ACTION_T_SET_STAND_STATE            = 47,               // StandState, unused, unused
     ACTION_T_CHANGE_MOVEMENT            = 48,               // MovementType, WanderDistance if Movement Type 1 and PathId if Movement Type 2, unused
@@ -411,7 +411,7 @@ struct CreatureEventAI_Action
         {
             uint32 eventType;
             uint32 radius;
-            uint32 unused;
+            uint32 target;
         } throwEvent;
         // ACTION_T_SET_THROW_MASK                          = 46
         struct

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -129,6 +129,7 @@ enum EventAI_ActionType
     ACTION_T_SET_REACT_STATE            = 50,               // React state, unused, unused
     ACTION_T_PAUSE_WAYPOINTS            = 51,               // DoPause 0: unpause waypoint 1: pause waypoint, unused, unused
     ACTION_T_INTERRUPT_SPELL            = 52,               // SpellType enum CurrentSpellTypes, unused, unused
+    ACTION_T_START_RELAY_SCRIPT         = 53,               // Relay script ID, unused, unused
 
     ACTION_T_END,
 };
@@ -445,11 +446,10 @@ struct CreatureEventAI_Action
             uint32 unused2;
         } setReactState;
         // ACTION_T_PAUSE_WAYPOINTS                         = 51
-        struct                                              
+        struct
         {
             uint32 doPause;                                 // bool: 1 = on; 0 = off
             uint32 unused1;
-            uint32 unused2;
         } pauseWaypoint;
         // ACTION_T_INTERRUPT_SPELL                         = 52
         struct
@@ -458,6 +458,13 @@ struct CreatureEventAI_Action
             uint32 unused1;
             uint32 unused2;
         } interruptSpell;
+        // ACTION_T_START_RELAY_SCRIPT                      = 51
+        struct
+        {
+            uint32 relayId;                                 // dbscript_on_relay id
+            uint32 target;                                  // target
+            uint32 unused2;
+        } relayScript;
         // RAW
         struct
         {

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -130,9 +130,9 @@ enum EventAI_ActionType
     ACTION_T_PAUSE_WAYPOINTS            = 51,               // DoPause 0: unpause waypoint 1: pause waypoint, unused, unused
     ACTION_T_INTERRUPT_SPELL            = 52,               // SpellType enum CurrentSpellTypes, unused, unused
     ACTION_T_START_RELAY_SCRIPT         = 53,               // Relay script ID, target, unused
-    ACTION_T_TEXT_NEW                   = 54,               // Text ID or template ID, target, template Id
     ACTION_T_TEXT_NEW                   = 54,               // Text ID, target, template Id
     ACTION_T_ATTACK_START               = 55,               // Target, unused, unused
+    ACTION_T_DESPAWN_GUARDIANS          = 56,               // Guardian Entry ID (or 0 to despawn all guardians), unused, unused
 
     ACTION_T_END,
 };
@@ -482,6 +482,13 @@ struct CreatureEventAI_Action
             uint32 unused;
             uint32 unused2;
         } attackStart;
+        // ACTION_T_DESPAWN_GUARDIANS                       = 56
+        struct
+        {
+            uint32 entryId;                                // guardian Entry
+            uint32 unused;
+            uint32 unused2;
+        } despawnGuardians;
         // RAW
         struct
         {

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -129,7 +129,8 @@ enum EventAI_ActionType
     ACTION_T_SET_REACT_STATE            = 50,               // React state, unused, unused
     ACTION_T_PAUSE_WAYPOINTS            = 51,               // DoPause 0: unpause waypoint 1: pause waypoint, unused, unused
     ACTION_T_INTERRUPT_SPELL            = 52,               // SpellType enum CurrentSpellTypes, unused, unused
-    ACTION_T_START_RELAY_SCRIPT         = 53,               // Relay script ID, unused, unused
+    ACTION_T_START_RELAY_SCRIPT         = 53,               // Relay script ID, target, unused
+    ACTION_T_TEXT_NEW                   = 54,               // Text ID or template ID, target, template Id
 
     ACTION_T_END,
 };
@@ -461,10 +462,17 @@ struct CreatureEventAI_Action
         // ACTION_T_START_RELAY_SCRIPT                      = 51
         struct
         {
-            uint32 relayId;                                 // dbscript_on_relay id
-            uint32 target;                                  // target
-            uint32 unused2;
+            int32 relayId;                                 // dbscript_on_relay id
+            uint32 target;                                 // target
+            uint32 unused;
         } relayScript;
+        // ACTION_T_TEXT_NEW                                = 54
+        struct
+        {
+            int32 textId;                                  // text id
+            uint32 target;                                 // target
+            uint32 templateId;                             // random template Id
+        } textNew;
         // RAW
         struct
         {

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -131,6 +131,8 @@ enum EventAI_ActionType
     ACTION_T_INTERRUPT_SPELL            = 52,               // SpellType enum CurrentSpellTypes, unused, unused
     ACTION_T_START_RELAY_SCRIPT         = 53,               // Relay script ID, target, unused
     ACTION_T_TEXT_NEW                   = 54,               // Text ID or template ID, target, template Id
+    ACTION_T_TEXT_NEW                   = 54,               // Text ID, target, template Id
+    ACTION_T_ATTACK_START               = 55,               // Target, unused, unused
 
     ACTION_T_END,
 };
@@ -473,6 +475,13 @@ struct CreatureEventAI_Action
             uint32 target;                                 // target
             uint32 templateId;                             // random template Id
         } textNew;
+        // ACTION_T_ATTACK_START                            = 55
+        struct
+        {
+            uint32 target;                                 // target
+            uint32 unused;
+            uint32 unused2;
+        } attackStart;
         // RAW
         struct
         {

--- a/src/game/AI/EventAI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/EventAI/CreatureEventAIMgr.cpp
@@ -27,6 +27,7 @@
 #include "Maps/GridDefines.h"
 #include "AI/ScriptDevAI/ScriptDevAIMgr.h"
 #include "World/World.h"
+#include "DBScripts/ScriptMgr.h"
 
 INSTANTIATE_SINGLETON_1(CreatureEventAIMgr);
 
@@ -73,11 +74,17 @@ void CreatureEventAIMgr::CheckUnusedAITexts()
                                 idx_set.erase(action.text.TextId[k]);
                         break;
                     }
+                    case ACTION_T_TEXT_NEW:
+                        if (action.textNew.textId)
+                            idx_set.erase(action.textNew.textId);
+                        break;
                     default: break;
                 }
             }
         }
     }
+
+    sScriptMgr.CheckRandomStringTemplates(idx_set);
 
     for (std::set<int32>::const_iterator itr = idx_set.begin(); itr != idx_set.end(); ++itr)
         sLog.outErrorEventAI("Entry %i in table `creature_ai_texts` but not used in EventAI scripts.", *itr);
@@ -915,11 +922,51 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                         }
                         break;
                     case ACTION_T_START_RELAY_SCRIPT:
-                        if (sRelayScripts.second.find(action.relayScript.relayId) == sRelayScripts.second.end())
+                        if (action.relayScript.relayId > 0)
                         {
-                            sLog.outErrorEventAI("Event %u Action %u uses invalid dbscript_on_relay id %u", i, j + 1, action.setReactState.reactState, REACT_AGGRESSIVE);
-                            continue;
+                            if (sRelayScripts.second.find(action.relayScript.relayId) == sRelayScripts.second.end())
+                            {
+                                sLog.outErrorEventAI("Event %u Action %u references invalid dbscript_on_relay id %u", i, j + 1, action.relayScript.relayId);
+                                continue;
+                            }
                         }
+                        else
+                        {
+                            if (!sScriptMgr.CheckScriptRelayTemplateId(uint32(-action.relayScript.relayId)))
+                            {
+                                sLog.outErrorEventAI("Event %u Action %u references non-existing entry for relay Id template (%i) in dbscript_random_templates table.", i, j + 1, action.relayScript.relayId);
+                                break;
+                            }
+                        }
+                        break;
+                    case ACTION_T_TEXT_NEW:
+                        if (action.textNew.textId)
+                        {
+                            if (!sObjectMgr.GetMangosStringLocale(action.textNew.textId))
+                            {
+                                sLog.outErrorEventAI("Event %u Action %u references non-existing entry (%i) in texts table.", i, j + 1, action.textNew.textId);
+                                action.textNew.textId = 0;
+                            }
+                            else
+                                usedTextIds.insert(action.textNew.textId);
+                        }
+                        else
+                        {
+                            if (!sScriptMgr.CheckScriptStringTemplateId(action.textNew.templateId))
+                            {
+                                sLog.outErrorEventAI("Event %u Action %u references non-existing entry for text template (%i) in dbscript_random_templates table.", i, j + 1, action.textNew.textId);
+                                break;
+                            }
+                            else
+                            {
+                                ScriptMgr::ScriptTemplateVector templateData;
+                                sScriptMgr.GetScriptStringTemplate(action.textNew.templateId, templateData);
+                                for(auto& data : templateData)
+                                    if(data.first)
+                                        usedTextIds.insert(data.first);
+                            }
+                        }
+
                         break;
                     default:
                         sLog.outErrorEventAI("Event %u Action %u have currently not checked at load action type (%u). Need check code update?", i, j + 1, temp.action[j].type);

--- a/src/game/AI/EventAI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/EventAI/CreatureEventAIMgr.cpp
@@ -966,7 +966,9 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                                         usedTextIds.insert(data.first);
                             }
                         }
-
+                        break;
+                    case ACTION_T_ATTACK_START:
+                        IsValidTargetType(temp.event_type, action.type, action.attackStart.target, i, j + 1);
                         break;
                     default:
                         sLog.outErrorEventAI("Event %u Action %u have currently not checked at load action type (%u). Need check code update?", i, j + 1, temp.action[j].type);

--- a/src/game/AI/EventAI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/EventAI/CreatureEventAIMgr.cpp
@@ -242,6 +242,7 @@ bool IsValidTargetType(EventAI_Type eventType, EventAI_ActionType actionType, ui
             }
             return true;
         case TARGET_T_SUMMONER:
+        case TARGET_T_EVENT_SPECIFIC:
             return true;
         default:
             sLog.outErrorEventAI("Event %u Action%u uses incorrect Target type", eventId, action);

--- a/src/game/AI/EventAI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/EventAI/CreatureEventAIMgr.cpp
@@ -914,6 +914,13 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                             continue;
                         }
                         break;
+                    case ACTION_T_START_RELAY_SCRIPT:
+                        if (sRelayScripts.second.find(action.relayScript.relayId) == sRelayScripts.second.end())
+                        {
+                            sLog.outErrorEventAI("Event %u Action %u uses invalid dbscript_on_relay id %u", i, j + 1, action.setReactState.reactState, REACT_AGGRESSIVE);
+                            continue;
+                        }
+                        break;
                     default:
                         sLog.outErrorEventAI("Event %u Action %u have currently not checked at load action type (%u). Need check code update?", i, j + 1, temp.action[j].type);
                         break;

--- a/src/game/AI/EventAI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/EventAI/CreatureEventAIMgr.cpp
@@ -970,6 +970,13 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                     case ACTION_T_ATTACK_START:
                         IsValidTargetType(temp.event_type, action.type, action.attackStart.target, i, j + 1);
                         break;
+                    case ACTION_T_DESPAWN_GUARDIANS:
+                        if (action.despawnGuardians.entryId && !sCreatureStorage.LookupEntry<CreatureInfo>(action.despawnGuardians.entryId))
+                        {
+                            sLog.outErrorEventAI("Event %u Action %u uses nonexistent Creature entry %u.", i, j + 1, action.despawnGuardians.entryId);
+                            action.despawnGuardians.entryId = 0;
+                        }
+                        break;
                     default:
                         sLog.outErrorEventAI("Event %u Action %u have currently not checked at load action type (%u). Need check code update?", i, j + 1, temp.action[j].type);
                         break;

--- a/src/game/AI/EventAI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/EventAI/CreatureEventAIMgr.cpp
@@ -882,7 +882,7 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                             sLog.outErrorEventAI("Event %u Action %u uses unexpected radius 0 (set to %f of CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS)", i, j + 1, sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS));
                             action.throwEvent.radius = uint32(sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS));
                         }
-
+                        IsValidTargetType(temp.event_type, action.type, action.throwEvent.target, i, j + 1);
                         break;
                     case ACTION_T_SET_THROW_MASK:
                         if (action.setThrowMask.eventTypeMask & ~((1 << MAXIMAL_AI_EVENT_EVENTAI) - 1))

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -513,6 +513,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "dbscripts_on_quest_end",      SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadDBScriptsOnQuestEndCommand,     "", nullptr },
         { "dbscripts_on_quest_start",    SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadDBScriptsOnQuestStartCommand,   "", nullptr },
         { "dbscripts_on_spell",          SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadDBScriptsOnSpellCommand,        "", nullptr },
+        { "dbscripts_on_relay",          SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadDBScriptsOnRelayCommand,        "", nullptr },
         { "disenchant_loot_template",    SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadLootTemplatesDisenchantCommand, "", nullptr },
         { "fishing_loot_template",       SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadLootTemplatesFishingCommand,    "", nullptr },
         { "game_graveyard_zone",         SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadGameGraveyardZoneCommand,       "", nullptr },

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -413,6 +413,7 @@ class ChatHandler
         bool HandleReloadDBScriptsOnQuestEndCommand(char* args);
         bool HandleReloadDBScriptsOnQuestStartCommand(char* args);
         bool HandleReloadDBScriptsOnSpellCommand(char* args);
+        bool HandleReloadDBScriptsOnRelayCommand(char* args);
 
         bool HandleReloadEventAITextsCommand(char* args);
         bool HandleReloadEventAISummonsCommand(char* args);

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -302,6 +302,7 @@ bool ChatHandler::HandleReloadAllScriptsCommand(char* /*args*/)
     HandleReloadDBScriptsOnQuestEndCommand((char*)"a");
     HandleReloadDBScriptsOnQuestStartCommand((char*)"a");
     HandleReloadDBScriptsOnSpellCommand((char*)"a");
+    HandleReloadDBScriptsOnRelayCommand((char*)"a");
     SendGlobalSysMessage("DB tables `*_scripts` reloaded.");
     HandleReloadDbScriptStringCommand((char*)"a");
     return true;
@@ -964,6 +965,26 @@ bool ChatHandler::HandleReloadDBScriptsOnCreatureDeathCommand(char* args)
 
     if (*args != 'a')
         SendGlobalSysMessage("DB table `dbscripts_on_creature_death` reloaded.");
+
+    return true;
+}
+
+bool ChatHandler::HandleReloadDBScriptsOnRelayCommand(char* args)
+{
+    if (sScriptMgr.IsScriptScheduled())
+    {
+        SendSysMessage("DB scripts used currently, please attempt reload later.");
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    if (*args != 'a')
+        sLog.outString("Re-Loading Scripts from `dbscripts_on_quest_end`...");
+
+    sScriptMgr.LoadQuestEndScripts();
+
+    if (*args != 'a')
+        SendGlobalSysMessage("DB table `dbscripts_on_quest_end` reloaded.");
 
     return true;
 }

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -822,9 +822,9 @@ bool ChatHandler::HandleReloadEventAIScriptsCommand(char* /*args*/)
 
 bool ChatHandler::HandleReloadDbScriptStringCommand(char* /*args*/)
 {
-    sLog.outString("Re-Loading Script strings from `db_script_string`...");
+    sLog.outString("Re-Loading Script strings from `dbscript_string`...");
     sScriptMgr.LoadDbScriptStrings();
-    SendGlobalSysMessage("DB table `db_script_string` reloaded.");
+    SendGlobalSysMessage("DB table `dbscript_string` reloaded.");
     return true;
 }
 

--- a/src/game/DBScripts/ScriptMgr.cpp
+++ b/src/game/DBScripts/ScriptMgr.cpp
@@ -868,8 +868,24 @@ void ScriptMgr::LoadRelayScripts()
     // check ids
     for (ScriptMapMap::const_iterator itr = sRelayScripts.second.begin(); itr != sRelayScripts.second.end(); ++itr)
     {
-        if (!sObjectMgr.GetCreatureTemplate(itr->first))
-            sLog.outErrorDb("Table `dbscripts_on_creature_death` has not existing creature (Entry: %u) as script id", itr->first);
+        for (auto& data : itr->second) // need to check after load is complete, because of nesting
+        {
+            if (data.second.command == SCRIPT_COMMAND_START_RELAY_SCRIPT)
+            {
+                bool hasErrored = false;
+                if (data.second.relayScript.relayId)
+                {
+                    if (sRelayScripts.second.find(data.second.relayScript.relayId) == sRelayScripts.second.end())
+                    {
+                        sLog.outErrorDb("Table `dbscripts_on_relay` uses nonexistent relay ID %u in SCRIPT_COMMAND_START_RELAY_SCRIPT for script id %u.", data.second.relayScript.relayId, data.second.id);
+                        hasErrored = true;
+                    }
+                }
+
+                if (hasErrored)
+                    continue;
+            }
+        }
     }
 }
 
@@ -883,7 +899,7 @@ void ScriptMgr::LoadDbScriptStrings()
         if (sObjectMgr.GetMangosStringLocale(i))
             ids.insert(i);
 
-    LoadDbScriptStringTemplates(ids);
+    CheckRandomStringTemplates(ids);
 
     CheckScriptTexts(sQuestEndScripts, ids);
     CheckScriptTexts(sQuestStartScripts, ids);
@@ -902,11 +918,9 @@ void ScriptMgr::LoadDbScriptStrings()
         sLog.outErrorDb("Table `db_script_string` has unused string id %u", *itr);
 }
 
-void ScriptMgr::LoadDbScriptStringTemplates(std::set<int32>& ids)
+void ScriptMgr::LoadDbScriptRandomTemplates()
 {
-    sLog.outString("Loading script string templates");
-
-    QueryResult* result = WorldDatabase.Query("SELECT id, string_id FROM dbscript_string_template");
+    QueryResult* result = WorldDatabase.Query("SELECT id, type, target_id, chance FROM dbscript_random_templates");
 
     if (result)
     {
@@ -915,16 +929,37 @@ void ScriptMgr::LoadDbScriptStringTemplates(std::set<int32>& ids)
             Field* fields = result->Fetch();
 
             uint32 id = fields[0].GetUInt32();
-            int32 stringId = fields[1].GetInt32();
-            m_stringTemplates[id].push_back(stringId);
-
-            if (ids.find(stringId) != ids.end())
-                ids.erase(stringId);
+            int32 type = fields[1].GetUInt32();
+            int32 targetId = fields[2].GetInt32();
+            uint32 chance = fields[3].GetUInt32();
+            if(type < MAX_TYPE)
+                m_scriptTemplates[type][id].push_back({ targetId, chance });
+            else
+                sLog.outErrorDb("Table `dbscript_random_templates` entry (%u) uses invalid type (%u). Won't be used.", id, type);
         }
         while (result->NextRow());
 
         delete result;
     }
+
+    // String templates are checked on string loading
+    CheckRandomRelayTemplates();
+}
+
+void ScriptMgr::CheckRandomStringTemplates(std::set<int32>& ids)
+{
+    for (auto& templateData : m_scriptTemplates[STRING_TEMPLATE])
+        for (auto& data : templateData.second)
+            if (ids.find(data.first) != ids.end())
+                ids.erase(data.first);
+}
+
+void ScriptMgr::CheckRandomRelayTemplates()
+{
+    for (auto& templateData : m_scriptTemplates[RELAY_TEMPLATE])
+        for (auto& data : templateData.second)
+            if (data.first && sRelayScripts.second.find(data.first) == sRelayScripts.second.end())
+                sLog.outErrorDb("Table `dbscript_random_templates` entry (%u) uses nonexistent relay ID (%u).", templateData.first, data.first);
 }
 
 void ScriptMgr::CheckScriptTexts(ScriptMapMapName const& scripts, std::set<int32>& ids)
@@ -946,11 +981,11 @@ void ScriptMgr::CheckScriptTexts(ScriptMapMapName const& scripts, std::set<int32
 
                 if (itrM->second.talk.stringTemplateId)
                 {
-                    std::vector<int32>& vector = m_stringTemplates[itrM->second.talk.stringTemplateId];
-                    for (int32& stringId : vector)
+                    auto& vector = m_scriptTemplates[STRING_TEMPLATE][itrM->second.talk.stringTemplateId];
+                    for (auto& data : vector)
                     {
-                        if(!sObjectMgr.GetMangosStringLocale(stringId))
-                            sLog.outErrorDb("Table `db_script_string` is missing string id %u, used in database script template table dbscript_string_template id %u.", stringId, itrM->second.talk.stringTemplateId);
+                        if(!sObjectMgr.GetMangosStringLocale(data.first))
+                            sLog.outErrorDb("Table `db_script_string` is missing string id %u, used in database script template table dbscript_string_template id %u.", data.first, itrM->second.talk.stringTemplateId);
                     }
                 }
             }
@@ -1219,9 +1254,8 @@ bool ScriptAction::HandleScriptStep()
 
             if (m_script->talk.stringTemplateId)
             {
-                bool includingNone = m_script->data_flags & SCRIPT_FLAG_COMMAND_ADDITIONAL;
-                textId = sScriptMgr.GetRandomScriptStringFromTemplate(m_script->talk.stringTemplateId, includingNone);
-                if (textId == 0 && includingNone)
+                textId = sScriptMgr.GetRandomScriptStringFromTemplate(m_script->talk.stringTemplateId);
+                if (textId == 0)
                     break;
             }
             else
@@ -2100,7 +2134,15 @@ bool ScriptAction::HandleScriptStep()
             if (LogIfNotUnit(pSource))
                 return false;
 
-            m_map->ScriptsStart(sRelayScripts, m_script->relayScript.relayId, pSource, pTarget);
+            uint32 chosenId;
+            if (m_script->relayScript.templateId)
+                chosenId = sScriptMgr.GetRandomRelayDbscriptFromTemplate(m_script->relayScript.templateId);
+            else
+                chosenId = m_script->relayScript.relayId;
+
+            if (chosenId)
+                m_map->ScriptsStart(sRelayScripts, chosenId, pSource, pTarget);
+            break;
         }
         default:
             sLog.outErrorDb(" DB-SCRIPTS: Process table `%s` id %u, command %u unknown command used.", m_table, m_script->id, m_script->command);
@@ -2108,6 +2150,45 @@ bool ScriptAction::HandleScriptStep()
     }
 
     return false;
+}
+
+int32 ScriptMgr::GetRandomScriptTemplateId(uint32 id, uint8 templateType)
+{
+    auto& scriptTemplate = m_scriptTemplates[templateType][id];
+    if (scriptTemplate.empty())
+        return 0;
+
+    uint32 totalChance = 0;
+    for (auto& data : scriptTemplate)
+        totalChance += data.second;
+
+    if (totalChance == 0)
+    {
+        uint32 random = urand(0, scriptTemplate.size() - 1);
+        return scriptTemplate[random].first;
+    }
+    else
+    {
+        uint32 random = urand(0, totalChance);
+        uint32 cumulativeChance = 0;
+        for (auto& data : scriptTemplate)
+        {
+            cumulativeChance += data.second;
+            if (cumulativeChance >= random)
+                return data.first;
+        }
+        return 0; // should never get here - error suppression
+    }
+}
+
+int32 ScriptMgr::GetRandomScriptStringFromTemplate(uint32 id)
+{
+    return GetRandomScriptTemplateId(id, STRING_TEMPLATE);
+}
+
+int32 ScriptMgr::GetRandomRelayDbscriptFromTemplate(uint32 id)
+{
+    return GetRandomScriptTemplateId(id, RELAY_TEMPLATE);
 }
 
 // /////////////////////////////////////////////////////////

--- a/src/game/DBScripts/ScriptMgr.cpp
+++ b/src/game/DBScripts/ScriptMgr.cpp
@@ -891,7 +891,7 @@ void ScriptMgr::LoadRelayScripts()
 
 void ScriptMgr::LoadDbScriptStrings()
 {
-    sObjectMgr.LoadMangosStrings(WorldDatabase, "db_script_string", MIN_DB_SCRIPT_STRING_ID, MAX_DB_SCRIPT_STRING_ID, true);
+    sObjectMgr.LoadMangosStrings(WorldDatabase, "dbscript_string", MIN_DB_SCRIPT_STRING_ID, MAX_DB_SCRIPT_STRING_ID, true);
 
     std::set<int32> ids;
 
@@ -915,7 +915,7 @@ void ScriptMgr::LoadDbScriptStrings()
     sWaypointMgr.CheckTextsExistance(ids);
 
     for (std::set<int32>::const_iterator itr = ids.begin(); itr != ids.end(); ++itr)
-        sLog.outErrorDb("Table `db_script_string` has unused string id %u", *itr);
+        sLog.outErrorDb("Table `dbscript_string` has unused string id %u", *itr);
 }
 
 void ScriptMgr::LoadDbScriptRandomTemplates()
@@ -973,7 +973,7 @@ void ScriptMgr::CheckScriptTexts(ScriptMapMapName const& scripts, std::set<int32
                 for (int i = 0; i < MAX_TEXT_ID; ++i)
                 {
                     if (itrM->second.textId[i] && !sObjectMgr.GetMangosStringLocale(itrM->second.textId[i]))
-                        sLog.outErrorDb("Table `db_script_string` is missing string id %u, used in database script table %s id %u.", itrM->second.textId[i], scripts.first, itrMM->first);
+                        sLog.outErrorDb("Table `dbscript_string` is missing string id %u, used in database script table %s id %u.", itrM->second.textId[i], scripts.first, itrMM->first);
 
                     if (ids.find(itrM->second.textId[i]) != ids.end())
                         ids.erase(itrM->second.textId[i]);
@@ -985,7 +985,7 @@ void ScriptMgr::CheckScriptTexts(ScriptMapMapName const& scripts, std::set<int32
                     for (auto& data : vector)
                     {
                         if(!sObjectMgr.GetMangosStringLocale(data.first))
-                            sLog.outErrorDb("Table `db_script_string` is missing string id %u, used in database script template table dbscript_string_template id %u.", data.first, itrM->second.talk.stringTemplateId);
+                            sLog.outErrorDb("Table `dbscript_string` is missing string id %u, used in database script template table dbscript_string_template id %u.", data.first, itrM->second.talk.stringTemplateId);
                     }
                 }
             }

--- a/src/game/DBScripts/ScriptMgr.cpp
+++ b/src/game/DBScripts/ScriptMgr.cpp
@@ -42,6 +42,7 @@ ScriptMapMapName sEventScripts;
 ScriptMapMapName sGossipScripts;
 ScriptMapMapName sCreatureDeathScripts;
 ScriptMapMapName sCreatureMovementScripts;
+ScriptMapMapName sRelayScripts;
 
 INSTANTIATE_SINGLETON_1(ScriptMgr);
 
@@ -706,6 +707,15 @@ void ScriptMgr::LoadScripts(ScriptMapMapName& scripts, const char* tablename)
                 }
                 break;
             }
+            case SCRIPT_COMMAND_START_RELAY_SCRIPT:         // 45
+            {
+                if (sRelayScripts.second.find(tmp.relayScript.relayId) == sRelayScripts.second.end())
+                {
+                    sLog.outErrorDb("Table `%s` uses nonexistent relay ID %u in SCRIPT_COMMAND_START_RELAY_SCRIPT for script id %u.", tablename, tmp.relayScript.relayId, tmp.id);
+                    continue;
+                }
+                break;
+            }
             default:
             {
                 sLog.outErrorDb("Table `%s` unknown command %u, skipping.", tablename, tmp.command);
@@ -851,6 +861,18 @@ void ScriptMgr::LoadCreatureDeathScripts()
     }
 }
 
+void ScriptMgr::LoadRelayScripts()
+{
+    LoadScripts(sRelayScripts, "dbscripts_on_relay");
+
+    // check ids
+    for (ScriptMapMap::const_iterator itr = sRelayScripts.second.begin(); itr != sRelayScripts.second.end(); ++itr)
+    {
+        if (!sObjectMgr.GetCreatureTemplate(itr->first))
+            sLog.outErrorDb("Table `dbscripts_on_creature_death` has not existing creature (Entry: %u) as script id", itr->first);
+    }
+}
+
 void ScriptMgr::LoadDbScriptStrings()
 {
     sObjectMgr.LoadMangosStrings(WorldDatabase, "db_script_string", MIN_DB_SCRIPT_STRING_ID, MAX_DB_SCRIPT_STRING_ID, true);
@@ -872,6 +894,7 @@ void ScriptMgr::LoadDbScriptStrings()
     CheckScriptTexts(sGossipScripts, ids);
     CheckScriptTexts(sCreatureDeathScripts, ids);
     CheckScriptTexts(sCreatureMovementScripts, ids);
+    CheckScriptTexts(sRelayScripts, ids);
 
     sWaypointMgr.CheckTextsExistance(ids);
 
@@ -2071,6 +2094,13 @@ bool ScriptAction::HandleScriptStep()
             else
                 sLog.outErrorDb(" DB-SCRIPTS: Process table `%s` id %u, command %u failed. Source already has specified creature entry.", m_table, m_script->id, m_script->command);
             break;
+        }
+        case SCRIPT_COMMAND_START_RELAY_SCRIPT:             // 45
+        {
+            if (LogIfNotUnit(pSource))
+                return false;
+
+            m_map->ScriptsStart(sRelayScripts, m_script->relayScript.relayId, pSource, pTarget);
         }
         default:
             sLog.outErrorDb(" DB-SCRIPTS: Process table `%s` id %u, command %u unknown command used.", m_table, m_script->id, m_script->command);

--- a/src/game/DBScripts/ScriptMgr.cpp
+++ b/src/game/DBScripts/ScriptMgr.cpp
@@ -1219,10 +1219,10 @@ bool ScriptAction::HandleScriptStep()
 
             if (m_script->talk.stringTemplateId)
             {
-                std::vector<int32> stringTemplate;
-                sScriptMgr.GetScriptStringTemplate(m_script->talk.stringTemplateId, stringTemplate);
-                if (!stringTemplate.empty())
-                    textId = stringTemplate[urand(0, stringTemplate.size() - 1)];
+                bool includingNone = m_script->data_flags & SCRIPT_FLAG_COMMAND_ADDITIONAL;
+                textId = sScriptMgr.GetRandomScriptStringFromTemplate(m_script->talk.stringTemplateId, includingNone);
+                if (textId == 0 && includingNone)
+                    break;
             }
             else
             {

--- a/src/game/DBScripts/ScriptMgr.h
+++ b/src/game/DBScripts/ScriptMgr.h
@@ -35,7 +35,7 @@ struct SpellEntry;
 enum ScriptCommand                                          // resSource, resTarget are the resulting Source/ Target after buddy search is done
 {
     SCRIPT_COMMAND_TALK                     = 0,            // resSource = WorldObject, resTarget = Unit/none
-                                                            // dataint = text entry from db_script_string -table. dataint2-4 optional for random selected texts.
+                                                            // dataint = text entry from dbscript_string -table. dataint2-4 optional for random selected texts.
     SCRIPT_COMMAND_EMOTE                    = 1,            // resSource = Unit, resTarget = Unit/none
                                                             // datalong1 = emote_id, dataint1-4 optional for random selected emotes
     SCRIPT_COMMAND_FIELD_SET                = 2,            // source = any, datalong = field_id, datalong2 = value

--- a/src/game/DBScripts/ScriptMgr.h
+++ b/src/game/DBScripts/ScriptMgr.h
@@ -121,6 +121,7 @@ enum ScriptCommand                                          // resSource, resTar
     SCRIPT_COMMAND_UPDATE_TEMPLATE          = 44,           // resSource = Creature
                                                             // datalong = new Creature entry
                                                             // datalong2 = Alliance(0) Horde(1), other values throw error
+    SCRIPT_COMMAND_START_RELAY_SCRIPT       = 45,           // datalong = dbscript_on_relay id
 };
 
 #define MAX_TEXT_ID 4                                       // used for SCRIPT_COMMAND_TALK, SCRIPT_COMMAND_EMOTE, SCRIPT_COMMAND_CAST_SPELL, SCRIPT_COMMAND_TERMINATE_SCRIPT
@@ -391,6 +392,11 @@ struct ScriptInfo
             uint32 newFactionTeam;                          // datalong2
         } updateTemplate;
 
+        struct                                              // SCRIPT_COMMAND_START_RELAY_SCRIPT
+        {
+            uint32 relayId;                                 // datalong
+        } relayScript;
+
         struct
         {
             uint32 data[3];
@@ -518,6 +524,7 @@ extern ScriptMapMapName sEventScripts;
 extern ScriptMapMapName sGossipScripts;
 extern ScriptMapMapName sCreatureDeathScripts;
 extern ScriptMapMapName sCreatureMovementScripts;
+extern ScriptMapMapName sRelayScripts;
 
 class ScriptMgr
 {
@@ -534,6 +541,7 @@ class ScriptMgr
         void LoadGossipScripts();
         void LoadCreatureDeathScripts();
         void LoadCreatureMovementScripts();
+        void LoadRelayScripts();
 
         void LoadDbScriptStrings();
         void LoadDbScriptStringTemplates(std::set<int32>& ids);

--- a/src/game/DBScripts/ScriptMgr.h
+++ b/src/game/DBScripts/ScriptMgr.h
@@ -121,7 +121,7 @@ enum ScriptCommand                                          // resSource, resTar
     SCRIPT_COMMAND_UPDATE_TEMPLATE          = 44,           // resSource = Creature
                                                             // datalong = new Creature entry
                                                             // datalong2 = Alliance(0) Horde(1), other values throw error
-    SCRIPT_COMMAND_START_RELAY_SCRIPT       = 45,           // datalong = dbscript_on_relay id
+    SCRIPT_COMMAND_START_RELAY_SCRIPT       = 45,           // datalong = relayId, datalong2 = random template Id
 };
 
 #define MAX_TEXT_ID 4                                       // used for SCRIPT_COMMAND_TALK, SCRIPT_COMMAND_EMOTE, SCRIPT_COMMAND_CAST_SPELL, SCRIPT_COMMAND_TERMINATE_SCRIPT
@@ -395,6 +395,7 @@ struct ScriptInfo
         struct                                              // SCRIPT_COMMAND_START_RELAY_SCRIPT
         {
             uint32 relayId;                                 // datalong
+            uint32 templateId;                              // datalong2
         } relayScript;
 
         struct
@@ -528,6 +529,13 @@ extern ScriptMapMapName sRelayScripts;
 
 class ScriptMgr
 {
+    enum RandomTemplates
+    {
+        STRING_TEMPLATE = 0,
+        RELAY_TEMPLATE = 1,
+        MAX_TYPE // must always be last
+    };
+
     public:
         ScriptMgr();
         ~ScriptMgr() {};
@@ -544,11 +552,18 @@ class ScriptMgr
         void LoadRelayScripts();
 
         void LoadDbScriptStrings();
-        void LoadDbScriptStringTemplates(std::set<int32>& ids);
+        void LoadDbScriptRandomTemplates();
+        void CheckRandomStringTemplates(std::set<int32>& ids);
+        void CheckRandomRelayTemplates();
 
-        bool CheckScriptStringTemplateId(uint32 id) const { return m_stringTemplates.find(id) != m_stringTemplates.end(); }
-        void GetScriptStringTemplate(uint32 id, std::vector<int32>& stringTemplate) { stringTemplate = m_stringTemplates[id]; }
-        uint32 GetRandomScriptStringFromTemplate(uint32 id, bool includingNone = false);
+        bool CheckScriptStringTemplateId(uint32 id) const { return m_scriptTemplates[STRING_TEMPLATE].find(id) != m_scriptTemplates[STRING_TEMPLATE].end(); }
+        bool CheckScriptRelayTemplateId(uint32 id) const { return m_scriptTemplates[RELAY_TEMPLATE].find(id) != m_scriptTemplates[RELAY_TEMPLATE].end(); }
+        typedef std::vector<std::pair<int32, uint32>> ScriptTemplateVector;
+        void GetScriptStringTemplate(uint32 id, ScriptTemplateVector& stringTemplate) { stringTemplate = m_scriptTemplates[STRING_TEMPLATE][id]; }
+        void GetScriptRelayTemplate(uint32 id, ScriptTemplateVector& stringTemplate) { stringTemplate = m_scriptTemplates[RELAY_TEMPLATE][id]; }
+        int32 GetRandomScriptTemplateId(uint32 id, uint8 templateType);
+        int32 GetRandomScriptStringFromTemplate(uint32 id);
+        int32 GetRandomRelayDbscriptFromTemplate(uint32 id);
 
         uint32 IncreaseScheduledScriptsCount() { return (uint32)++m_scheduledScripts; }
         uint32 DecreaseScheduledScriptCount() { return (uint32)--m_scheduledScripts; }
@@ -564,12 +579,12 @@ class ScriptMgr
         typedef std::vector<std::string> ScriptNameMap;
         typedef std::unordered_map<uint32, uint32> AreaTriggerScriptMap;
         typedef std::unordered_map<uint32, uint32> EventIdScriptMap;
-        typedef std::unordered_map<uint32, std::vector<int32>> ScriptStringTemplateMap;
+        typedef std::unordered_map<uint32, ScriptTemplateVector> ScriptTemplateMap;
 
         AreaTriggerScriptMap    m_AreaTriggerScripts;
         EventIdScriptMap        m_EventIdScripts;
 
-        ScriptStringTemplateMap m_stringTemplates;
+        ScriptTemplateMap       m_scriptTemplates[MAX_TYPE];
         ScriptNameMap           m_scriptNames;
 
         // atomic op counter for active scripts amount

--- a/src/game/DBScripts/ScriptMgr.h
+++ b/src/game/DBScripts/ScriptMgr.h
@@ -548,6 +548,7 @@ class ScriptMgr
 
         bool CheckScriptStringTemplateId(uint32 id) const { return m_stringTemplates.find(id) != m_stringTemplates.end(); }
         void GetScriptStringTemplate(uint32 id, std::vector<int32>& stringTemplate) { stringTemplate = m_stringTemplates[id]; }
+        uint32 GetRandomScriptStringFromTemplate(uint32 id, bool includingNone = false);
 
         uint32 IncreaseScheduledScriptsCount() { return (uint32)++m_scheduledScripts; }
         uint32 DecreaseScheduledScriptCount() { return (uint32)--m_scheduledScripts; }

--- a/src/game/Globals/ObjectMgr.h
+++ b/src/game/Globals/ObjectMgr.h
@@ -99,7 +99,7 @@ typedef std::unordered_map<uint32/*(mapid,spawnMode) pair*/, CellObjectGuidsMap>
 // mangos string ranges
 #define MIN_MANGOS_STRING_ID           1                    // 'mangos_string'
 #define MAX_MANGOS_STRING_ID           2000000000
-#define MIN_DB_SCRIPT_STRING_ID        MAX_MANGOS_STRING_ID // 'db_script_string'
+#define MIN_DB_SCRIPT_STRING_ID        MAX_MANGOS_STRING_ID // 'dbscript_string'
 #define MAX_DB_SCRIPT_STRING_ID        2001000000
 #define MIN_CREATURE_AI_TEXT_STRING_ID (-1)                 // 'creature_ai_texts'
 #define MAX_CREATURE_AI_TEXT_STRING_ID (-1000000)

--- a/src/game/MotionGenerators/ConfusedMovementGenerator.cpp
+++ b/src/game/MotionGenerators/ConfusedMovementGenerator.cpp
@@ -106,6 +106,7 @@ template<>
 void ConfusedMovementGenerator<Player>::Finalize(Player& unit) const
 {
     unit.clearUnitState(UNIT_STAT_CONFUSED | UNIT_STAT_CONFUSED_MOVE);
+    unit.SetConfused(false);
     unit.StopMoving(true);
 }
 
@@ -113,6 +114,7 @@ template<>
 void ConfusedMovementGenerator<Creature>::Finalize(Creature& unit) const
 {
     unit.clearUnitState(UNIT_STAT_CONFUSED | UNIT_STAT_CONFUSED_MOVE);
+    unit.SetConfused(false);
 }
 
 template void ConfusedMovementGenerator<Player>::Initialize(Player& player);

--- a/src/game/MotionGenerators/FleeingMovementGenerator.cpp
+++ b/src/game/MotionGenerators/FleeingMovementGenerator.cpp
@@ -145,6 +145,7 @@ template<>
 void FleeingMovementGenerator<Creature>::Finalize(Creature& owner) const
 {
     owner.clearUnitState(UNIT_STAT_FLEEING | UNIT_STAT_FLEEING_MOVE);
+    owner.SetFeared(false);
 }
 
 template<class T>
@@ -196,7 +197,7 @@ template bool FleeingMovementGenerator<Creature>::Update(Creature&, const uint32
 
 void TimedFleeingMovementGenerator::Finalize(Unit& owner)
 {
-    owner.clearUnitState(UNIT_STAT_FLEEING | UNIT_STAT_FLEEING_MOVE);
+    FleeingMovementGenerator<Creature>::Finalize((Creature&)owner);
     if (Unit* victim = owner.getVictim())
     {
         if (owner.isAlive())

--- a/src/game/Server/SQLStorages.cpp
+++ b/src/game/Server/SQLStorages.cpp
@@ -34,8 +34,7 @@ const char InstanceTemplatesrcfmt[] = "iiiiiisl";
 const char InstanceTemplatedstfmt[] = "iiiiiiil";
 const char WorldTemplatesrcfmt[] = "is";
 const char WorldTemplatedstfmt[] = "ii";
-const char ConditionsSrcFmt[] = "iiii";
-const char ConditionsDstFmt[] = "iiii";
+const char ConditionsFmt[] = "iiiix";
 const char CreatureTemplateSpellsFmt[] = "iiiii";
 const char SpellScriptTargetFmt[] = "iiii";
 const char SpellEntryfmt[] = "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiifiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiffffffiiiiiiiiiiiiiiiiiiiiifffiiiiiiiiiiiiiiifffiiiissssssssssssssssssssssssssssssssiiiiiLiiifffiiiii";
@@ -51,7 +50,7 @@ SQLStorage sItemStorage(ItemPrototypesrcfmt, ItemPrototypedstfmt, "entry", "item
 SQLStorage sPageTextStore(PageTextfmt, "entry", "page_text");
 SQLStorage sInstanceTemplate(InstanceTemplatesrcfmt, InstanceTemplatedstfmt, "map", "instance_template");
 SQLStorage sWorldTemplate(WorldTemplatesrcfmt, WorldTemplatedstfmt, "map", "world_template");
-SQLStorage sConditionStorage(ConditionsSrcFmt, ConditionsDstFmt, "condition_entry", "conditions");
+SQLStorage sConditionStorage(ConditionsFmt, "condition_entry", "conditions");
 SQLStorage sSpellTemplate(SpellEntryfmt, "id", "spell_template");
 SQLStorage sDungeonEncounterStore(DungeonEncounterFmt, "id", "instance_dungeon_encounters");
 

--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -1146,6 +1146,9 @@ void World::SetInitialWorldSettings()
     sLog.outString("Loading Waypoint scripts...");          // before loading from creature_movement
     sScriptMgr.LoadCreatureMovementScripts();
 
+    sLog.outString("Loading Relay scripts...");
+    sScriptMgr.LoadRelayScripts();
+
     sLog.outString("Loading Waypoints...");
     sWaypointMgr.Load();
 

--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -1214,6 +1214,9 @@ void World::SetInitialWorldSettings()
     sLog.outString(">>> Scripts loaded");
     sLog.outString();
 
+    sLog.outString("Loading Scripts random templates...");      // must be before String calls
+    sScriptMgr.LoadDbScriptRandomTemplates();
+
     sLog.outString("Loading Scripts text locales...");      // must be after Load*Scripts calls
     sScriptMgr.LoadDbScriptStrings();
 


### PR DESCRIPTION
This PR introduces dbscripts_on_relay which enable launching scripts from EAI, C++ or other dbscripts for example.

This also enables random scripting with waypoints. Minor refactor to use one joined structure for string and relay randomization.

Last but not least, rename of db_script_string into dbscript_string to keep a unified naming logic.

All of the newly added stuff is possible from dbscripts, EAI and SD2 alike.

@grz3s @xfurry @cala

It has been tested by @mantislord and @saltgurka already.