### PR TITLE
Smart PvP flag timers

### DIFF
--- a/src/game/Entities/CharacterHandler.cpp
+++ b/src/game/Entities/CharacterHandler.cpp
@@ -717,7 +717,7 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
         pCurrChar->SetPvPFreeForAll(true);
 
     if (pCurrChar->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_CONTESTED_PVP))
-        pCurrChar->SetContestedPvP();
+        pCurrChar->UpdatePvPContested(true);
 
     // Apply at_login requests
     if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_SPELLS))

--- a/src/game/Entities/GameObject.cpp
+++ b/src/game/Entities/GameObject.cpp
@@ -2053,6 +2053,9 @@ void GameObject::TickCapturePoint()
             // new player entered capture point zone
             m_UniqueUsers.insert(guid);
 
+            // update pvp info
+            (*itr)->pvpInfo.inPvPCapturePoint = true;
+
             // send capture point enter packets
             (*itr)->SendUpdateWorldState(info->capturePoint.worldState3, neutralPercent);
             (*itr)->SendUpdateWorldState(info->capturePoint.worldState2, oldValue);
@@ -2063,9 +2066,14 @@ void GameObject::TickCapturePoint()
 
     for (GuidSet::iterator itr = tempUsers.begin(); itr != tempUsers.end(); ++itr)
     {
-        // send capture point leave packet
         if (Player* owner = GetMap()->GetPlayer(*itr))
+        {
+            // update pvp info
+            owner->pvpInfo.inPvPCapturePoint = false;
+
+            // send capture point leave packet
             owner->SendUpdateWorldState(info->capturePoint.worldState1, WORLD_STATE_REMOVE);
+        }
 
         // player left capture point zone
         m_UniqueUsers.erase(*itr);

--- a/src/game/Entities/MiscHandler.cpp
+++ b/src/game/Entities/MiscHandler.cpp
@@ -351,23 +351,15 @@ void WorldSession::HandleTogglePvP(WorldPacket& recv_data)
     {
         bool newPvPStatus;
         recv_data >> newPvPStatus;
-        GetPlayer()->ApplyModFlag(PLAYER_FLAGS, PLAYER_FLAGS_IN_PVP, newPvPStatus);
+        GetPlayer()->ApplyModFlag(PLAYER_FLAGS, PLAYER_FLAGS_PVP_DESIRED, newPvPStatus);
     }
     else
     {
-        GetPlayer()->ToggleFlag(PLAYER_FLAGS, PLAYER_FLAGS_IN_PVP);
+        GetPlayer()->ToggleFlag(PLAYER_FLAGS, PLAYER_FLAGS_PVP_DESIRED);
     }
 
-    if (GetPlayer()->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_IN_PVP))
-    {
-        if (!GetPlayer()->IsPvP() || GetPlayer()->pvpInfo.endTimer != 0)
-            GetPlayer()->UpdatePvP(true, true);
-    }
-    else
-    {
-        if (!GetPlayer()->pvpInfo.inHostileArea && GetPlayer()->IsPvP())
-            GetPlayer()->pvpInfo.endTimer = time(nullptr);     // start toggle-off
-    }
+    if (GetPlayer()->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_PVP_DESIRED))
+        GetPlayer()->UpdatePvP(true);
 }
 
 void WorldSession::HandleZoneUpdateOpcode(WorldPacket& recv_data)

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -567,8 +567,6 @@ Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_
     m_summon_y = 0.0f;
     m_summon_z = 0.0f;
 
-    m_contestedPvPTimer = 0;
-
     m_declinedname = nullptr;
 
     m_lastFallTime = 0;
@@ -1203,9 +1201,9 @@ void Player::Update(uint32 update_diff, uint32 p_time)
 
     time_t now = time(nullptr);
 
-    UpdatePvPFlag(now);
+    UpdatePvPFlagTimer(update_diff);
 
-    UpdateContestedPvP(update_diff);
+    UpdatePvPContestedFlagTimer(update_diff);
 
     UpdateDuelFlag(now);
 
@@ -1809,7 +1807,7 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
 
             RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TELEPORTED);
 
-            ResetContestedPvP();
+            UpdatePvPContested(false, true);
 
             // remove player from battleground on far teleport (when changing maps)
             if (BattleGround const* bg = GetBattleGround())
