### PR TITLE
Commands: Add .gobject activate command.

### DIFF
--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -293,6 +293,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "near",           SEC_GAMEMASTER,     false, &ChatHandler::HandleGameObjectNearCommand,      "", nullptr },
         { "target",         SEC_GAMEMASTER,     false, &ChatHandler::HandleGameObjectTargetCommand,    "", nullptr },
         { "turn",           SEC_GAMEMASTER,     false, &ChatHandler::HandleGameObjectTurnCommand,      "", nullptr },
+        { "activate",       SEC_GAMEMASTER,     false, &ChatHandler::HandleGameObjectActivateCommand,  "", nullptr },
         { nullptr,          0,                  false, nullptr,                                        "", nullptr }
     };
 

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -250,6 +250,7 @@ class ChatHandler
         bool HandleGameObjectPhaseCommand(char* args);
         bool HandleGameObjectTargetCommand(char* args);
         bool HandleGameObjectTurnCommand(char* args);
+        bool HandleGameObjectActivateCommand(char* args);
 
         bool HandleGMCommand(char* args);
         bool HandleGMChatCommand(char* args);

--- a/src/game/Chat/Level2.cpp
+++ b/src/game/Chat/Level2.cpp
@@ -1184,6 +1184,36 @@ bool ChatHandler::HandleGameObjectNearCommand(char* args)
     return true;
 }
 
+bool ChatHandler::HandleGameObjectActivateCommand(char* args) {
+    // number or [name] Shift-click form |color|Hgameobject:go_id|h[name]|h|r
+    uint32 lowguid;
+    if (!ExtractUint32KeyFromLink(&args, "Hgameobject", lowguid))
+        return false;
+
+    if (!lowguid)
+        return false;
+
+    GameObject* obj = nullptr;
+
+    // by DB guid
+    if (GameObjectData const* go_data = sObjectMgr.GetGOData(lowguid))
+        obj = GetGameObjectWithGuid(lowguid, go_data->id);
+
+    if (!obj)
+    {
+        PSendSysMessage(LANG_COMMAND_OBJNOTFOUND, lowguid);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    uint32_t const autoCloseTime = obj->GetGOInfo()->GetAutoCloseTime() ? 10000u : 0u;
+
+    obj->SetLootState(GO_READY);
+    obj->UseDoorOrButton(autoCloseTime, false);
+
+    this->SendSysMessage("Object activated!");
+}
+
 bool ChatHandler::HandleGUIDCommand(char* /*args*/)
 {
     ObjectGuid guid = m_session->GetPlayer()->GetSelectionGuid();


### PR DESCRIPTION
This command was never in MaNGOS-based emus, but it is an extremely useful and honestly at times, necessary, command in order to work more easily and productively in-game. I feel it has a place to be added.