### PR TITLE
Pet: Clear arena auras when entering arena

### DIFF
--- a/src/game/Entities/Pet.cpp
+++ b/src/game/Entities/Pet.cpp
@@ -348,6 +348,10 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petentry /*= 0*/, uint32 petnumber
     // load spells/cooldowns/auras
     _LoadAuras(timediff);
 
+    // remove arena auras if in arena
+    if (map->IsBattleArena())
+        RemoveArenaAuras();
+
     // init AB
     LearnPetPassives();
     CastPetAuras(current);


### PR DESCRIPTION
Fixes the ability to hide non-arena buffs on a pet by dismissing them before entering the arena battle, and summoning them once inside.