@@ -2279,7 +2277,7 @@ void Player::SetGameMaster(bool on)
         CallForAllControlledUnits(SetGameMasterOnHelper(), CONTROLLED_PET | CONTROLLED_TOTEMS | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
 
         SetPvPFreeForAll(false);
-        ResetContestedPvP();
+        UpdatePvPContested(false, true);
 
         getHostileRefManager().setOnlineOfflineState(false);
         CombatStopWithPets();
@@ -2684,7 +2682,7 @@ void Player::InitStatsForLevel(bool reapplyMods)
     SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED);    // must be set
 
     // cleanup player flags (will be re-applied if need at aura load), to avoid have ghost flag without ghost aura, for example.
-    RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_AFK | PLAYER_FLAGS_DND | PLAYER_FLAGS_GM | PLAYER_FLAGS_GHOST | PLAYER_FLAGS_IN_PVP | PLAYER_FLAGS_FFA_PVP);
+    RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_AFK | PLAYER_FLAGS_DND | PLAYER_FLAGS_GM | PLAYER_FLAGS_GHOST | PLAYER_FLAGS_PVP_DESIRED | PLAYER_FLAGS_FFA_PVP);
 
     RemoveStandFlags(UNIT_STAND_FLAGS_ALL);                 // one form stealth modified bytes
 
@@ -6644,38 +6642,28 @@ void Player::UpdateZone(uint32 newZone, uint32 newArea)
     switch (zone->team)
     {
         case AREATEAM_ALLY:
-            pvpInfo.inHostileArea = GetTeam() != ALLIANCE && (sWorld.IsPvPRealm() || zone->flags & AREA_FLAG_CAPITAL);
+            pvpInfo.inPvPEnforcedArea = GetTeam() != ALLIANCE && (sWorld.IsPvPRealm() || zone->flags & AREA_FLAG_CAPITAL);
             break;
         case AREATEAM_HORDE:
-            pvpInfo.inHostileArea = GetTeam() != HORDE && (sWorld.IsPvPRealm() || zone->flags & AREA_FLAG_CAPITAL);
+            pvpInfo.inPvPEnforcedArea = GetTeam() != HORDE && (sWorld.IsPvPRealm() || zone->flags & AREA_FLAG_CAPITAL);
             break;
         case AREATEAM_NONE:
             // overwrite for battlegrounds, maybe batter some zone flags but current known not 100% fit to this
-            pvpInfo.inHostileArea = sWorld.IsPvPRealm() || InBattleGround();
+            pvpInfo.inPvPEnforcedArea = sWorld.IsPvPRealm() || InBattleGround();
             break;
         default:                                            // 6 in fact
-            pvpInfo.inHostileArea = false;
+            pvpInfo.inPvPEnforcedArea = false;
             break;
     }
 
-    if (pvpInfo.inHostileArea)                              // in hostile area
-    {
-        if (!IsPvP() || pvpInfo.endTimer != 0)
-            UpdatePvP(true, true);
-    }
-    else                                                    // in friendly area
-    {
-        if (IsPvP() && !HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_IN_PVP) && pvpInfo.endTimer == 0)
-            pvpInfo.endTimer = time(nullptr);               // start toggle-off
-    }
+    if (pvpInfo.inPvPEnforcedArea)                              // in hostile area
+        UpdatePvP(true);
 
     if (zone->flags & AREA_FLAG_SANCTUARY)                  // in sanctuary
     {
         SetPvPSanctuary(true);
 
-        // Sanctuary zones removes pvp flags
-        if (IsPvP() || pvpInfo.endTimer != 0)
-            UpdatePvP(false);
+        UpdatePvP(false, true);
 
         if (sWorld.IsFFAPvPRealm())
             SetPvPFreeForAll(false);
@@ -16960,26 +16948,24 @@ void Player::UpdateAfkReport(time_t currTime)
     }
 }
 
