### PR TITLE
Fixed item sockets display in guild banks

### DIFF
--- a/src/game/Guilds/Guild.cpp
+++ b/src/game/Guilds/Guild.cpp
@@ -1674,7 +1674,7 @@ void Guild::AppendDisplayGuildBankSlot(WorldPacket& data, GuildBankTab const* ta
         {
             if (uint32 enchantId = item->GetEnchantmentId(EnchantmentSlot(socketSlot)))
             {
-                data << uint8(socketSlot);
+                data << uint8(socketSlot - SOCK_ENCHANTMENT_SLOT); // BC client count gems slot from 0
                 data << uint32(enchantId);
                 ++socketCount;
             }


### PR DESCRIPTION
f2d14ad30d129c480c3bf36009 follow-up

Client does not use EnchantmentSlot index but a socket index. With current code you get gems visually offset by +2 slots in guild bank.