### PR TITLE
Add a possibility to set a pool of creature as a target for script.

### DIFF
--- a/src/game/DBScripts/ScriptMgr.cpp
+++ b/src/game/DBScripts/ScriptMgr.cpp
@@ -177,7 +177,7 @@ void ScriptMgr::LoadScripts(ScriptMapMapName& scripts, const char* tablename)
                 sLog.outErrorDb("Table `%s` has invalid data_flags %u in command %u for script id %u, skipping.", tablename, tmp.data_flags, tmp.command, tmp.id);
                 continue;
             }
-            if (tmp.data_flags & SCRIPT_FLAG_BUDDY_AS_TARGET && ! tmp.buddyEntry)
+            if ((tmp.data_flags & SCRIPT_FLAG_BUDDY_AS_TARGET) != 0 && (tmp.data_flags & SCRIPT_FLAG_BUDDY_BY_POOL) == 0 && !tmp.buddyEntry)
             {
                 sLog.outErrorDb("Table `%s` has buddy required in data_flags %u in command %u for script id %u, but no buddy defined, skipping.", tablename, tmp.data_flags, tmp.command, tmp.id);
                 continue;
@@ -209,6 +209,27 @@ void ScriptMgr::LoadScripts(ScriptMapMapName& scripts, const char* tablename)
                     if (data->id != tmp.buddyEntry)
                     {
                         sLog.outErrorDb("Table `%s` has go-buddy defined by guid (SCRIPT_FLAG_BUDDY_BY_GUID %u set) but spawned go with guid %u has entry %u, expected buddy_entry is %u, skipping.", tablename, SCRIPT_FLAG_BUDDY_BY_GUID,  tmp.searchRadiusOrGuid, data->id, tmp.buddyEntry);
+                        continue;
+                    }
+                }
+            }
+            else if (tmp.data_flags & SCRIPT_FLAG_BUDDY_BY_POOL)
+            {
+                if (tmp.IsCreatureBuddy())
+                {
+                    auto pool = sPoolMgr.GetPoolCreatures(tmp.searchRadiusOrGuid);
+                    if (pool.isEmpty())
+                    {
+                        sLog.outErrorDb("Table `%s` has go-buddy defined by pool (SCRIPT_FLAG_BUDDY_BY_POOL %u set) but pool %u is empty, skipping.", tablename, tmp.data_flags, tmp.searchRadiusOrGuid);
+                        continue;
+                    }
+                }
+                else
+                {
+                    auto pool = sPoolMgr.GetPoolGameObjects(tmp.searchRadiusOrGuid);
+                    if (pool.isEmpty())
+                    {
+                        sLog.outErrorDb("Table `%s` has go-buddy defined by pool (SCRIPT_FLAG_BUDDY_BY_POOL %u set) but pool %u is empty, skipping.", tablename, tmp.data_flags, tmp.searchRadiusOrGuid);
                         continue;
                     }
                 }
@@ -1060,12 +1081,12 @@ bool ScriptAction::GetScriptCommandObject(const ObjectGuid guid, bool includeIte
 }
 
 /// Select source and target for a script command
-/// Returns false iff an error happened
+/// Returns false if an error happened
 bool ScriptAction::GetScriptProcessTargets(WorldObject* pOrigSource, WorldObject* pOrigTarget, WorldObject*& pFinalSource, WorldObject*& pFinalTarget) const
 {
     WorldObject* pBuddy = nullptr;
 
-    if (m_script->buddyEntry)
+    if (m_script->buddyEntry || (m_script->data_flags & SCRIPT_FLAG_BUDDY_BY_POOL) != 0)
     {
         if (m_script->data_flags & SCRIPT_FLAG_BUDDY_BY_GUID)
         {
@@ -1089,6 +1110,49 @@ bool ScriptAction::GetScriptProcessTargets(WorldObject* pOrigSource, WorldObject
             if (!pBuddy)
             {
                 sLog.outErrorDb(" DB-SCRIPTS: Process table `%s` id %u, command %u has buddy %u by guid %u not loaded in map %u (data-flags %u), skipping.", m_table, m_script->id, m_script->command, m_script->buddyEntry, m_script->searchRadiusOrGuid, m_map->GetId(), m_script->data_flags);
+                return false;
+            }
+        }
+        else if (m_script->data_flags & SCRIPT_FLAG_BUDDY_BY_POOL)
+        {
+            if (m_script->IsCreatureBuddy())
+            {
+                PoolGroup<Creature> const& pool = sPoolMgr.GetPoolCreatures(m_script->searchRadiusOrGuid);
+                auto equalChancedObjectList = pool.GetEqualChanced();
+                for (auto objItr : equalChancedObjectList)
+                {
+                    CreatureData const* cData = sObjectMgr.GetCreatureData(objItr.guid);
+                    if (Creature* buddy = m_map->GetCreature(cData->GetObjectGuid(objItr.guid)))
+                    {
+                        if (buddy->isAlive())
+                        {
+                            pBuddy = buddy;
+                            break;
+                        }
+                    }
+                }
+
+                if (!pBuddy)
+                {
+                    auto explicitlyChancedObjectList = pool.GetExplicitlyChanced();
+                    for (auto objItr : explicitlyChancedObjectList)
+                    {
+                        CreatureData const* cData = sObjectMgr.GetCreatureData(objItr.guid);
+                        if (Creature* buddy = m_map->GetCreature(cData->GetObjectGuid(objItr.guid)))
+                        {
+                            if (buddy->isAlive())
+                            {
+                                pBuddy = buddy;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (!pBuddy)
+            {
+                sLog.outErrorDb(" DB-SCRIPTS: Process table `%s` id %u, command %u has buddy %u by pool id %u and no creature found in map %u (data-flags %u), skipping.", m_table, m_script->id, m_script->command, m_script->buddyEntry, m_script->searchRadiusOrGuid, m_map->GetId(), m_script->data_flags);
                 return false;
             }
         }

--- a/src/game/DBScripts/ScriptMgr.cpp
+++ b/src/game/DBScripts/ScriptMgr.cpp
@@ -649,7 +649,12 @@ void ScriptMgr::LoadScripts(ScriptMapMapName& scripts, const char* tablename)
             {
                 if (tmp.terminateScript.npcEntry && !ObjectMgr::GetCreatureTemplate(tmp.terminateScript.npcEntry))
                 {
-                    sLog.outErrorDb("Table `%s` has datalong = %u in SCRIPT_COMMAND_TERMINATE_SCRIPT for script id %u, but this npc entry does not exist.", tablename, tmp.sendTaxiPath.taxiPathId, tmp.id);
+                    sLog.outErrorDb("Table `%s` has npc entry = '%u' in SCRIPT_COMMAND_TERMINATE_SCRIPT for script id %u, but this npc entry does not exist.", tablename, tmp.terminateScript.npcEntry, tmp.id);
+                    continue;
+                }
+                else if (tmp.terminateScript.poolId && tmp.terminateScript.poolId > sPoolMgr.GetMaxPoolId())
+                {
+                    sLog.outErrorDb("Table `%s` has pool id = '%u' in SCRIPT_COMMAND_TERMINATE_SCRIPT for script id %u, but this pool id does not exist.", tablename, tmp.terminateScript.poolId, tmp.id);
                     continue;
                 }
                 break;
@@ -1934,25 +1939,68 @@ bool ScriptAction::HandleScriptStep()
         case SCRIPT_COMMAND_TERMINATE_SCRIPT:               // 31
         {
             bool result = false;
-            if (m_script->terminateScript.npcEntry)
+            if (m_script->terminateScript.npcEntry || m_script->terminateScript.poolId)
             {
-                WorldObject* pSearcher = pSource ? pSource : pTarget;
-                if (pSearcher->GetTypeId() == TYPEID_PLAYER && pTarget && pTarget->GetTypeId() != TYPEID_PLAYER)
-                    pSearcher = pTarget;
-
                 Creature* pCreatureBuddy = nullptr;
-                MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck u_check(*pSearcher, m_script->terminateScript.npcEntry, true, false, m_script->terminateScript.searchDist, true);
-                MaNGOS::CreatureLastSearcher<MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck> searcher(pCreatureBuddy, u_check);
-                Cell::VisitGridObjects(pSearcher, searcher, m_script->terminateScript.searchDist);
+                if (m_script->terminateScript.npcEntry)
+                {
+                    WorldObject* pSearcher = pSource ? pSource : pTarget;
+                    if (pSearcher->GetTypeId() == TYPEID_PLAYER && pTarget && pTarget->GetTypeId() != TYPEID_PLAYER)
+                        pSearcher = pTarget;
+                    MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck u_check(*pSearcher, m_script->terminateScript.npcEntry, true, false, m_script->terminateScript.searchDist, true);
+                    MaNGOS::CreatureLastSearcher<MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck> searcher(pCreatureBuddy, u_check);
+                    Cell::VisitGridObjects(pSearcher, searcher, m_script->terminateScript.searchDist);
+                }
+                else
+                {
+                    // poolId is provided
+                    PoolGroup<Creature> const& pool = sPoolMgr.GetPoolCreatures(m_script->terminateScript.poolId);
+                    auto equalChancedObjectList = pool.GetEqualChanced();
+                    for (auto objItr : equalChancedObjectList)
+                    {
+                        CreatureData const* cData = sObjectMgr.GetCreatureData(objItr.guid);
+                        if (Creature* buddy = m_map->GetCreature(cData->GetObjectGuid(objItr.guid)))
+                        {
+                            if (buddy->isAlive())
+                            {
+                                pCreatureBuddy = buddy;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!pCreatureBuddy)
+                    {
+                        auto explicitlyChancedObjectList = pool.GetExplicitlyChanced();
+                        for (auto objItr : explicitlyChancedObjectList)
+                        {
+                            CreatureData const* cData = sObjectMgr.GetCreatureData(objItr.guid);
+                            if (Creature* buddy = m_map->GetCreature(cData->GetObjectGuid(objItr.guid)))
+                            {
+                                if (buddy->isAlive())
+                                {
+                                    pCreatureBuddy = buddy;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
 
                 if (!(m_script->data_flags & SCRIPT_FLAG_COMMAND_ADDITIONAL) && !pCreatureBuddy)
                 {
-                    DEBUG_LOG("DB-SCRIPTS: Process table `%s` id %u, terminate further steps of this script! (as searched other npc %u was not found alive)", m_table, m_script->id, m_script->terminateScript.npcEntry);
+                    if (m_script->terminateScript.npcEntry)
+                        DEBUG_LOG("DB-SCRIPTS: Process table `%s` id %u, terminate further steps of this script! (as searched npc entry(%u) was not found alive)", m_table, m_script->id, m_script->terminateScript.npcEntry);
+                    else
+                        DEBUG_LOG("DB-SCRIPTS: Process table `%s` id %u, terminate further steps of this script! (as no npc in pool id(%u) was found alive)", m_table, m_script->id, m_script->terminateScript.poolId);
                     result = true;
                 }
                 else if (m_script->data_flags & SCRIPT_FLAG_COMMAND_ADDITIONAL && pCreatureBuddy)
                 {
-                    DEBUG_LOG("DB-SCRIPTS: Process table `%s` id %u, terminate further steps of this script! (as searched other npc %u was found alive)", m_table, m_script->id, m_script->terminateScript.npcEntry);
+                    if (m_script->terminateScript.npcEntry)
+                        DEBUG_LOG("DB-SCRIPTS: Process table `%s` id %u, terminate further steps of this script! (as searched npc entry(%u) was found alive)", m_table, m_script->id, m_script->terminateScript.npcEntry);
+                    else
+                        DEBUG_LOG("DB-SCRIPTS: Process table `%s` id %u, terminate further steps of this script! (as searched npc in pool id(%u) was found alive)", m_table, m_script->id, m_script->terminateScript.poolId);
                     result = true;
                 }
             }

--- a/src/game/DBScripts/ScriptMgr.h
+++ b/src/game/DBScripts/ScriptMgr.h
@@ -135,9 +135,10 @@ enum ScriptInfoDataFlags
     SCRIPT_FLAG_COMMAND_ADDITIONAL          = 0x08,         // command dependend
     SCRIPT_FLAG_BUDDY_BY_GUID               = 0x10,         // take the buddy by guid
     SCRIPT_FLAG_BUDDY_IS_PET                = 0x20,         // buddy is a pet
-    SCRIPT_FLAG_BUDDY_IS_DESPAWNED          = 0X40,         // buddy is dead or despawned
+    SCRIPT_FLAG_BUDDY_IS_DESPAWNED          = 0x40,         // buddy is dead or despawned
+    SCRIPT_FLAG_BUDDY_BY_POOL               = 0x80          // buddy should be part of a pool
 };
-#define MAX_SCRIPT_FLAG_VALID               (2 * SCRIPT_FLAG_BUDDY_IS_DESPAWNED - 1)
+#define MAX_SCRIPT_FLAG_VALID               (2 * SCRIPT_FLAG_BUDDY_BY_POOL - 1)
 
 struct ScriptInfo
 {

--- a/src/game/DBScripts/ScriptMgr.h
+++ b/src/game/DBScripts/ScriptMgr.h
@@ -331,6 +331,7 @@ struct ScriptInfo
         {
             uint32 npcEntry;                                // datalong
             uint32 searchDist;                              // datalong2
+            uint32 poolId;                                  // datalong3
             // changeWaypointWaitTime                       // dataint
         } terminateScript;
 


### PR DESCRIPTION
Avoiding to set explicitly a specific creature for some basic command.

You have to use SCRIPT_FLAG_BUDDY_BY_POOL (128) and dont put anything to entry. Search Radius Or Guid field will contain the pool id.

This is related to -> https://github.com/cmangos/tbc-db/commit/d57fe2b65e5420707c32d4be5c753c09ec6cac23#commitcomment-24357406

@Saltgurka @killerwife @Grz3s @cala 

This need to be tested by one of you guys i will not push it without a green light because i know it have some limitation.

I choose to select first available target that is alive. It may cause some unneeded error if no target are alive at T time.