-void Player::UpdateContestedPvP(uint32 diff)
+void Player::UpdatePvPFlagTimer(uint32 diff)
 {
-    if (!m_contestedPvPTimer || isInCombat())
-        return;
-    if (m_contestedPvPTimer <= diff)
-    {
-        ResetContestedPvP();
-    }
-    else
-        m_contestedPvPTimer -= diff;
+    // Freeze flag timer while participating in PvP combat, in pvp enforced zone, in capture points, when carrying flag or on player preference
+    if (!pvpInfo.inPvPCombat && !pvpInfo.inPvPEnforcedArea && !pvpInfo.inPvPCapturePoint && !pvpInfo.isPvPFlagCarrier && !HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_PVP_DESIRED))
+        pvpInfo.timerPvPRemaining -= std::min(pvpInfo.timerPvPRemaining, diff);
+
+    // Timer tries to drop flag if all conditions are met and time has passed
+    UpdatePvP(false);
 }
 
-void Player::UpdatePvPFlag(time_t currTime)
+void Player::UpdatePvPContestedFlagTimer(uint32 diff)
 {
-    if (!IsPvP())
-        return;
-    if (pvpInfo.endTimer == 0 || currTime < (pvpInfo.endTimer + 300))
-        return;
+    // Freeze flag timer while participating in PvP combat
+    if (!pvpInfo.inPvPCombat)
+        pvpInfo.timerPvPContestedRemaining -= std::min(pvpInfo.timerPvPContestedRemaining, diff);
 
-    UpdatePvP(false);
+    // Timer tries to drop flag if all conditions are met and time has passed
+    UpdatePvPContested(false);
 }
 
 void Player::UpdateDuelFlag(time_t currTime)
@@ -18111,19 +18097,59 @@ void Player::UpdateHomebindTime(uint32 time)
     }
 }
 
-void Player::UpdatePvP(bool state, bool ovrride)
+void Player::UpdatePvP(bool state, bool overriding)
 {
-    if (!state || ovrride)
+    if (!state || overriding)
     {
-        SetPvP(state);
-        pvpInfo.endTimer = 0;
+        // Updating into unset state or overriding anything
+        if (!pvpInfo.timerPvPRemaining || overriding)
+        {
+            if (IsPvP() != state)
+            {
+                SetPvP(state);
+                pvpInfo.timerPvPRemaining = 0;
+            }
+        }
     }
     else
     {
-        if (pvpInfo.endTimer != 0)
-            pvpInfo.endTimer = time(nullptr);
-        else
+        // Updating into set state
+        if (!IsPvP())
             SetPvP(state);
+
+        // Refresh timer
+        pvpInfo.timerPvPRemaining = 300000;
+    }
+}
+
+void Player::UpdatePvPContested(bool state, bool overriding)
+{
+    if (!state || overriding)
+    {
+        // Updating into unset state or overriding anything
+        if (!pvpInfo.timerPvPContestedRemaining || overriding)
+        {
+            if (HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_CONTESTED_PVP) != state)
+            {
+                SetPvPContested(state);
+                pvpInfo.timerPvPContestedRemaining = 0;
+            }
+        }
+    }
+    else
+    {
+        // Updating into set state
+        if (!HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_CONTESTED_PVP))
+        {
+            SetPvPContested(state);
+
+            // Legacy way of calling MoveInLineOfSight for nearby contested guards
+            // TODO: Find a better way to do this, needs marking for a delayed reaction update
+            UpdateVisibilityAndView();
+        }
+
+        // Refresh timer
+        pvpInfo.timerPvPContestedRemaining = 30000;
     }
 }
 

--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -277,10 +277,14 @@ struct PlayerInfo
 
 struct PvPInfo
 {
-    PvPInfo() : inHostileArea(false), endTimer(0) {}
+    PvPInfo() : inPvPCombat(false), inPvPEnforcedArea(false), inPvPCapturePoint(false), isPvPFlagCarrier(false), timerPvPRemaining(0), timerPvPContestedRemaining(0) {}
 
-    bool inHostileArea;
-    time_t endTimer;
+    bool inPvPCombat;
+    bool inPvPEnforcedArea;
+    bool inPvPCapturePoint;
+    bool isPvPFlagCarrier;
+    uint32 timerPvPRemaining;
+    uint32 timerPvPContestedRemaining;
 };
 
 struct DuelInfo
