### PR TITLE
Log: Add arena logging

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -720,6 +720,7 @@ void BattleGround::EndBattleGround(Team winner)
                 DEBUG_LOG("--- Winner rating: %u, Loser rating: %u, Winner change: %i, Loser change: %i ---", winner_rating, loser_rating, winner_change, loser_change);
                 SetArenaTeamRatingChangeForTeam(winner, winner_change);
                 SetArenaTeamRatingChangeForTeam(GetOtherTeam(winner), loser_change);
+                sLog.outArena("Arena match Type: %u for Team1Id: %u - Team2Id: %u ended. WinnerTeamId: %u. Winner rating: %u, Loser rating: %u. RatingChange: %i.", m_ArenaType, m_ArenaTeamIds[TEAM_INDEX_ALLIANCE], m_ArenaTeamIds[TEAM_INDEX_HORDE], winner_arena_team->GetId(), winner_rating, loser_rating, winner_change);
             }
             else
             {
@@ -784,6 +785,13 @@ void BattleGround::EndBattleGround(Team winner)
                 winner_arena_team->MemberWon(plr, loser_rating);
             else
                 loser_arena_team->MemberLost(plr, winner_rating);
+        }
+
+        if (isArena() && isRated())
+        {
+            BattleGroundScoreMap::iterator score = m_PlayerScores.find(itr->first);
+            BattleGroundScore *pScore = score->second;
+            sLog.outArena("Statistics for %s (GUID: " UI64FMTD ", Team: %u, IP: %s): %u damage, %u healing, %u killing blows", plr->GetName(), plr->GetGUIDLow(), plr->GetArenaTeamId(m_ArenaType == 5 ? 2 : m_ArenaType == 3), plr->GetSession()->GetRemoteAddress().c_str(), pScore->GetDamageDone(), pScore->GetHealingDone(), pScore->GetKillingBlows());
         }
 
         // store battleground score statistics for each player
@@ -1181,6 +1189,9 @@ void BattleGround::StartBattleGround()
 
     // add BG to free slot queue
     AddToBGFreeSlotQueue();
+
+    if (m_IsRated)
+        sLog.outArena("Arena match type: %u for Team1Id: %u - Team2Id: %u started.", m_ArenaType, m_ArenaTeamIds[TEAM_INDEX_ALLIANCE], m_ArenaTeamIds[TEAM_INDEX_HORDE]);
 
     // add bg to update list
     // This must be done here, because we need to have already invited some players when first BG::Update() method is executed

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -3,7 +3,7 @@
 #####################################
 
 [MangosdConf]
-ConfVersion=2018050401
+ConfVersion=2018051501
 
 ###################################################################################################################
 # CONNECTIONS AND DIRECTORIES
@@ -368,6 +368,10 @@ MaxWhoListReturns = 49
 #                     in form Logname_#ID_YYYY-MM-DD_HH-MM-SS.Ext
 #                     or form Logname_#ID.Ext
 #
+#    ArenaLogFile
+#        Log file of arena fights and arena team creations
+#        Default: "" - Empty name for disable
+#
 #    RaLogFile
 #        Log file of RA commands
 #        Default: "Ra.log"
@@ -415,6 +419,7 @@ CharLogDump = 0
 GmLogFile = ""
 GmLogTimestamp = 0
 GmLogPerAccount = 0
+ArenaLogFile = ""
 RaLogFile = ""
 LogColors = ""
 

--- a/src/shared/Log.cpp
+++ b/src/shared/Log.cpp
@@ -65,7 +65,7 @@ enum LogType
 const int LogType_count = int(LogError) + 1;
 
 Log::Log() :
-    raLogfile(nullptr), logfile(nullptr), gmLogfile(nullptr), charLogfile(nullptr), customLogFile(nullptr),
+    raLogfile(nullptr), logfile(nullptr), gmLogfile(nullptr), charLogfile(nullptr), customLogFile(nullptr), arenaLogFile(nullptr),
     dberLogfile(nullptr), eventAiErLogfile(nullptr), scriptErrLogFile(nullptr), worldLogfile(nullptr), m_colored(false), m_includeTime(false), m_gmlog_per_account(false), m_scriptLibName(nullptr)
 {
     Initialize();
@@ -266,6 +266,7 @@ void Log::Initialize()
     raLogfile = openLogFile("RaLogFile", nullptr, "a");
     worldLogfile = openLogFile("WorldLogFile", "WorldLogTimestamp", "a");
     customLogFile = openLogFile("CustomLogFile", nullptr, "a");
+    arenaLogFile = openLogFile("ArenaLogFile", nullptr, "a");
 
     // Main log file settings
     m_includeTime  = sConfig.GetBoolDefault("LogTime", false);
@@ -960,6 +961,26 @@ void Log::outCustomLog(const char* str, ...)
         fprintf(customLogFile, "\n");
         va_end(ap);
         fflush(customLogFile);
+    }
+
+    fflush(stdout);
+}
+
+void Log::outArena(const char* str, ...)
+{
+    if (!str)
+        return;
+
+    std::lock_guard<std::mutex> guard(m_worldLogMtx);
+    if (arenaLogFile)
+    {
+        va_list ap;
+        outTimestamp(arenaLogFile);
+        va_start(ap, str);
+        vfprintf(arenaLogFile, str, ap);
+        fprintf(arenaLogFile, "\n");
+        va_end(ap);
+        fflush(arenaLogFile);
     }
 
     fflush(stdout);

--- a/src/shared/Log.h
+++ b/src/shared/Log.h
@@ -133,6 +133,10 @@ class Log : public MaNGOS::Singleton<Log, MaNGOS::ClassLevelLockable<Log, std::m
             if (customLogFile != nullptr)
                 fclose(customLogFile);
             customLogFile = nullptr;
+
+            if (arenaLogFile != nullptr)
+                fclose(arenaLogFile);
+            arenaLogFile = nullptr;
         }
     public:
         void Initialize();
@@ -169,7 +173,8 @@ class Log : public MaNGOS::Singleton<Log, MaNGOS::ClassLevelLockable<Log, std::m
         // any log level
         void outCharDump(const char* str, uint32 account_id, uint32 guid, const char* name);
         void outRALog(const char* str, ...)       ATTR_PRINTF(2, 3);
-        void outCustomLog(const char* str, ...)       ATTR_PRINTF(2, 3);
+        void outCustomLog(const char* str, ...)   ATTR_PRINTF(2, 3);
+        void outArena(const char* str, ...)       ATTR_PRINTF(2, 3);
         uint32 GetLogLevel() const { return m_logLevel; }
         void SetLogLevel(char* Level);
         void SetLogFileLevel(char* Level);
@@ -202,6 +207,7 @@ class Log : public MaNGOS::Singleton<Log, MaNGOS::ClassLevelLockable<Log, std::m
         FILE* scriptErrLogFile;
         FILE* worldLogfile;
         FILE* customLogFile;
+        FILE* arenaLogFile;
         std::mutex m_worldLogMtx;
 
         // log/console control


### PR DESCRIPTION
Adds an arena log file (disabled by default) to log matches and the stats of the match, team creation, disbandment, etc.

**PR Note**: I combined the "ArenaExtendedLog" feature into one. If people disagree and think these should still remain separate, let me know. I just don't see why not to have it included these days. The "extended" (on/off) feature for those who may not be aware was is simply the addition of the individual player stats and info in the match. Eg: player info, damage done, healing done, kills, IP address, etc. Without this enabled it normally would only report team creation & disbandment, and match started/match ended. No player stats.