### PR TITLE
Civilian flag misunderstanding crisis resolution

### DIFF
--- a/src/game/AI/BaseAI/CreatureAI.cpp
+++ b/src/game/AI/BaseAI/CreatureAI.cpp
@@ -42,7 +42,7 @@ CreatureAI::CreatureAI(Creature* creature) :
 {
     m_dismountOnAggro = !(m_creature->GetCreatureInfo()->CreatureTypeFlags & CREATURE_TYPEFLAGS_MOUNTED_COMBAT);
 
-    if (m_creature->IsCivilian())
+    if (m_creature->IsNoAggroOnSight())
         SetReactState(REACT_DEFENSIVE);
     if(m_creature->IsGuard() || m_unit->GetCharmInfo()) // guards and charmed targets
         m_visibilityDistance = sWorld.getConfig(CONFIG_FLOAT_SIGHT_GUARDER);
@@ -76,7 +76,7 @@ void CreatureAI::MoveInLineOfSight(Unit * who)
     if (m_creature->getVictim() && !m_creature->GetMap()->IsDungeon())
         return;
 
-    if (m_creature->IsCivilian() || m_creature->IsNeutralToAll())
+    if (m_creature->IsNoAggroOnSight() || m_creature->IsNeutralToAll())
         return;
 
     if (who->GetObjectGuid().IsCreature() && who->isInCombat())

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -51,10 +51,10 @@ int CreatureEventAI::Permissible(const Creature* creature)
     if (creature->GetAIName() == "EventAI")
         return PERMIT_BASE_SPECIAL;
 
-    if (creature->IsCivilian() || creature->IsNeutralToAll())
+    if (creature->IsNoAggroOnSight() || creature->IsNeutralToAll())
         return PERMIT_BASE_REACTIVE;
 
-    if (!creature->IsCivilian() && !creature->IsNeutralToAll())
+    if (!creature->IsNoAggroOnSight() && !creature->IsNeutralToAll())
         return PERMIT_BASE_PROACTIVE;
 
     return PERMIT_BASE_NO;

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -1890,7 +1890,7 @@ bool Creature::CanAssistTo(const Unit* u, const Unit* enemy, bool checkfaction /
         return false;
 
     // we don't need help from non-combatant ;)
-    if (IsCivilian())
+    if (IsNoAggroOnSight())
         return false;
 
     if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_IMMUNE_TO_NPC))

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -42,7 +42,7 @@ struct GameEventCreatureData;
 enum CreatureExtraFlags
 {
     CREATURE_EXTRA_FLAG_INSTANCE_BIND          = 0x00000001,       // creature kill bind instance with killer and killer's group
-    CREATURE_EXTRA_FLAG_CIVILIAN               = 0x00000002,       // not aggro (ignore faction/reputation hostility)
+    CREATURE_EXTRA_FLAG_NO_AGGRO_ON_SIGHT      = 0x00000002,       // no aggro (ignore faction/reputation hostility)
     CREATURE_EXTRA_FLAG_NO_PARRY               = 0x00000004,       // creature can't parry
     CREATURE_EXTRA_FLAG_NO_PARRY_HASTEN        = 0x00000008,       // creature can't counter-attack at parry
     CREATURE_EXTRA_FLAG_NO_BLOCK               = 0x00000010,       // creature can't block
@@ -57,7 +57,7 @@ enum CreatureExtraFlags
     CREATURE_EXTRA_FLAG_MMAP_FORCE_ENABLE      = 0x00002000,       // creature is forced to use MMaps
     CREATURE_EXTRA_FLAG_MMAP_FORCE_DISABLE     = 0x00004000,       // creature is forced to NOT use MMaps
     CREATURE_EXTRA_FLAG_WALK_IN_WATER          = 0x00008000,       // creature is forced to walk in water even it can swim
-    // CREATURE_EXTRA_FLAG_EMPTY                   = 0x00010000,       // fill
+    CREATURE_EXTRA_FLAG_CIVILIAN               = 0x00010000,       // CreatureInfo->civilian substitute (for new expansions)
     CREATURE_EXTRA_FLAG_NO_MELEE               = 0x00020000,       // creature can't melee
     // reserved by Killerwife - 0x00080000 is free
     CREATURE_EXTRA_FLAG_COUNT_SPAWNS           = 0x00200000,       // count creature spawns in Map*
@@ -590,6 +590,7 @@ class Creature : public Unit
         uint32 GetCorpseDecayTimer() const { return m_corpseDecayTimer; }
         bool IsRacialLeader() const { return GetCreatureInfo()->RacialLeader; }
         bool IsCivilian() const { return !!(GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_CIVILIAN); }
+        bool IsNoAggroOnSight() const { return (GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_NO_AGGRO_ON_SIGHT); }
         bool IsGuard() const { return !!(GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_GUARD); }
 
         bool CanWalk() const { return !!(GetCreatureInfo()->InhabitType & INHABIT_GROUND); }


### PR DESCRIPTION
* CREATURE_EXTRA_FLAG_CIVILIAN renamed to CREATURE_EXTRA_FLAG_NO_AGGRO_ON_SIGHT
* Introduced new CREATURE_EXTRA_FLAG_CIVILIAN as a substitute for classic CreatureInfo->civilian
* Introduced Creature::IsNoAggroOnSight() getter for the mentioned flag
* AI functionality responsible for aggro moved from creature->IsCivilian() to creature->IsNoAggroOnSight()

ATTENTION: Additional actions required for DBs in new expansions: fill in CreatureInfo->civilian from classic DB as new extra flag.

Alternative way to solve problem in https://github.com/cmangos/mangos-classic/pull/321 with all expansions in mind, as described in https://github.com/cmangos/classic-db/pull/73#issuecomment-339610935. Completely separates "no aggro on sight" and "civilian" flags.

Dicussion:
https://github.com/cmangos/classic-db/pull/73#issuecomment-338945718
https://github.com/cmangos/mangos-classic/pull/321#issuecomment-339598383

Tagging @cala @killerwife 