@@ -396,7 +400,7 @@ enum PlayerFlags
     PLAYER_FLAGS_UNK7                   = 0x00000040,       // admin?
     PLAYER_FLAGS_FFA_PVP                = 0x00000080,
     PLAYER_FLAGS_CONTESTED_PVP          = 0x00000100,       // Player has been involved in a PvP combat and will be attacked by contested guards
-    PLAYER_FLAGS_IN_PVP                 = 0x00000200,
+    PLAYER_FLAGS_PVP_DESIRED            = 0x00000200,       // Stores player's permanent PvP flag preference
     PLAYER_FLAGS_HIDE_HELM              = 0x00000400,
     PLAYER_FLAGS_HIDE_CLOAK             = 0x00000800,
     PLAYER_FLAGS_PARTIAL_PLAY_TIME      = 0x00001000,       // played long time
@@ -1551,7 +1555,8 @@ class Player : public Unit
         void SendInitialActionButtons() const;
 
         PvPInfo pvpInfo;
-        void UpdatePvP(bool state, bool ovrride = false);
+        void UpdatePvP(bool state, bool overriding = false);
+        void UpdatePvPContested(bool state, bool overriding = false);
 
         void UpdateZone(uint32 newZone, uint32 newArea);
         void UpdateArea(uint32 newArea);
@@ -1562,15 +1567,8 @@ class Player : public Unit
         void UpdateZoneDependentPets();
 
         void UpdateAfkReport(time_t currTime);
-        void UpdatePvPFlag(time_t currTime);
-        void UpdateContestedPvP(uint32 currTime);
-        void SetContestedPvPTimer(uint32 newTime) {m_contestedPvPTimer = newTime;}
-        void ResetContestedPvP()
-        {
-            clearUnitState(UNIT_STAT_ATTACK_PLAYER);
-            RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_CONTESTED_PVP);
-            m_contestedPvPTimer = 0;
-        }
+        void UpdatePvPFlagTimer(uint32 diff);
+        void UpdatePvPContestedFlagTimer(uint32 diff);
 
         /** todo: -maybe move UpdateDuelFlag+DuelComplete to independent DuelHandler.. **/
         DuelInfo* duel;
@@ -2206,9 +2204,6 @@ class Player : public Unit
         }
 
     protected:
-
-        uint32 m_contestedPvPTimer;
-
         /*********************************************************/
         /***               BATTLEGROUND SYSTEM                 ***/
         /*********************************************************/

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -1797,11 +1797,8 @@ void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
         if (GetTypeId() == TYPEID_PLAYER && pVictim->isAlive())
             ((Player*)this)->CastItemCombatSpell(pVictim, damageInfo->attackType);
 
-        SetInCombatWith(pVictim);
-        pVictim->SetInCombatWith(this);
-
-        if (Player* attackedPlayer = pVictim->GetBeneficiaryPlayer())
-            SetContestedPvP(attackedPlayer);
+        SetInCombatWithVictim(pVictim);
+        pVictim->SetInCombatWithAggressor(this);
 
         // If not immune
         if (damageInfo->TargetState != VICTIMSTATE_IS_IMMUNE)
@@ -5553,7 +5550,7 @@ bool Unit::IsHostileTo(Unit const* unit) const
     if (!tester_faction || !target_faction)
         return false;
 
-    if (target->isAttackingPlayer() && tester->IsContestedGuard())
+    if (target->IsPvPContested() && tester->IsContestedGuard())
         return true;
 
     // PvC forced reaction and reputation case
@@ -5667,7 +5664,7 @@ bool Unit::IsFriendlyTo(Unit const* unit) const
     if (!tester_faction || !target_faction)
         return false;
 
-    if (target->isAttackingPlayer() && tester->IsContestedGuard())
+    if (target->IsPvPContested() && tester->IsContestedGuard())
         return false;
 
     // PvC forced reaction and reputation case
