### PR TITLE
Fix memleak in SessionMap and session duplication

### DIFF
--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -211,6 +211,8 @@ World::AddSession_(WorldSession* s)
             // prevent decrease sessions count if session queued
             if (RemoveQueuedSession(old->second))
                 decrease_session = false;
+            // do not remove replaced session from queue if listed
+            delete old->second;
         }
     }
 


### PR DESCRIPTION
This restores the original logic in that function and fixes #1177 #1252 and #1347 but will also suffer for #1359 problems:
yet, it's the good way to go. We need to fix that too asap.