@@ -5892,20 +5889,6 @@ void Unit::CombatStopWithPets(bool includingCast)
 {
     CombatStop(includingCast);
     CallForAllControlledUnits(CombatStopWithPetsHelper(includingCast), CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
-}
-
-struct IsAttackingPlayerHelper
-{
-    explicit IsAttackingPlayerHelper() {}
-    bool operator()(Unit const* unit) const { return unit->isAttackingPlayer(); }
-};
-
-bool Unit::isAttackingPlayer() const
-{
-    if (hasUnitState(UNIT_STAT_ATTACK_PLAYER))
-        return true;
-
-    return CheckAllControlledUnits(IsAttackingPlayerHelper(), CONTROLLED_PET | CONTROLLED_TOTEMS | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
 }
 
 void Unit::RemoveAllAttackers()
@@ -7325,6 +7308,105 @@ void Unit::SetInCombatWith(Unit* enemy)
     SetInCombatState(false, enemy);
 }
 
+void Unit::SetInCombatWithAggressor(Unit* aggressor)
+{
+    // This is a wrapper for SetInCombatWith initially created to improve PvP timers responsiveness. Can be extended in the future for broader use.
+
+    if (!aggressor)
+        return;
+
+    // PvP combat participation pulse: refresh pvp timers on pvp combat (we are the victim)
+    if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED))
+    {
+        if (aggressor->IsPvP() && aggressor->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED))
+        {
+            // Use beneficiary for detecting own player (pet's pets forced into combat is not counted as direct pvp action)
+            if (Player* thisPlayer = GetBeneficiaryPlayer())
+            {
+                // Use controlling for detecting aggressor's player (forced into combat by pet's pets is counted as direct pvp action)
+                if (Player const* aggressorPlayer = aggressor->GetControllingPlayer())
+                {
+                    if (thisPlayer != aggressorPlayer && !thisPlayer->IsInDuelWith(aggressorPlayer))
+                    {
+                        thisPlayer->pvpInfo.inPvPCombat = true;
+                        thisPlayer->UpdatePvP(true);
+                    }
+                }
+            }
+        }
+    }
+
+    SetInCombatWith(aggressor);
+}
+
+void Unit::SetInCombatWithAssisted(Unit* assisted)
+{
+    // This is a wrapper for SetInCombatWith initially created to improve PvP timers responsiveness. Can be extended in the future for broader use.
+
+    if (!assisted)
+        return;
+
+    // PvP combat participation pulse: refresh pvp timers on pvp combat (we are the assister)
+    if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED))
+    {
+        if (assisted->IsPvP() && assisted->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED))
+        {
+            // Use beneficiary for detecting own player (pet's pets entering combat is not counted as assist)
+            if (Player* thisPlayer = GetBeneficiaryPlayer())
+            {
+                // Use controlling for detecting asissted unit's player (entering combat with pet's pets is counted as assist)
+                if (Player const* assistedPlayer = assisted->GetControllingPlayer())
+                {
+                    if (thisPlayer != assistedPlayer)
+                    {
+                        if (assistedPlayer->pvpInfo.inPvPCombat)
+                            thisPlayer->pvpInfo.inPvPCombat = true;
+
+                        thisPlayer->UpdatePvP(true);
+
+                        if (assistedPlayer->IsPvPContested())
+                            thisPlayer->UpdatePvPContested(true);
+                    }
+                }
+            }
+        }
+    }
+
+    SetInCombatState(assisted->GetCombatTimer() > 0);
+}
+
+void Unit::SetInCombatWithVictim(Unit* victim)
+{
+    // This is a wrapper for SetInCombatWith initially created to improve PvP timers responsiveness. Can be extended in the future for broader use.
+
+    if (!victim)
+        return;
+
+    // PvP combat participation pulse: refresh pvp timers on pvp combat (we are the aggressor)
+    if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED))
+    {
+        if (victim->IsPvP() && victim->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED))
+        {
+            // Use beneficiary for detecting own player (pet's pets entering combat is not an act of aggression)
+            if (Player* thisPlayer = GetBeneficiaryPlayer())
+            {
+                // Use controlling for detecting victim's player (entering combat with pet's pets is an act of aggression)
+                if (Player const* victimPlayer = victim->GetControllingPlayer())
+                {
+                    if (thisPlayer != victimPlayer && !thisPlayer->IsInDuelWith(victimPlayer))
+                    {
+                        thisPlayer->pvpInfo.inPvPCombat = true;
+                        thisPlayer->UpdatePvP(true);
+                        thisPlayer->UpdatePvPContested(true);
+                    }
+                }
+            }
+        }
+    }
+
+    SetInCombatWith(victim);
+}
+
 void Unit::SetInCombatState(bool PvP, Unit* enemy)
 {
     // only alive units can be in combat
@@ -7378,9 +7460,8 @@ void Unit::ClearInCombat()
     if (isCharmed() || (GetTypeId() != TYPEID_PLAYER && ((Creature*)this)->IsPet()))
         RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PET_IN_COMBAT);
 
-    // Player's state will be cleared in Player::UpdateContestedPvP
-    if (GetTypeId() == TYPEID_UNIT)
-        clearUnitState(UNIT_STAT_ATTACK_PLAYER);
+    if (GetTypeId() == TYPEID_PLAYER)
+        static_cast<Player*>(this)->pvpInfo.inPvPCombat = false;
 }
 
 bool Unit::isTargetableForAttack(bool inverseAlive /*=false*/) const
@@ -10119,31 +10200,6 @@ Aura* Unit::GetDummyAura(uint32 spell_id) const
             return *itr;
 
     return nullptr;
-}
-
-void Unit::SetContestedPvP(Player* attackedPlayer)
-{
-    Player* player = GetBeneficiaryPlayer();
-
-    if (!player || (attackedPlayer && (attackedPlayer == player || player->IsInDuelWith(attackedPlayer))))
-        return;
-
-    player->SetContestedPvPTimer(30000);
-
-    if (!player->hasUnitState(UNIT_STAT_ATTACK_PLAYER))
-    {
-        player->addUnitState(UNIT_STAT_ATTACK_PLAYER);
-        player->SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_CONTESTED_PVP);
-        // call MoveInLineOfSight for nearby contested guards
-        UpdateVisibilityAndView();
-    }
-
-    if (!hasUnitState(UNIT_STAT_ATTACK_PLAYER))
-    {
-        addUnitState(UNIT_STAT_ATTACK_PLAYER);
-        // call MoveInLineOfSight for nearby contested guards
-        UpdateVisibilityAndView();
-    }
 }
 
 void Unit::AddPetAura(PetAura const* petSpell)

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -393,7 +393,7 @@ enum UnitState
 {
     // persistent state (applied by aura/etc until expire)
     UNIT_STAT_MELEE_ATTACKING = 0x00000001,                 // unit is melee attacking someone Unit::Attack
-    UNIT_STAT_ATTACK_PLAYER   = 0x00000002,                 // unit attack player or player's controlled unit and have contested pvpv timer setup, until timer expire, combat end and etc
+    //UNIT_STAT_ATTACK_PLAYER = 0x00000002,                 // (Deprecated) unit attack player or player's controlled unit and have contested pvpv timer setup, until timer expire, combat end and etc
     UNIT_STAT_DIED            = 0x00000004,                 // Unit::SetFeignDeath
     UNIT_STAT_STUNNED         = 0x00000008,                 // Aura::HandleAuraModStun
     UNIT_STAT_ROOT            = 0x00000010,                 // Aura::HandleAuraModRoot
@@ -1354,8 +1354,6 @@ class Unit : public WorldObject
         /// Returns the Unit::m_attackers, that stores the units that are attacking you
         AttackerSet const& getAttackers() const { return m_attackers; }
 
-        bool isAttackingPlayer() const;                     //< Returns if this unit is attacking a player (or this unit's minions/pets are attacking a player)
-
         Unit* getVictim() const { return m_attacking; }     //< Returns the victim that this unit is currently attacking
         void CombatStop(bool includingCast = false, bool includingCombo = true);        //< Stop this unit from combat, if includingCast==true, also interrupt casting
         void CombatStopWithPets(bool includingCast = false);
@@ -1622,6 +1620,9 @@ class Unit : public WorldObject
         bool isInCombat()  const { return HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IN_COMBAT); }
         void SetInCombatState(bool PvP, Unit* enemy = nullptr);
         void SetInCombatWith(Unit* enemy);
+        void SetInCombatWithAggressor(Unit* aggressor);
+        void SetInCombatWithAssisted(Unit* assisted);
+        void SetInCombatWithVictim(Unit* victim);
         void ClearInCombat();
         uint32 GetCombatTimer() const { return m_CombatTimer; }
 

--- a/src/game/MotionGenerators/MovementHandler.cpp
+++ b/src/game/MotionGenerators/MovementHandler.cpp
@@ -182,7 +182,7 @@ void WorldSession::HandleMoveWorldportAckOpcode()
         _player->RemoveSpellsCausingAura(SPELL_AURA_MOUNTED);
 
     // honorless target
-    if (GetPlayer()->pvpInfo.inHostileArea)
+    if (GetPlayer()->pvpInfo.inPvPEnforcedArea)
         GetPlayer()->CastSpell(GetPlayer(), 2479, TRIGGERED_OLD_TRIGGERED);
 
     // resummon pet
@@ -234,7 +234,7 @@ void WorldSession::HandleMoveTeleportAckOpcode(WorldPacket& recv_data)
     if (old_zone != newzone)
     {
         // honorless target
-        if (plMover->pvpInfo.inHostileArea)
+        if (plMover->pvpInfo.inPvPEnforcedArea)
             plMover->CastSpell(plMover, 2479, TRIGGERED_OLD_TRIGGERED);
     }
 

--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -444,7 +444,7 @@ void FlightPathMovementGenerator::Finalize(Player& player)
     {
         player.m_taxi.NextTaxiDestination(); // successfully reached end and pop final point
         player.getHostileRefManager().setOnlineOfflineState(true);
-        if (player.pvpInfo.inHostileArea)
+        if (player.pvpInfo.inPvPEnforcedArea)
             player.CastSpell(&player, 2479, TRIGGERED_OLD_TRIGGERED);
 
         TaxiNodesEntry const* node = sTaxiNodesStore.LookupEntry(player.m_taxi.GetLastNode());

--- a/src/game/OutdoorPvP/OutdoorPvPNA.cpp
+++ b/src/game/OutdoorPvP/OutdoorPvPNA.cpp
@@ -443,8 +443,7 @@ bool OutdoorPvPNA::HandleGameObjectUse(Player* player, GameObject* go)
             else if (go->GetEntry() == nagrandRoostsAlliance[i])
             {
                 // mark player as pvp
-                player->UpdatePvP(true, true);
-                player->SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_IN_PVP);
+                player->UpdatePvP(true);
 
                 // prevent despawning after go use
                 go->SetRespawnTime(0);
@@ -489,8 +488,7 @@ bool OutdoorPvPNA::HandleGameObjectUse(Player* player, GameObject* go)
             else if (go->GetEntry() == nagrandRoostsHorde[i])
             {
                 // mark player as pvp
-                player->UpdatePvP(true, true);
-                player->SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_IN_PVP);
+                player->UpdatePvP(true);
 
                 // prevent despawning after go use
                 go->SetRespawnTime(0);

--- a/src/game/OutdoorPvP/OutdoorPvPSI.cpp
+++ b/src/game/OutdoorPvP/OutdoorPvPSI.cpp
@@ -193,8 +193,7 @@ bool OutdoorPvPSI::HandleGameObjectUse(Player* player, GameObject* go)
     {
         // Also mark player with pvp on
         player->CastSpell(player, SPELL_SILITHYST, TRIGGERED_OLD_TRIGGERED);
-        player->UpdatePvP(true, true);
-        player->SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_IN_PVP);
+        player->UpdatePvP(true);
         // Despawn the gameobject (workaround)
         go->SetLootState(GO_JUST_DEACTIVATED);
         return true;

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -1096,11 +1096,8 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
                     ((Creature*)unit)->AI()->AttackedBy(real_caster);
 
                 unit->AddThreat(real_caster);
-                unit->SetInCombatWith(real_caster);
-                real_caster->SetInCombatWith(unit);
-
-                if (Player* attackedPlayer = unit->GetBeneficiaryPlayer())
-                    real_caster->SetContestedPvP(attackedPlayer);
+                unit->SetInCombatWithAggressor(real_caster);
+                real_caster->SetInCombatWithVictim(unit);
             }
         }
     }
@@ -1346,22 +1343,16 @@ void Spell::DoSpellHitOnUnit(Unit* unit, uint32 effectMask, bool isReflected)
                     unit->AttackedBy(realCaster);
 
                 unit->AddThreat(realCaster);
-                unit->SetInCombatWith(realCaster);
-                realCaster->SetInCombatWith(unit);
-
-                if (Player* attackedPlayer = unit->GetBeneficiaryPlayer())
-                    realCaster->SetContestedPvP(attackedPlayer);
+                unit->SetInCombatWithAggressor(realCaster);
+                realCaster->SetInCombatWithVictim(unit);
             }
         }
         else
         {
             // assisting case, healing and resurrection
-            if (unit->hasUnitState(UNIT_STAT_ATTACK_PLAYER))
-                realCaster->SetContestedPvP();
-
             if (unit->isInCombat() && !m_spellInfo->HasAttribute(SPELL_ATTR_EX3_NO_INITIAL_AGGRO))
             {
-                realCaster->SetInCombatState(unit->GetCombatTimer() > 0);
+                realCaster->SetInCombatWithAssisted(unit);
                 unit->getHostileRefManager().threatAssist(realCaster, 0.0f, m_spellInfo);
             }
         }

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -4088,14 +4088,21 @@ void Aura::HandleAuraModEffectImmunity(bool apply, bool /*Real*/)
     Unit* target = GetTarget();
 
     // when removing flag aura, handle flag drop
-    if (!apply && target->GetTypeId() == TYPEID_PLAYER
-            && (GetSpellProto()->AuraInterruptFlags & AURA_INTERRUPT_FLAG_IMMUNE_OR_LOST_SELECTION))
+    if (target->GetTypeId() == TYPEID_PLAYER && (GetSpellProto()->AuraInterruptFlags & AURA_INTERRUPT_FLAG_IMMUNE_OR_LOST_SELECTION))
     {
-        Player* player = (Player*)target;
-        if (BattleGround* bg = player->GetBattleGround())
-            bg->EventPlayerDroppedFlag(player);
-        else if (OutdoorPvP* outdoorPvP = sOutdoorPvPMgr.GetScript(player->GetCachedZoneId()))
-            outdoorPvP->HandleDropFlag(player, GetSpellProto()->Id);
+        Player* player = static_cast<Player*>(target);
+
+        if (apply)
+            player->pvpInfo.isPvPFlagCarrier = true;
+        else
+        {
+            player->pvpInfo.isPvPFlagCarrier = false;
+
+            if (BattleGround* bg = player->GetBattleGround())
+                bg->EventPlayerDroppedFlag(player);
+            else if (OutdoorPvP* outdoorPvP = sOutdoorPvPMgr.GetScript(player->GetCachedZoneId()))
+                outdoorPvP->HandleDropFlag(player, GetSpellProto()->Id);
+        }
     }
 
     target->ApplySpellImmune(GetId(), IMMUNITY_EFFECT, m_modifier.m_miscvalue, apply);


### PR DESCRIPTION
Concentrating all PvP timers in one place.

Contested PvP flag propagation works in conjuction with PvP flag propagation.

New contested PvP flag API modeled after pre-existed PvP flag API.

Many outdated pieces of code related to contested are now cleaned up.

Most notable changes:
* PLAYER_FLAGS_IN_PVP renamed to more official term PLAYER_FLAGS_PVP_DESIRED to avoid confusion: based on lua GetPVPDesired()
* A better performance PvP flag timer (using diffs only).
* Improved contested PvP flag propagation logic (e.g. healing a victim who didn't fight back will not flag healer).
* Getting attacked in PvP now refereshes victim's PvP flag timer.
* Additionally update caster/attacker's PvP flag on spell/attack landing in compliance with demons videos (in addition to current update on melee swing timer and pre-cast).
* A number of changes to PvP flag timer to improve world PvP encounter experience on PvE ruleset realms in some scenarios:
  - PvP flag timer now freezes when player is in outdoor PvP capture points.
  - PvP flag timer now freezes when player is a PvP objective flag carrier.
  - Experimental: All PvP flag timers now freeze during actual PvP combat to prevent any premature flag drops.
* Initial implementation for a few wrapper extensions over SetInCombatWith to hold the new PvP flag timer logic in:
  - SetInCombatWithAggressor
  - SetInCombatWithAssisted
  - SetInCombatWithVictim
* WotLK-specific feature: Full PLAYER_FLAGS_PVP_TIMER flag management.