### PR TITLE
Substantial EAI rework

### DIFF
--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -1,5 +1,5 @@
 ===========================================================================
-MaNGOS EventAI (Creature_AI) Documentation: (Last Updated: August 22, 2012)
+MaNGOS EventAI (Creature_AI) Documentation: (Last Updated: June 25, 2018)
 ===========================================================================
 
 EventAI allows users to create new creature scripts entirely within the database.
@@ -7,6 +7,7 @@ EventAI allows users to create new creature scripts entirely within the database
 For the AI to be used, you must first make sure to set AIname for each creature that should use this AI.
 UPDATE creature_template SET AIName = 'EventAI' WHERE entry IN (...);
 
+Note: Edit in Spaces, not Tabs
 
 =========================================
 Basic Structure of EventAI
@@ -28,6 +29,8 @@ event_param1                    Variables for the event (depends on event_type)
 event_param2                    Variables for the event (depends on event_type)
 event_param3                    Variables for the event (depends on event_type)
 event_param4                    Variables for the event (depends on event_type)
+event_param5                    Variables for the event (depends on event_type)
+event_param6                    Variables for the event (depends on event_type)
 
 action1_type                    Action #1 to take when the Event occurs (see "Action types" below)
 action1_param1                  Variables used by Action1 (depends on action_type)
@@ -47,8 +50,8 @@ action3_param3                  Variables used by Action1 (depends on action_typ
 All params are signed 32-bit values (+/- 2147483647). Time values are always in milliseconds.
 In case of a percentage value, use value/100 (ie. param = 500 then that means 500%, -50 = -50%)
 
-[*] Phase mask is a bitmask of phases which shouldn't trigger this event. (ie. Phase mask of value 12 (binary 1100) results in triggering this event in phases 0, 1 and all others with exception for phases 2 and 3 (counting from 0).
-[*] Phase 0 is default so this will occur in all phases unless specified. (1101 = Triggers in Phase 1 of 3, 1011 = Triggers in Phase 2 of 3, 0111 = Triggers in Phase 3 of 3, 0011 = Triggers in Both Phase 2 and 3).
+[*] Phase mask is a bitmask of phases which shouldn't trigger this event. (ie. Phase mask of value 12 (binary 1100) results in triggering this event in phases 0, 1 and all others with exception for phases 2 and 3 (counting from 1 as Phase 0 = 1).
+[*] Phase 0 is default so this will occur in all phases unless specified. (1101 = Triggers in Phase 1, 1011 = Triggers in Phase 2, 0111 = Triggers in Phase 3, 0011 = Triggers in Phase 2 and 3).
 [*] Take Desired Binary Configuration and convert into Decimal and this is your event_inverse_phase_mask to use in your script.
 
 =========================================
@@ -62,40 +65,40 @@ Params are always read in the ascending order (from Param1 to Param3).
 NOTE: Events will not repeat until the creature exits combat or unless EFLAG_REPEATABLE value is set in Event Flags.
 Some events such as EVENT_T_AGGRO, EVENT_T_DEATH, EVENT_T_SPAWNED, and EVENT_T_EVADE cannot repeat even if EFLAG_REPEATABLE value is set.
 
-#    Internal Name                   Event Param Usage (Param1, Param2, Param3, Param4)      Description
+#   Internal Name                       Event (Param1, Param2, Param3, Param4, Param5, Param6)          Description
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-0    EVENT_T_TIMER_IN_COMBAT         InitialMin, InitialMax, RepeatMin, RepeatMax            Expires at first between (Param1) and (Param2) and then will repeat between every (Param3) and (Param4),  EXPIRES ONLY IN COMBAT.
-1    EVENT_T_TIMER_OOC               InitialMin, InitialMax, RepeatMin, RepeatMax            Expires at first between (Param1) and (Param2) and then will repeat between every (Param3) and (Param4),  EXPIRES ONLY OUT OF COMBAT BUT NOT DURING EVADE.
-2    EVENT_T_HP                      HPMax%, HPMin%, RepeatMin, RepeatMax                    Expires when the NPC's HP% is between (Param1) and (Param2). Will repeat between every (Param3) and (Param4) If Event Conditions Are Still Met.
-3    EVENT_T_MANA                    ManaMax%, ManaMin%, RepeatMin, RepeatMax                Expires when the NPC's Mana% is between (Param1) and (Param2). Will repeat between every (Param3) and (Param4) If Event Conditions Are Still Met.
-4    EVENT_T_AGGRO                   NONE                                                    Expires ONLY upon the NPC's INITIAL Aggro at the Start of Combat (Does NOT Repeat) and Only Resets on Spawn or Evade.
-5    EVENT_T_KILL                    RepeatMin, RepeatMax                                    Expires upon Killing a Player. Will Repeat Check between (Param1) and (Param2). This Event Will Not Trigger Again Until Repeat Timer Expires
-6    EVENT_T_DEATH                   ConditionId                                             Expires on the NPC's Death. (This Triggers At The Moment The NPC Dies) Optionally if ConditionId is provided the event will only trigger if the condition returns true
-7    EVENT_T_EVADE                   NONE                                                    Expires at the moment the Creature EnterEvadeMode() and Exits Combat.
-8    EVENT_T_SPELLHIT                SpellID, Schoolmask, RepeatMin, RepeatMax               Expires upon Spell Hit of the NPC. When (param1) is set, it is the specific Spell ID used as the trigger. With (param2) specified, the expiration is limited to specific spell schools (-1 for all) and Spell ID value is ignored. Will repeat Event Conditions Check between every (Param3) and (Param4). Only A Spell ID or Spell School may be Specified but NOT both.
-9    EVENT_T_RANGE                   MinDist, MaxDist, RepeatMin, RepeatMax                  Expires when the Highest Threat Target Distance is Greater than (Param1) and Less than (Param2). Will repeat between every (Param3) and (Param4) if Event Conditions Are Still Met.
-10   EVENT_T_OOC_LOS                 Hostile-or-Not, MaxAllowedRange, RepeatMin, RepeatMax   Expires when a unit moves within distance (MaxAllowedRange) of the NPC. If (Param1) is 0 it will expire only when unit is hostile, If (Param1) is 1 it will expire only when unit is friendly. This depends generally on faction relations. Will repeat every (Param3) and (Param4). Does NOT expire when the NPC is in combat.
-11   EVENT_T_SPAWNED                 Condition, CondValue1                                   Expires on initial spawn and respawn of the NPC if Condition is met (Useful for setting Ranged Movement/Summoning Pets/Applying Buffs).
-12   EVENT_T_TARGET_HP               HPMax%, HPMin%, RepeatMin, RepeatMax                    Expires when current target's HP% is between (Param1) and (Param2). Will repeat every (Param3) and (Param4)If Event Conditions Are Still Met.
-13   EVENT_T_TARGET_CASTING          RepeatMin, RepeatatMax                                  Expires when the current target is casting a spell. Will repeat every (Param1) and (Param2) If Event Conditions Are Still Met.
-14   EVENT_T_FRIENDLY_HP             HPDeficit, Radius, RepeatMin, RepeatMax                 Expires when a friendly unit in (Radius) has at least (Param1) HP points missing. Will repeat every (Param3) and (Param4) If Event Conditions Are Still Met.
-15   EVENT_T_FRIENDLY_IS_CC          DispelType, Radius, RepeatMin, RepeatMax                Expires when a friendly unit is crowd controlled within the given Radius (Param2). Will repeat every (Param3) and (Param4).
-16   EVENT_T_FRIENDLY_MISSING_BUFF   SpellId, Radius, RepeatMin, RepeatMax                   Expires when a friendly unit is missing aura(s) given by a spell (Param1) within Radius (Param2). Will repeat every (Param3) and (Param4) If Event Conditions Are Still Met.
-17   EVENT_T_SUMMONED_UNIT           CreatureId, RepeatMin, RepeatMax                        Expires after creature with entry = (Param1) is spawned (Param1 = 0 means all spawns). Will repeat every (Param2) and (Param3).
-18   EVENT_T_TARGET_MANA             ManaMax%, ManaMin%, RepeatMin, RepeatMax                Expires when current target's Mana% is between (Param1) and (Param2). Will repeat every (Param3) and (Param4) If Event Conditions Are Still Met.
-21   EVENT_T_REACHED_HOME            NONE                                                    Expires when a creature reaches it's home (spawn) location after evade. This is commonly used for NPC's who Stealth once reaching their Spawn Location
-22   EVENT_T_RECEIVE_EMOTE           EmoteId, Condition, CondValue1, CondValue2              Expires when a creature receives an emote with emote text id ("enum TextEmotes" from SharedDefines.h in Mangos Source) in (Param1). Conditions can be defined (Param2) with optional values (Param3,Param4), see (enum ConditionType) in ObjectMgr.h (Mangos Source).
-23   EVENT_T_AURA                    SpellID, AmmountInStack, RepeatMin, RepeatMax           Expires when a creature has spell (Param1) auras applied in a stack greater or equal to value provided in (Param2). Will repeat every (Param3) and (Param4) If Event Conditions Are Still Met.
-24   EVENT_T_TARGET_AURA             SpellID, AmmountInStack, RepeatMin, RepeatMax           Expires when a target unit has spell (Param1) auras applied in a stack greater or equal to value provided in (Param2). Will repeat every (Param3) and (Param4) If Event Conditions Are Still Met.
-25   EVENT_T_SUMMONED_JUST_DIED      CreatureId, RepeatMin, RepeatMax                        Expires after creature with entry = (Param1) is die (Param1 = 0 means all spawns). Will repeat every (Param2) and (Param3).
-26   EVENT_T_SUMMONED_JUST_DESPAWN   CreatureId, RepeatMin, RepeatMax                        Expires before creature with entry = (Param1) is despawn (Param1 = 0 means all spawns). Will repeat every (Param2) and (Param3).
-27   EVENT_T_MISSING_AURA            SpellID, AmmountInStack, RepeatMin, RepeatMax           Expires when a creature not has spell (Param1) auras applied in a stack greater or equal to value provided in (Param2). Will repeat every (Param3) and (Param4).
-28   EVENT_T_TARGET_MISSING_AURA     SpellID, AmmountInStack, RepeatMin, RepeatMax           Expires when a target unit not has spell (Param1) auras applied in a stack greater or equal to value provided in (Param2). Will repeat every (Param3) and (Param4).
-29   EVENT_T_TIMER_GENERIC           InitialMin, InitialMax, RepeatMin, RepeatMax            Expires at first between (Param1) and (Param2) and then will repeat between every (Param3) and (Param4).
-30   EVENT_T_RECEIVE_AI_EVENT        AIEventType, Sender-Entry                               Expires when the creature receives an AIEvent of type (Param1), sent by creature (Param2 != 0). If (Param2 = 0) then sent by any creature
-31   EVENT_T_ENERGY                  EnergyMax%, EnergyMin%, RepeatMin, RepeatMax            Expires when the NPC's Energy% is between (Param1) and (Param2). Will repeat between every (Param3) and (Param4) If Event Conditions Are Still Met.
-32   EVENT_T_SELECT_ATTACKING_TARGET MinRange, MaxRange, RepeatMin, RepeatMax                Expires when the NPC has a target in threat table further than Param1 and closer than Param2. First time happens after and will repeat after Param3 and Param4.
-33   EVENT_T_FACING_TARGET           BackOrFront, unused, RepeatMin, RepeatMax               Expires when the NPC is in back (Param1=0) or in front (Param1=1) of its current target. Will repeat after Param3 and Param4.
+0   EVENT_T_TIMER_IN_COMBAT             InitialMin, InitialMax, RepeatMin, RepeatMax                    Expires at first between (Param1) and (Param2) and then will repeat between every (Param3) and (Param4),  EXPIRES ONLY IN COMBAT.
+1   EVENT_T_TIMER_OOC                   InitialMin, InitialMax, RepeatMin, RepeatMax                    Expires at first between (Param1) and (Param2) and then will repeat between every (Param3) and (Param4),  EXPIRES ONLY OUT OF COMBAT BUT NOT DURING EVADE.
+2   EVENT_T_HP                          HPMax%, HPMin%, RepeatMin, RepeatMax                            Expires when the NPC's HP% is between (Param1) and (Param2). Will repeat between every (Param3) and (Param4) If Event Conditions Are Still Met.
+3   EVENT_T_MANA                        ManaMax%, ManaMin%, RepeatMin, RepeatMax                        Expires when the NPC's Mana% is between (Param1) and (Param2). Will repeat between every (Param3) and (Param4) If Event Conditions Are Still Met.
+4   EVENT_T_AGGRO                       NONE                                                            Expires ONLY upon the NPC's INITIAL Aggro at the Start of Combat (Does NOT Repeat) and Only Resets on Spawn or Evade.
+5   EVENT_T_KILL                        RepeatMin, RepeatMax                                            Expires upon Killing a Player. Will Repeat Check between (Param1) and (Param2). This Event Will Not Trigger Again Until Repeat Timer Expires
+6   EVENT_T_DEATH                       ConditionId                                                     Expires on the NPC's Death. (This Triggers At The Moment The NPC Dies) Optionally if ConditionId is provided the event will only trigger if the condition returns true
+7   EVENT_T_EVADE                       NONE                                                            Expires at the moment the Creature EnterEvadeMode() and Exits Combat.
+8   EVENT_T_SPELLHIT                    SpellID, Schoolmask*, RepeatMin, RepeatMax                      Expires upon Spell Hit of the NPC. When (param1) is set, it is the specific Spell ID used as the trigger. With (param2) specified, the expiration is limited to specific spell schools (-1 for all) and Spell ID value is ignored. Will repeat Event Conditions Check between every (Param3) and (Param4). Only A Spell ID or Spell School may be Specified but NOT both.
+9   EVENT_T_RANGE                       MinDist, MaxDist, RepeatMin, RepeatMax                          Expires when the Highest Threat Target Distance is Greater than (Param1) and Less than (Param2). Will repeat between every (Param3) and (Param4) if Event Conditions Are Still Met.
+10  EVENT_T_OOC_LOS                     Hostile-or-Not, MaxAllowedRange, RepeatMin, RepeatMax           Expires when a unit moves within distance (MaxAllowedRange) of the NPC. If (Param1) is 0 it will expire only when unit is hostile, If (Param1) is 1 it will expire only when unit is friendly. This depends generally on faction relations. Will repeat every (Param3) and (Param4). Does NOT expire when the NPC is in combat.
+11  EVENT_T_SPAWNED                     Condition, CondValue1                                           Expires on initial spawn and respawn of the NPC if Condition is met (Useful for setting Ranged Movement/Summoning Pets/Applying Buffs).
+12  EVENT_T_TARGET_HP                   HPMax%, HPMin%, RepeatMin, RepeatMax                            Expires when current target's HP% is between (Param1) and (Param2). Will repeat every (Param3) and (Param4)If Event Conditions Are Still Met.
+13  EVENT_T_TARGET_CASTING              RepeatMin, RepeatatMax                                          Expires when the current target is casting a spell. Will repeat every (Param1) and (Param2) If Event Conditions Are Still Met.
+14  EVENT_T_FRIENDLY_HP                 HPDeficit, Radius, RepeatMin, RepeatMax                         Expires when a friendly unit in (Radius) has at least (Param1) HP points missing. Will repeat every (Param3) and (Param4) If Event Conditions Are Still Met.
+15  EVENT_T_FRIENDLY_IS_CC              DispelType, Radius, RepeatMin, RepeatMax                        Expires when a friendly unit is crowd controlled within the given Radius (Param2). Will repeat every (Param3) and (Param4).
+16  EVENT_T_FRIENDLY_MISSING_BUFF       SpellId, Radius, RepeatMin, RepeatMax                           Expires when a friendly unit is missing aura(s) given by a spell (Param1) within Radius (Param2). Will repeat every (Param3) and (Param4) If Event Conditions Are Still Met.
+17  EVENT_T_SUMMONED_UNIT               CreatureId, RepeatMin, RepeatMax                                Expires after creature with entry = (Param1) is spawned (Param1 = 0 means all spawns). Will repeat every (Param2) and (Param3).
+18  EVENT_T_TARGET_MANA                 ManaMax%, ManaMin%, RepeatMin, RepeatMax                        Expires when current target's Mana% is between (Param1) and (Param2). Will repeat every (Param3) and (Param4) If Event Conditions Are Still Met.
+21  EVENT_T_REACHED_HOME                NONE                                                            Expires when a creature reaches it's home (spawn) location after evade. This is commonly used for NPC's who Stealth once reaching their Spawn Location
+22  EVENT_T_RECEIVE_EMOTE               EmoteId, Condition, CondValue1, CondValue2                      Expires when a creature receives an emote with emote text id ("enum TextEmotes" from SharedDefines.h in Mangos Source) in (Param1). Conditions can be defined (Param2) with optional values (Param3,Param4), see (enum ConditionType) in ObjectMgr.h (Mangos Source).
+23  EVENT_T_AURA                        SpellID, AmmountInStack, RepeatMin, RepeatMax                   Expires when a creature has spell (Param1) auras applied in a stack greater or equal to value provided in (Param2). Will repeat every (Param3) and (Param4) If Event Conditions Are Still Met.
+24  EVENT_T_TARGET_AURA                 SpellID, AmmountInStack, RepeatMin, RepeatMax                   Expires when a target unit has spell (Param1) auras applied in a stack greater or equal to value provided in (Param2). Will repeat every (Param3) and (Param4) If Event Conditions Are Still Met.
+25  EVENT_T_SUMMONED_JUST_DIED          CreatureId, RepeatMin, RepeatMax                                Expires after creature with entry = (Param1) is die (Param1 = 0 means all spawns). Will repeat every (Param2) and (Param3).
+26  EVENT_T_SUMMONED_JUST_DESPAWN       CreatureId, RepeatMin, RepeatMax                                Expires before creature with entry = (Param1) is despawn (Param1 = 0 means all spawns). Will repeat every (Param2) and (Param3).
+27  EVENT_T_MISSING_AURA                SpellID, AmmountInStack, RepeatMin, RepeatMax                   Expires when a creature not has spell (Param1) auras applied in a stack greater or equal to value provided in (Param2). Will repeat every (Param3) and (Param4).
+28  EVENT_T_TARGET_MISSING_AURA         SpellID, AmmountInStack, RepeatMin, RepeatMax                   Expires when a target unit not has spell (Param1) auras applied in a stack greater or equal to value provided in (Param2). Will repeat every (Param3) and (Param4).
+29  EVENT_T_TIMER_GENERIC               InitialMin, InitialMax, RepeatMin, RepeatMax                    Expires at first between (Param1) and (Param2) and then will repeat between every (Param3) and (Param4).
+30  EVENT_T_RECEIVE_AI_EVENT            AIEventType, Sender-Entry                                       Expires when the creature receives an AIEvent of type (Param1), sent by creature (Param2 != 0). If (Param2 = 0) then sent by any creature
+31  EVENT_T_ENERGY                      EnergyMax%, EnergyMin%, RepeatMin, RepeatMax                    Expires when the NPC's Energy% is between (Param1) and (Param2). Will repeat between every (Param3) and (Param4) If Event Conditions Are Still Met.
+32  EVENT_T_SELECT_ATTACKING_TARGET     MinRange, MaxRange, RepeatMin, RepeatMax                        Deprecated use TARGET_T_NEAREST_AOE_TARGET - Expires when the NPC has a target in threat table further than Param1 and closer than Param2. First time happens after and will repeat after Param3 and Param4.
+33  EVENT_T_FACING_TARGET               BackOrFront, unused, RepeatMin, RepeatMax                       Expires when the NPC is in back (Param1=0) or in front (Param1=1) of its current target. Will repeat after Param3 and Param4.
 
 =========================================
 Action Types
@@ -105,72 +108,73 @@ This is a list of action types that EventAI is able to handle.
 Each event type has it's own specific interpretation of it's params, just like Events.
 For all ACTION_T_RANDOM Actions, When a Particular Param is selected for the Event... The SAME Param # is selected for all 3 actions when Event is triggered.
 
-#    Internal name                          Param usage                     Description
+#   Internal Name                           Action (Param1, Param2, Param3)     Description
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-0    ACTION_T_NONE                          No Action                       Does nothing.
-1    ACTION_T_TEXT - deprecated use 54      -TextId1, -TextId2, -TextId3    Displays the specified -TextId. When -TextId2 and -TextId3 are specified, the selection will be Randomized between 1,2 or 3. Text ID's are defined, along with other options for the text, in creature_ai_texts table. Below is detailed Text Information. All text ID values for EventAI MUST be negative.
-2    ACTION_T_SET_FACTION                   FactionId, Flags              Changes faction for a creature. When param1 is zero, creature will revert to it's default faction. Flags will determine when faction is restored to default (evade, respawn etc)
-3    ACTION_T_MORPH_TO_ENTRY_OR_MODEL       CreatureEntry, ModelId          Sets either model from creature_template.entry (Param1) OR explicit modelId (Param2) for the NPC. If (Param1) AND (Param2) are both 0, NPC will demorph and revert to the default model (as specified in creature_template).
-4    ACTION_T_SOUND                         SoundId                         NPC Plays a specified Sound ID.
-5    ACTION_T_EMOTE                         EmoteId                         NPC Does a specified Emote ID.
-6    UNUSED                                 UNUSED                          UNUSED
-7    UNUSED                                 UNUSED                          UNUSED
-8    UNUSED                                 UNUSED                          UNUSED
-9    ACTION_T_RANDOM_SOUND                  SoundId1, SoundId2, SoundId3    NPC Plays a Random Sound ID (Random Selects Param1, Param2 or Param3) *
-10   ACTION_T_RANDOM_EMOTE                  EmoteId1, EmoteId2, EmoteId3    NPC Emotes a Random Emote ID (Random Selects Param1, Param2 or Param3) *
-11   ACTION_T_CAST                          SpellId, Target, CastFlags      Casts spell (Param1) on a target (Param2) using cast flags (Param3) --> Specified Below
-12   ACTION_T_SPAWN                         CreatureID, Target, Duration    Summons a Creature ID (Param1) for (Param3) duration after Evade (In MS) and orders it to attack (Param2) target (specified below). Spawns on top of NPC who summons it.
-13   ACTION_T_THREAT_SINGLE_PCT             Threat%, Target                 Modifies a threat by (Param1) percent on a target (Param2).
-14   ACTION_T_THREAT_ALL_PCT                Threat%                         Modifies a threat by (Param1) on all targets in the threat list (using -100% here will result in full aggro dump).
-15   ACTION_T_QUEST_EVENT                   QuestID, Target, RewardGroup    Calls AreaExploredOrEventHappens with (Param1) for a target in (Param2). Param3 decides if award entire group (1 = yes, 0 = no).
-16   ACTION_T_QUEST_CASTCREATUREGO          CreatureID, SpellId, Target     Sends CastCreatureOrGo for a creature specified by CreatureId (Param1) with provided spell id (Param2) for a target in (Param3).
-17   ACTION_T_SET_UNIT_FIELD                Field_Number, Value, Target     Sets a unit field (Param1) to provided value (Param2) on a target in (Param3).
-18   ACTION_T_SET_UNIT_FLAG                 Flags, Target                   Sets flag (flags can be used together to modify multiple flags at once) on a target (Param2).
-19   ACTION_T_REMOVE_UNIT_FLAG              Flags, Target                   Removes flag on a target (Param2).
-20   ACTION_T_AUTO_ATTACK                   AllowAutoAttack                 Stop melee attack when (Param1) is zero, otherwise continue attacking / allow melee attack.
-21   ACTION_T_COMBAT_MOVEMENT               AllowCombatMovement             Stop combat based movement when (Param1) is zero, otherwise continue/allow combat based movement (targeted movement generator).
-22   ACTION_T_SET_PHASE                     Phase                           Sets the current phase to (Param1).
-23   ACTION_T_INC_PHASE                     Value                           Increments the phase by (Param1). May be negative to decrement, but should not be zero.
-24   ACTION_T_EVADE                         No Params                       Forces the creature to evade, wiping all threat and dropping combat.
-25   ACTION_T_FLEE_FOR_ASSIST               No Params                       Causes the creature to flee for assistence (often at low health).
-26   ACTION_T_QUEST_EVENT_ALL               QuestId, UseThreatList          Calls GroupEventHappens with (Param1). Only used if it's _expected_ event should call quest completion for all players in a current party. Can be used for the creature's threat list, for complex scripted events.
-27   ACTION_T_CASTCREATUREGO_ALL            QuestId, SpellId                Calls CastedCreatureOrGo for all players on the threat list with quest id specified in (Param1) and spell id in (Param2).
-28   ACTION_T_REMOVEAURASFROMSPELL          Target, Spellid                 Removes all auras on a target (Param1) caused by a spell (Param2).
-29   ACTION_T_RANGED_MOVEMENT               Distance, Angle                 Changes the movement generator to a ranged type. (note: default melee type can still be set by using 0 as angle and 0 as distance).
-30   ACTION_T_RANDOM_PHASE                  PhaseId1, PhaseId2, PhaseId3    Sets a phase to a specified id(s)*
-31   ACTION_T_RANDOM_PHASE_RANGE            PhaseMin, PhaseMax              Sets a phase to a random id (Phase = PhaseMin + rnd % PhaseMin-PhaseMax). PhaseMax must be greater than PhaseMin.
-32   ACTION_T_SUMMON_ID                     CreatureID, Target, SummonID    Summons a creature (Param1) to attack target (Param2) at location specified by EventAI_Summons (Param3).
-33   ACTION_T_KILLED_MONSTER                CreatureID, Target              Calls KilledMonster (Param1) for a target (Param2).
-34   ACTION_T_SET_INST_DATA                 Field, Data                     Calls ScriptedInstance::SetData with field (Param1) and data (Param2).
-35   ACTION_T_SET_INST_DATA64               Field, Target                   Calls ScriptedInstance::SetData64 with field (Param1) and target's GUID (Param2).
-36   ACTION_T_UPDATE_TEMPLATE               TemplateId, Team                Changes a creature's template to (Param1) with team = Alliance or Horde when (Param2) is either false or true respectively.
-37   ACTION_T_DIE                           No Params                       Kills the creature
-38   ACTION_T_ZONE_COMBAT_PULSE             No Params                       Puts all players within an instance into combat with the creature. Only works when a creature is already in combat. Doesn't work outside instances.
-39   ACTION_T_CALL_FOR_HELP                 Radius                          Call any friendly out-of-combat creatures in a radius (Param1) to attack current creature's target.
-40   ACTION_T_SET_SHEATH                    Sheath                          Sets sheath state for a creature (0 = no weapon, 1 = melee weapon, 2 = ranged weapon).
-41   ACTION_T_FORCE_DESPAWN                 Delay                           Despawns the creature, if delay = 0 immediate otherwise will despawn after delay time set in Param1 (in ms).
-42   ACTION_T_SET_INVINCIBILITY_HP_LEVEL    HP_Level, HP_Percent            Set min. health level for creature that can be set at damage as flat value or percent from max health
-43   ACTION_T_MOUNT_TO_ENTRY_OR_MODEL       CreatureEntry, ModelId          Set mount model from creature_template.entry (Param1) OR explicit modelId (Param2). If (Param1) AND (Param2) are both 0, unmount.
-44   ACTION_T_CHANCED_TEXT  - deprecated use 54 Chance, -TextId1, -TextId2      Displays by Chance (1..100) the specified -TextId. When -TextId2 is specified, the selection will be randomized. Text types are defined, along with other options for the text, in a table below. Param2 and Param3 needs to be negative.
-45   ACTION_T_THROW_AI_EVENT                EventType, Radius, Target       Throws an AIEvent of type (Param1) to nearby friendly Npcs in range of (Param2), Invoker of event is Target
-46   ACTION_T_SET_THROW_MASK                EventTypeMask                   Marks for which AIEvents the npc will throw AIEvents on its own.
-47   ACTION_T_SET_STAND_STATE               StandState                      Set the unit stand state (Param1) of the current creature.
-48   ACTION_T_CHANGE_MOVEMENT               MovementType, WanderDistance    Change the unit movement type (Param1). If the movement type is Random Movement (1), the WanderDistance (Param2) must be provided. If the movement type is Waypoint Movement (2), Param2 is PathId.
-49   ACTION_T_DYNAMIC_MOVEMENT              EnableDynamicMovement           Enable dynamic movement behavior (1 = on; 0 = off)
-50   ACTION_T_SET_REACT_STATE               ReactState                      Change react state of the creature
-51   ACTION_T_PAUSE_WAYPOINTS               DoPause                         Pause waypoints of creature
-52   ACTION_T_INTERRUPT_SPELL               SpellType - CurrentSpellTypes   Interrupt spell in given slot for creature
-53   ACTION_T_START_RELAY_SCRIPT            RelayIDorTemplate, Target       Launches dbscripts_on_relay script, either static one, or when param1 is < 0 then random one chosen from dbscript_random_templates
-54   ACTION_T_TEXT_NEW                      TextId, Target, TemplateId      Displays text, either static one or when param3 != 0, then random one chosen from dbscript_random_templates
-55   ACTION_T_ATTACK_START                  Target                          Attacks targeted creature
-56   ACTION_T_DESPAWN_GUARDIANS             EntryId                         Despawns guardian with specified entry, or if 0 despawns all guardians
+0   ACTION_T_NONE                           No Action                           Does nothing.
+1   ACTION_T_TEXT                           -TextId1, -TextId2, -TextId3        Displays the specified -TextId. When -TextId2 and -TextId3 are specified, the selection will be Randomized between 1,2 or 3. Text ID's are defined, along with other options for the text, in creature_ai_texts table. Below is detailed Text Information. All text ID values for EventAI MUST be negative.
+2   ACTION_T_SET_FACTION                    FactionId, Flags                    Changes faction for a creature. When param1 is zero, creature will revert to it's default faction. Flags will determine when faction is restored to default (evade, respawn etc)
+3   ACTION_T_MORPH_TO_ENTRY_OR_MODEL        CreatureEntry, ModelId              Sets either model from creature_template.entry (Param1) OR explicit modelId (Param2) for the NPC. If (Param1) AND (Param2) are both 0, NPC will demorph and revert to the default model (as specified in creature_template).
+4   ACTION_T_SOUND                          SoundId                             NPC Plays a specified Sound ID.
+5   ACTION_T_EMOTE                          EmoteId                             NPC Does a specified Emote ID.
+6   UNUSED                                  UNUSED                              UNUSED
+7   UNUSED                                  UNUSED                              UNUSED
+8   UNUSED                                  UNUSED                              UNUSED
+9   ACTION_T_RANDOM_SOUND                   SoundId1*, SoundId2*, SoundId3*     NPC Plays a Random Sound ID (Random Selects Param1, Param2 or Param3)
+10  ACTION_T_RANDOM_EMOTE                   EmoteId1*, EmoteId2*, EmoteId3*     NPC Emotes a Random Emote ID (Random Selects Param1, Param2 or Param3)
+11  ACTION_T_CAST                           SpellId, Target, CastFlags          Casts spell (Param1) on a target (Param2) using cast flags (Param3) --> Specified Below
+12  ACTION_T_SPAWN                          CreatureID, Target, Duration        Summons a Creature ID (Param1) for (Param3) duration after Evade (In MS) and orders it to attack (Param2) target (specified below). Spawns on top of NPC who summons it.
+13  ACTION_T_THREAT_SINGLE_PCT              Threat%, Target                     Modifies a threat by (Param1) percent on a target (Param2).
+14  ACTION_T_THREAT_ALL_PCT                 Threat%                             Modifies a threat by (Param1) on all targets in the threat list (using -100% here will result in full aggro dump).
+15  ACTION_T_QUEST_EVENT                    QuestID, Target, RewardGroup        Calls AreaExploredOrEventHappens with (Param1) for a target in (Param2). Param3 decides if award entire group (1 = yes, 0 = no).
+16  ACTION_T_QUEST_CASTCREATUREGO           CreatureID, SpellId, Target         Sends CastCreatureOrGo for a creature specified by CreatureId (Param1) with provided spell id (Param2) for a target in (Param3).
+17  ACTION_T_SET_UNIT_FIELD                 Field_Number, Value, Target         Sets a unit field (Param1) to provided value (Param2) on a target in (Param3).
+18  ACTION_T_SET_UNIT_FLAG                  Flags, Target                       Sets flag (flags can be used together to modify multiple flags at once) on a target (Param2).
+19  ACTION_T_REMOVE_UNIT_FLAG               Flags, Target                       Removes flag on a target (Param2).
+20  ACTION_T_AUTO_ATTACK                    AllowAutoAttack                     Stop melee attack when (Param1) is zero, otherwise continue attacking / allow melee attack.
+21  ACTION_T_COMBAT_MOVEMENT                AllowCombatMovement                 Stop combat based movement when (Param1) is zero, otherwise continue/allow combat based movement (targeted movement generator).
+22  ACTION_T_SET_PHASE                      Phase                               Sets the current phase to (Param1).
+23  ACTION_T_INC_PHASE                      Value                               Increments the phase by (Param1). May be negative to decrement, but should not be zero.
+24  ACTION_T_EVADE                          No Params                           Forces the creature to evade, wiping all threat and dropping combat.
+25  ACTION_T_FLEE_FOR_ASSIST                No Params                           Causes the creature to flee for assistence (often at low health).
+26  ACTION_T_QUEST_EVENT_ALL                QuestId, UseThreatList              Calls GroupEventHappens with (Param1). Only used if it's _expected_ event should call quest completion for all players in a current party. Can be used for the creature's threat list, for complex scripted events.
+27  ACTION_T_CASTCREATUREGO_ALL             QuestId, SpellId                    Calls CastedCreatureOrGo for all players on the threat list with quest id specified in (Param1) and spell id in (Param2).
+28  ACTION_T_REMOVEAURASFROMSPELL           Target, Spellid                     Removes all auras on a target (Param1) caused by a spell (Param2).
+29  ACTION_T_RANGED_MOVEMENT                Distance, Angle                     Changes the movement generator to a ranged type. (note: default melee type can still be set by using 0 as angle and 0 as distance).
+30  ACTION_T_RANDOM_PHASE                   PhaseId1*, PhaseId2*, PhaseId3*     Sets a phase to a specified id(s)
+31  ACTION_T_RANDOM_PHASE_RANGE             PhaseMin, PhaseMax                  Sets a phase to a random id (Phase = PhaseMin + rnd % PhaseMin-PhaseMax). PhaseMax must be greater than PhaseMin.
+32  ACTION_T_SUMMON_ID                      CreatureID, Target, SummonID        Summons a creature (Param1) to attack target (Param2) at location specified by EventAI_Summons (Param3).
+33  ACTION_T_KILLED_MONSTER                 CreatureID, Target                  Calls KilledMonster (Param1) for a target (Param2).
+34  ACTION_T_SET_INST_DATA                  Field, Data                         Calls ScriptedInstance::SetData with field (Param1) and data (Param2).
+35  ACTION_T_SET_INST_DATA64                Field, Target                       Calls ScriptedInstance::SetData64 with field (Param1) and target's GUID (Param2).
+36  ACTION_T_UPDATE_TEMPLATE                TemplateId, Team                    Changes a creature's template to (Param1) with team = Alliance or Horde when (Param2) is either false or true respectively.
+37  ACTION_T_DIE                            No Params                           Kills the creature
+38  ACTION_T_ZONE_COMBAT_PULSE              No Params                           Puts all players within an instance into combat with the creature. Only works when a creature is already in combat. Doesn't work outside instances.
+39  ACTION_T_CALL_FOR_HELP                  Radius                              Call any friendly out-of-combat creatures in a radius (Param1) to attack current creature's target.
+40  ACTION_T_SET_SHEATH                     Sheath                              Sets sheath state for a creature (0 = no weapon, 1 = melee weapon, 2 = ranged weapon).
+41  ACTION_T_FORCE_DESPAWN                  Delay                               Despawns the creature, if delay = 0 immediate otherwise will despawn after delay time set in Param1 (in ms).
+42  ACTION_T_SET_INVINCIBILITY_HP_LEVEL     HP_Level, HP_Percent                Set min. health level for creature that can be set at damage as flat value or percent from max health
+43  ACTION_T_MOUNT_TO_ENTRY_OR_MODEL        CreatureEntry, ModelId              Set mount model from creature_template.entry (Param1) OR explicit modelId (Param2). If (Param1) AND (Param2) are both 0, unmount.
+44  ACTION_T_CHANCED_TEXT                   Chance, -TextId1, -TextId2          Deprecated use 54 - Displays by Chance (1..100) the specified -TextId. When -TextId2 is specified, the selection will be randomized. Text types are defined, along with other options for the text, in a table below. Param2 and Param3 needs to be negative.
+45  ACTION_T_THROW_AI_EVENT                 EventType, Radius, Target           Throws an AIEvent of type (Param1) to nearby friendly Npcs in range of (Param2), Invoker of event is Target
+46  ACTION_T_SET_THROW_MASK                 EventTypeMask                       Marks for which AIEvents the npc will throw AIEvents on its own.
+47  ACTION_T_SET_STAND_STATE                StandState                          Set the unit stand state (Param1) of the current creature.
+48  ACTION_T_CHANGE_MOVEMENT                MovementType, WanderDistance        Change the unit movement type (Param1). If the movement type is Random Movement (1), the WanderDistance (Param2) must be provided. If the movement type is Waypoint Movement (2), Param2 is PathId.
+49  ACTION_T_DYNAMIC_MOVEMENT               EnableDynamicMovement               Deprecated use 57 - Enable dynamic movement behavior (1 = on; 0 = off)
+50  ACTION_T_SET_REACT_STATE                ReactState                          Change react state of the creature
+51  ACTION_T_PAUSE_WAYPOINTS                DoPause                             Pause waypoints of creature
+52  ACTION_T_INTERRUPT_SPELL                SpellType - CurrentSpellTypes       Interrupt spell in given slot for creature
+53  ACTION_T_START_RELAY_SCRIPT             RelayIDorTemplate, Target           Launches dbscripts_on_relay script, either static one, or when param1 is < 0 then random one chosen from dbscript_random_templates
+54  ACTION_T_TEXT_NEW                       TextId, Target, TemplateId          Displays text, either static one or when param3 != 0, then random one chosen from dbscript_random_templates
+55  ACTION_T_ATTACK_START                   Target                              Attacks targeted creature
+56  ACTION_T_DESPAWN_GUARDIANS              EntryId                             Despawns guardian with specified entry, or if 0 despawns all guardians
+57  ACTION_T_SET_RANGED_MODE                RangeModeType,chaseDistance         Enables RangeModeType AI (0 off, 1 = caster, 2 = hunter), distance to chase at                
 
 * = Use -1 where the param is expected to do nothing. Random constant is generated for each event, so if you have a random yell and a random sound, they will be linked up with each other (ie. param2 with param2).
-
 
 ==============================================
 Event Types: Expanded and Detailed Information
 ==============================================
+
 Note:
 COMBAT ONLY - Means that this event will only trigger durring combat.
 OUT OF COMBAT ONLY - Means that this event will only trigger while out of combat.
@@ -183,8 +187,8 @@ Events that do not have lables on them are events that are directly involved wit
 ------------------
 Parameter 1: InitialMin - Minumum Time used to calculate Random Initial Expire
 Parameter 2: InitialMax - Maximum Time used to calculate Random Initial Expire
-Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Expire
-Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Expire
+Parameter 3: RepeatMin  - Minimum Time used to calculate Random Repeat Expire
+Parameter 4: RepeatMax  - Maximum Time used to calculate Random Repeat Expire
 
 COMBAT ONLY - Expires first between (Param1) and (Param2) and then between every (Param3) and (Param4) from then on.
 This is commonly used for spells that repeat cast during combat (Simulates Spell Cooldown).
@@ -192,10 +196,10 @@ This is commonly used for spells that repeat cast during combat (Simulates Spell
 ----------------------
 1 = EVENT_T_TIMER_OOC:
 ----------------------
-Parameter 1: InitialMin - Minimum Time used to calculate Random Initial Event Expire
-Parameter 2: InitialMax - Maximum Time used to calculate Random Initial Event Expire
-Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Event Expire
-Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Event Expire
+Parameter 1: InitialMin	- Minimum Time used to calculate Random Initial Event Expire
+Parameter 2: InitialMax	- Maximum Time used to calculate Random Initial Event Expire
+Parameter 3: RepeatMin	- Minimum Time used to calculate Random Repeat Event Expire
+Parameter 4: RepeatMax	- Maximum Time used to calculate Random Repeat Event Expire
 
 OUT OF COMBAT ONLY (Not while evading) - Expires first between (Param1) and (Param2) and then between every (Param3) and (Param4) from then on.
 This is commonly used for events that occur and repeat outside of combat like random NPC Say or Random Emotes.
@@ -203,8 +207,8 @@ This is commonly used for events that occur and repeat outside of combat like ra
 ---------------
 2 = EVENT_T_HP:
 ---------------
-Parameter 1: HPMax% - Maximum HP% That will trigger this Event to Expire
-Parameter 2: HPMin% - Minimum HP% That will trigger this Event to Expire
+Parameter 1: HPMax%    - Maximum HP% That will trigger this Event to Expire
+Parameter 2: HPMin%    - Minimum HP% That will trigger this Event to Expire
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Event Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Event Expire
 
@@ -215,8 +219,8 @@ NOTE: For Repeat Events the Repeat Timer ONLY Re-Check's Event Conditions to see
 -----------------
 3 = EVENT_T_MANA:
 -----------------
-Parameter 1: ManaMax% - Maximum Mana% That will trigger this Event to Expire
-Parameter 2: ManaMin% - Minimum Mana% That will trigger this Event to Expire
+Parameter 1: ManaMax%  - Maximum Mana% That will trigger this Event to Expire
+Parameter 2: ManaMin%  - Minimum Mana% That will trigger this Event to Expire
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Event Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Event Expire
 
@@ -255,8 +259,8 @@ This is commonly used for NPC's who use phases, allows you to reset their phase 
 ---------------------
 8 = EVENT_T_SPELLHIT:
 ---------------------
-Parameter 1: SpellID - The Spell ID that will trigger the Event to occur (NOTE: If you use Spell School as the trigger ALWAYS set this value to 0)
-Parameter 2: School - Spell School to trigger the Event (NOTE: If you use a SpellID then ALWAYS set this value to -1) - *See Below for Spell School Bitmask Values*
+Parameter 1: SpellID   - The Spell ID that will trigger the Event to occur (NOTE: If you use Spell School as the trigger ALWAYS set this value to 0)
+Parameter 2: School    - Spell School to trigger the Event (NOTE: If you use a SpellID then ALWAYS set this value to -1) - *See Below for Spell School Bitmask Values*
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Event Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Event Expire
 
@@ -278,8 +282,8 @@ Use These Bitmask Values For Schoolmask (Param2) or Any Combinations Of These Sc
 ------------------
 9 = EVENT_T_RANGE:
 ------------------
-Parameter 1: MinDist - This Distance is the Minimum Distance between the NPC and its target to allow this Event to Expire
-Parameter 2: MaxDist - This Distance is the Maximum Distance between the NPC and its target to allow this Event to Expire
+Parameter 1: MinDist   - This Distance is the Minimum Distance between the NPC and its target to allow this Event to Expire
+Parameter 2: MaxDist   - This Distance is the Maximum Distance between the NPC and its target to allow this Event to Expire
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Event Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Event Expire
 
@@ -289,10 +293,10 @@ This Event is commonly used for NPC's who have Ranged Combat and will Throw/Shoo
 ---------------------
 10 = EVENT_T_OOC_LOS:
 ---------------------
-Parameter 1: Hostile-or-Not   - This will expire if Unit are hostile. If Param1=1 it will only expire if Unit are not Hostile(generally determined by faction)
-Parameter 2: MaxAllowedRange  - Expires when a Unit moves within this distance to creature
-Parameter 3: RepeatMin        - Minimum Time used to calculate Random Repeat Expire
-Parameter 4: RepeatMax        - Maximum Time used to calculate Random Repeat Expire
+Parameter 1: Hostile-or-Not  - This will expire if Unit are hostile. If Param1=1 it will only expire if Unit are not Hostile(generally determined by faction)
+Parameter 2: MaxAllowedRange - Expires when a Unit moves within this distance to creature
+Parameter 3: RepeatMin       - Minimum Time used to calculate Random Repeat Expire
+Parameter 4: RepeatMax       - Maximum Time used to calculate Random Repeat Expire
 
 OUT OF COMBAT ONLY
 This Event is commonly used for NPC's who do something or say something to you when you walk past them Out of Combat.
@@ -311,8 +315,8 @@ This Event is commonly used for NPC's who cast a spell or do something special w
 -----------------------
 12 = EVENT_T_TARGET_HP:
 -----------------------
-Parameter 1: HPMax% - Maximum HP% That this Event will Expire
-Parameter 2: HPMin% - Minimum HP% That this Event will Expire
+Parameter 1: HPMax%    - Maximum HP% That this Event will Expire
+Parameter 2: HPMin%    - Minimum HP% That this Event will Expire
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Expire
 
@@ -332,7 +336,7 @@ This event is commonly used for NPC's who will cast a counter spell when their t
 14 = EVENT_T_FRIENDLY_HP:
 -------------------------
 Parameter 1: HPDeficit - This is the Amount of HP Missing from Full HP to trigger this event (You would need to calculate the amount of HP the event happens and subtract that from Full HP Value to get this number)
-Parameter 2: Radius - This is the Range in Yards the NPC will scan for nearby Friendlies (Faction is Friendly To) for the missing amount of HP in Param1.
+Parameter 2: Radius    - This is the Range in Yards the NPC will scan for nearby Friendlies (Faction is Friendly To) for the missing amount of HP in Param1.
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Expire
 
@@ -343,9 +347,9 @@ This is commonly used when an NPC in Combat will heal a nearby Friendly NPC in C
 15 = EVENT_T_FRIENDLY_IS_CC:
 ----------------------------
 Parameter 1: DispelType - Dispel Type to trigger the event - *See Below for Dispel Bitmask Values*
-Parameter 2: Radius - This is the Range in Yards the NPC will scan for nearby Friendlies being Crowd Controlled
-Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Expire
-Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Expire
+Parameter 2: Radius     - This is the Range in Yards the NPC will scan for nearby Friendlies being Crowd Controlled
+Parameter 3: RepeatMin  - Minimum Time used to calculate Random Repeat Expire
+Parameter 4: RepeatMax  - Maximum Time used to calculate Random Repeat Expire
 
 COMBAT ONLY - Expires when a friendly unit is Crowd controlled within the given radius (param2). Will repeat every (Param3) and (Param4).
 This is commonly used for NPC's who can come to the resule of other Friendly NPC's if being Crowd Controlled
@@ -353,8 +357,8 @@ This is commonly used for NPC's who can come to the resule of other Friendly NPC
 -----------------------------------
 16 = EVENT_T_FRIENDLY_MISSING_BUFF:
 -----------------------------------
-Parameter 1: SpellId - This is the SpellID That the Aura Check will look for (If it is missing this Aura)
-Parameter 2: Radius - This is the Range in Yards the NPC will scan for nearby Friendlies (Faction is Friendly To) for the missing Aura.
+Parameter 1: SpellId   - This is the SpellID That the Aura Check will look for (If it is missing this Aura)
+Parameter 2: Radius    - This is the Range in Yards the NPC will scan for nearby Friendlies (Faction is Friendly To) for the missing Aura.
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Expire
 
@@ -365,8 +369,8 @@ This is commonly used for NPC's who watch friendly units for a debuff to end so 
 17 = EVENT_T_SUMMONED_UNIT:
 ---------------------------
 Parameter 1: CreatureId - The CreatureID that the NPC is watching to spawn to trigger this event
-Parameter 2: RepeatMin - Minimum Time used to calculate Random Repeat Expire
-Parameter 3: RepeatMax - Maximum Time used to calculate Random Repeat Expire
+Parameter 2: RepeatMin  - Minimum Time used to calculate Random Repeat Expire
+Parameter 3: RepeatMax  - Maximum Time used to calculate Random Repeat Expire
 
 BOTH - Expires after creature with entry(Param1) is spawned or for all spawns if param1 = 0. Will repeat every (Param2) and (Param3) .
 This is commonly used for NPC's who will do something special once another NPC is summoned. Usually used is Complex Scripts or Special Events.
@@ -374,8 +378,8 @@ This is commonly used for NPC's who will do something special once another NPC i
 ---------------------------
 18 = EVENT_T_TARGET_MANA:
 ---------------------------
-Parameter 1: ManaMax% - Maximum Mana% That will trigger this Event to Expire
-Parameter 2: ManaMin% - Minimum Mana% That will trigger this Event to Expire
+Parameter 1: ManaMax%  - Maximum Mana% That will trigger this Event to Expire
+Parameter 2: ManaMin%  - Minimum Mana% That will trigger this Event to Expire
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Expire
 
@@ -390,8 +394,8 @@ Most commonly used to cast spells that can not be casted in EVENT_T_EVADE and ot
 ---------------------------
 22 = EVENT_T_RECEIVE_EMOTE:
 ---------------------------
-Parameter 1: EmoteId - Valid text emote ID from Mangos source (SharedDefines.h - enum TextEmotes)
-Parameter 2: Condition - Conditions based on <MaNGOS>/src/game/ObjectMgr.h - enum ConditionType
+Parameter 1: EmoteId    - Valid text emote ID from Mangos source (SharedDefines.h - enum TextEmotes)
+Parameter 2: Condition  - Conditions based on <MaNGOS>/src/game/ObjectMgr.h - enum ConditionType
 Parameter 3: CondValue1 -
 Parameter 4: CondValue2 -
 
@@ -401,8 +405,8 @@ Event does not require any conditions to process, however many are expected to h
 ---------------------------
 23 = EVENT_T_AURA         :
 ---------------------------
-Parameter 1: SpellId - This is the SpellID That the Aura Check will look for
-Parameter 2: Amount -  This is the amount of SpellID's auras at creature required for event expire.
+Parameter 1: SpellId   - This is the SpellID That the Aura Check will look for
+Parameter 2: Amount    - This is the amount of SpellID's auras at creature required for event expire.
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Expire
 
@@ -411,8 +415,8 @@ BOTH - Expires when a creature has spell (Param1) auras applied in a stack great
 ---------------------------
 24 = EVENT_T_TARGET_AURA:
 ---------------------------
-Parameter 1: SpellId - This is the SpellID That the Aura Check will look for
-Parameter 2: Amount -  This is the amount of SpellID's auras at target unit required for event expire.
+Parameter 1: SpellId   - This is the SpellID That the Aura Check will look for
+Parameter 2: Amount    - This is the amount of SpellID's auras at target unit required for event expire.
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Expire
 
@@ -422,8 +426,8 @@ COMBAT ONLY - Expires when a target unit has spell (Param1) auras applied in a s
 25 = EVENT_T_SUMMONED_JUST_DIED:
 --------------------------------
 Parameter 1: CreatureId - The CreatureID that the NPC is watching die to trigger this event
-Parameter 2: RepeatMin - Minimum Time used to calculate Random Repeat Expire
-Parameter 3: RepeatMax - Maximum Time used to calculate Random Repeat Expire
+Parameter 2: RepeatMin  - Minimum Time used to calculate Random Repeat Expire
+Parameter 3: RepeatMax  - Maximum Time used to calculate Random Repeat Expire
 
 BOTH - Expires after creature with entry(Param1) is die or for all spawns if param1 = 0. Will repeat every (Param2) and (Param3) .
 This is commonly used for NPC's who will do something special once another NPC is die. Usually used is Complex Scripts or Special Events.
@@ -432,8 +436,8 @@ This is commonly used for NPC's who will do something special once another NPC i
 26 = EVENT_T_SUMMONED_JUST_DESPAWN:
 -----------------------------------
 Parameter 1: CreatureId - The CreatureID that the NPC is watching despawn to trigger this event
-Parameter 2: RepeatMin - Minimum Time used to calculate Random Repeat Expire
-Parameter 3: RepeatMax - Maximum Time used to calculate Random Repeat Expire
+Parameter 2: RepeatMin  - Minimum Time used to calculate Random Repeat Expire
+Parameter 3: RepeatMax  - Maximum Time used to calculate Random Repeat Expire
 
 BOTH - Expires before creature with entry(Param1) is despawned or for all spawns if param1 = 0. Will repeat every (Param2) and (Param3) .
 This is commonly used for NPC's who will do something special once another NPC is despawn. Usually used is Complex Scripts or Special Events.
@@ -442,8 +446,8 @@ NOTE: Called before despawn happens, so summoned creature is still in world at e
 --------------------------
 27 = EVENT_T_MISSING_BUFF:
 --------------------------
-Parameter 1: SpellId - This is the SpellID That the Aura Check will look for to be missing
-Parameter 2: Amount -  This is the amount or less of SpellID's auras at creature required for event expire.
+Parameter 1: SpellId   - This is the SpellID That the Aura Check will look for to be missing
+Parameter 2: Amount    - This is the amount or less of SpellID's auras at creature required for event expire.
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Expire
 
@@ -452,8 +456,8 @@ BOTH - Expires when a creature not has spell (Param1) auras applied in a stack g
 ---------------------------------
 28 = EVENT_T_TARGET_MISSING_AURA:
 ---------------------------------
-Parameter 1: SpellId - This is the SpellID That the Aura Check will look for to be missing
-Parameter 2: Amount -  This is the amount or less of SpellID's auras at creature required for event expire.
+Parameter 1: SpellId   - This is the SpellID That the Aura Check will look for to be missing
+Parameter 2: Amount    - This is the amount or less of SpellID's auras at creature required for event expire.
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Expire
 
@@ -464,8 +468,8 @@ COMBAT ONLY - Expires when a target unit not has spell (Param1) auras applied in
 ---------------------------
 Parameter 1: InitialMin - Minumum Time used to calculate Random Initial Expire
 Parameter 2: InitialMax - Maximum Time used to calculate Random Initial Expire
-Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Expire
-Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Expire
+Parameter 3: RepeatMin  - Minimum Time used to calculate Random Repeat Expire
+Parameter 4: RepeatMax  - Maximum Time used to calculate Random Repeat Expire
 
 BOTH - Expires first between (Param1) and (Param2) and then between every (Param3) and (Param4) from then on.
 
@@ -483,8 +487,8 @@ Note: This is the only EVENT where the target-type TARGET_T_EVENT_SENDER (10) is
 -----------------
 Parameter 1: EnergyMax% - Maximum Energy% That will trigger this Event to Expire
 Parameter 2: EnergyMin% - Minimum Energy% That will trigger this Event to Expire
-Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Event Expire
-Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Event Expire
+Parameter 3: RepeatMin  - Minimum Time used to calculate Random Repeat Event Expire
+Parameter 4: RepeatMax  - Maximum Time used to calculate Random Repeat Event Expire
 
 COMBAT ONLY - Expires once Energy% is between (Param1) and (Param2). Will repeat every (Param3) and (Param4).
 This is commonly used for events where an NPC low on Energy will do something (Such as stop casting spells and switch to melee).
@@ -492,21 +496,22 @@ This is commonly used for events where an NPC low on Energy will do something (S
 -------------------------------------
 32 = EVENT_T_SELECT_ATTACKING_TARGET:
 -------------------------------------
-Parameter 1: MinDist - This Distance is the Minimum Distance between the NPC and any hostile target to allow this Event to Expire
-Parameter 2: MaxDist - This Distance is the Maximum Distance between the NPC and any hostile target to allow this Event to Expire
+Parameter 1: MinDist   - This Distance is the Minimum Distance between the NPC and any hostile target to allow this Event to Expire
+Parameter 2: MaxDist   - This Distance is the Maximum Distance between the NPC and any hostile target to allow this Event to Expire
 Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Event Expire
 Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Event Expire
 
 COMBAT ONLY - Expires when a random hostile target is found in a distance greater than (Param1) and less than (Param2). Will repeat every (Param3) and (Param4).
 Note: This event will fill TARGET_T_EVENT_SPECIFIC with the target found
+Deprecated - Issue with timers expiring when cast did not succeed is solved now and no need for this event
 
 ---------------------------
 33 = EVENT_T_FACING_TARGET:
 ---------------------------
 Parameter 1: BackOrFront - Define is the NPC must be in back (Parameter 1=0) or in front (Parameter 1=1) or its current target.
 Parameter 2: Unused
-Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Event Expire
-Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Event Expire
+Parameter 3: RepeatMin   - Minimum Time used to calculate Random Repeat Event Expire
+Parameter 4: RepeatMax   - Maximum Time used to calculate Random Repeat Event Expire
 
 COMBAT ONLY - Expires when the NPC is facing the back (or front) of its current target. Will repeat every (Param3) and (Param4).
 This is commonly used for events where a NPC needs to use abilities available only when facing its target's back/front (Such as rogues' backstab ability).
@@ -598,8 +603,8 @@ Similar to the ACTION_T_EMOTE action, it will choose at random an Emote to Visua
 -------------------
 11 = ACTION_T_CAST:
 -------------------
-Parameter 1: SpellId - The Spell ID to use for the NPC to cast. The value used in this field needs to be a valid Spell ID.
-Parameter 2: Target - The Target Type defining who the creature should cast the spell at. The value in this field needs to be a valid Target Type as specified in the reference tables below.
+Parameter 1: SpellId   - The Spell ID to use for the NPC to cast. The value used in this field needs to be a valid Spell ID.
+Parameter 2: Target    - The Target Type defining who the creature should cast the spell at. The value in this field needs to be a valid Target Type as specified in the reference tables below.
 Parameter 3: CastFlags - See Table Below for Cast Flag Bitmask Values. If you are unsure what to set this value at leave it at 0.
 
 The creature will cast a spell specified by a spell ID on a target specified by the target type.
@@ -610,8 +615,8 @@ This is commonly used for NPC's who cast spells.
 12 = ACTION_T_SPAWN:
 ---------------------
 Parameter 1: CreatureID - The Creature Template ID to be Summoned. The value here needs to be a valid Creature Template ID.
-Parameter 2: Target - The Target Type defining who the Summoned creature will attack once spawned. The value in this field needs to be a valid Target Type as specified in the reference tables below.
-Parameter 3: Duration - The duration until the summoned creature should be unsummoned AFTER Combat ends. The value in this field is in milliseconds or 0.
+Parameter 2: Target     - The Target Type defining who the Summoned creature will attack once spawned. The value in this field needs to be a valid Target Type as specified in the reference tables below.
+Parameter 3: Duration   - The duration until the summoned creature should be unsummoned AFTER Combat ends. The value in this field is in milliseconds or 0.
 
 The NPC will Summon another cast flag 0 will work for you treature at the same spot as itself that will attack the specified target.
 NOTE: Almost all Creature Summons have proper Summon Spells that should be used when possible. This Action is a powerful last resort option only to be used if nothing else works.
@@ -625,7 +630,7 @@ NOTE: THIS ONLY WORKS IN COMBAT
 13 = ACTION_T_THREAT_SINGLE_PCT:
 --------------------------------
 Parameter 1: Threat% - Threat percent that should be modified. The value in this field can range from -100 to +100. If it is negative, threat will be taken away and if positive, threat will be added.
-Parameter 2: Target - The Target Type defining on whom the threat change should occur. The value in this field needs to be a valid target type as specified in the reference tables below.
+Parameter 2: Target  - The Target Type defining on whom the threat change should occur. The value in this field needs to be a valid target type as specified in the reference tables below.
 
 This action will modify the threat of a target in the creature's threat list by the specified percent.
 This is commonly used to allow an NPC to adjust the Threat to a single player.
@@ -642,8 +647,8 @@ This is commonly used to allow an NPC to drop threat for all players to zero.
 --------------------------
 15 = ACTION_T_QUEST_EVENT:
 --------------------------
-Parameter 1: QuestID - The Quest Template ID. The value here must be a valid quest template ID. Furthermore, the quest should have SpecialFlags | 2 as it would need to be completed by an external event which is the activation of this action.
-Parameter 2: Target - The Target Type defining whom the quest should be completed for. The value in this field needs to be a valid target type as specified in the reference tables below.
+Parameter 1: QuestID     - The Quest Template ID. The value here must be a valid quest template ID. Furthermore, the quest should have SpecialFlags | 2 as it would need to be completed by an external event which is the activation of this action.
+Parameter 2: Target      - The Target Type defining whom the quest should be completed for. The value in this field needs to be a valid target type as specified in the reference tables below.
 Parameter 3: RewardGroup - Used to decide if entire group should be rewarded (1 = entire group, 0 = single target)
 
 This action will satisfy the external completion requirement for the quest for the specified target defined by the target type.
@@ -654,8 +659,8 @@ This is commonly used for Quests where only ONE player will gain credit for the 
 16 = ACTION_T_CASTCREATUREGO:
 -----------------------------
 Parameter 1: CreatureID - The Creature Template ID to be Summoned. The value here needs to be a valid Creature Template ID.
-Parameter 2: SpellID - The Spell ID to use to simulate the cast. The value used in this field needs to be a valid Spell ID.
-Parameter 3: Target - The Target Type defining whom the quest credit should be given to. The value in this field needs to be a valid target type as specified in the reference tables below.
+Parameter 2: SpellID    - The Spell ID to use to simulate the cast. The value used in this field needs to be a valid Spell ID.
+Parameter 3: Target     - The Target Type defining whom the quest credit should be given to. The value in this field needs to be a valid target type as specified in the reference tables below.
 
 This action will call CastedCreatureOrGO() function for the player. It can be used to give quest credit for casting a spell on the creature.
 This is commonly used for NPC's who have a special requirement to have a Spell cast on them to complete a quest.
@@ -664,15 +669,15 @@ This is commonly used for NPC's who have a special requirement to have a Spell c
 17 = ACTION_T_SET_UNIT_FIELD:
 -----------------------------
 Parameter 1: Field_Number - The index of the Field Number to be changed. Use (http://wiki.udbforums.org/index.php/Character_data) for a list of indeces and what they control. Creatures only contain the OBJECT_FIELD_* and UNIT_FIELD_* fields. They do not contain the PLAYER_FIELD_* fields.
-Parameter 2: Value - The new value to be put in the field.
-Parameter 3: Target - The Target Type defining for whom the unit field should be changed. The value in this field needs to be a valid target type as specified in the reference tables below.
+Parameter 2: Value        - The new value to be put in the field.
+Parameter 3: Target       - The Target Type defining for whom the unit field should be changed. The value in this field needs to be a valid target type as specified in the reference tables below.
 
 When activated, this action can change the target's unit field values. More information on the field value indeces can be found at (http://wiki.udbforums.org/index.php/Character_data)
 
 ----------------------------
 18 = ACTION_T_SET_UNIT_FLAG:
 ----------------------------
-Parameter 1: Flags - The flag(s) to be set. Multiple flags can be set by using bitwise-OR on them (adding them together).
+Parameter 1: Flags  - The flag(s) to be set. Multiple flags can be set by using bitwise-OR on them (adding them together).
 Parameter 2: Target - The Target Type defining for whom the flags should be changed. The value in this field needs to be a valid Target Type as specified in the reference tables below.
 
 When activated, this action changes the target's flags by adding (turning on) more flags. For example, this action can make the creature unattackable/unselectable if the right flags are used.
@@ -680,7 +685,7 @@ When activated, this action changes the target's flags by adding (turning on) mo
 -------------------------------
 19 = ACTION_T_REMOVE_UNIT_FLAG:
 -------------------------------
-Parameter 1: Flags - The flag(s) to be removed. Multiple flags can be set by using bitwise-OR on them (adding them together).
+Parameter 1: Flags  - The flag(s) to be removed. Multiple flags can be set by using bitwise-OR on them (adding them together).
 Parameter 2: Target - The target type defining for whom the flags should be changed. The value in this field needs to be a valid Target Type as specified in the reference tables below.
 
 When activated, this action changes the target's flags by removing (turning off) flags. For example, this action can make the creature normal after it was unattackable/unselectable if the right flags are used.
@@ -739,7 +744,7 @@ NOTE: All Param Values Are 0 for this Action.
 ------------------------------
 26 = ACTION_T_QUEST_EVENT_ALL:
 ------------------------------
-Parameter 1: QuestId - The quest ID to finish for everyone.
+Parameter 1: QuestId       - The quest ID to finish for everyone.
 Parameter 2: UseThreatList - Bool. If set to 1 (true), it will complete the QuestId for all the players in the threat list. If set to 0 (false), it will use the action invoker.
 
 This action does the same thing as the ACTION_T_QUEST_EVENT does but it does it for all players in the creature's threat list.
@@ -757,7 +762,7 @@ NOTE: If a player is not in its threat list for whatever reason, he/she won't re
 -----------------------------------
 28 = ACTION_T_REMOVEAURASFROMSPELL:
 -----------------------------------
-Parameter 1: Target - The target type defining for whom the unit field should be changed. The value in this field needs to be a valid target type as specified in the reference tables below.
+Parameter 1: Target  - The target type defining for whom the unit field should be changed. The value in this field needs to be a valid target type as specified in the reference tables below.
 Parameter 2: SpellId - The spell ID whose auras will be removed.
 
 This action will remove all auras from a specific spell from the target.
@@ -767,7 +772,7 @@ This is commonly used for NPC's who have an OOC Aura that is removed at combat s
 29 = ACTION_T_RANGED_MOVEMENT:
 ------------------------------
 Parameter 1: Distance - The distance the mob should keep between it and its target.
-Parameter 2: Angle - The angle the mob should use.
+Parameter 2: Angle    - The angle the mob should use.
 
 This action changes the movement type generator to ranged type using the specified values for angle and distance.
 NOTE: Specifying zero angle and distance will make it just melee instead.
@@ -800,8 +805,8 @@ This is commonly used for Spellcasting NPC's who on Aggro may select at random a
 32 = ACTION_T_SUMMON_ID:
 ---------------------
 Parameter 1: CreatureID - The creature template ID to be summoned. The value here needs to be a valid creature template ID.
-Parameter 2: Target - The target type defining who the summoned creature will attack. The value in this field needs to be a valid target type as specified in the reference tables below. NOTE: Using target type 0 will cause the summoned creature to not attack anyone.
-Parameter 3: SummonID - The summon ID from the creature_ai_summons table controlling the position (and spawntime) where the summoned mob should be spawned at.
+Parameter 2: Target     - The target type defining who the summoned creature will attack. The value in this field needs to be a valid target type as specified in the reference tables below. NOTE: Using target type 0 will cause the summoned creature to not attack anyone.
+Parameter 3: SummonID   - The summon ID from the creature_ai_summons table controlling the position (and spawntime) where the summoned mob should be spawned at.
 
 Summons creature (param1) to attack target (param2) at location specified by creature_ai_summons (param3).
 NOTE: Param3 Value is the ID Value used for the entry used in creature_ai_summons for this action. You MUST have an creature_ai_summons entry to use this action.
@@ -811,7 +816,7 @@ This is commonly used for NPC's who need to Summon a creature at a specific loca
 33 = ACTION_T_KILLED_MONSTER:
 -----------------------------
 Parameter 1: CreatureID - The creature template ID. The value here must be a valid creature template ID.
-Parameter 2: Target - The target type defining whom the quest kill count should be given to. The value in this field needs to be a valid target type as specified in the reference tables below.
+Parameter 2: Target     - The target type defining whom the quest kill count should be given to. The value in this field needs to be a valid target type as specified in the reference tables below.
 
 When activated, this action will call KilledMonster() function for the player. It can be used to give creature credit for killing a creature. In general if the quest is set to be accompished on different creatures (e.g. "Credit" templates).
 NOTE: It can be ANY creature including certain quest specific triggers
@@ -821,7 +826,7 @@ This is commonly used for giving the player Quest Credits for NPC kills (Many NP
 34 = ACTION_T_SET_INST_DATA:
 ----------------------------
 Parameter 1: Field - The field to change in the instance script. Again, this field needs to be a valid field that has been already defined in the instance's script.
-Parameter 2: Data - The value to put at that field index.
+Parameter 2: Data  - The value to put at that field index.
 
 Sets data for the instance. Note that this will only work when the creature is inside an instantiable zone that has a valid script (ScriptedInstance) assigned.
 This is commonly used to link an EventAI script with a existing Script Library C++ Script. You make make things happen like opening doors on specific events that happen.
@@ -839,7 +844,7 @@ SPECIAL       = 4
 ------------------------------
 35 = ACTION_T_SET_INST_DATA64:
 ------------------------------
-Parameter 1: Field - The field to change in the instance script. Again, this field needs to be a valid field that has been already defined in the instance's script.
+Parameter 1: Field  - The field to change in the instance script. Again, this field needs to be a valid field that has been already defined in the instance's script.
 Parameter 2: Target - The target type to use to get the GUID that will be stored at the field index. The value in this field needs to be a valid target type as specified in the reference tables below.
 
 Sets GUID (64 bits) data for the instance based on the target. Note that this will only work when the creature is inside an instantiable zone that has a valid script (ScriptedInstance) assigned.
@@ -849,7 +854,7 @@ Calls ScriptedInstance::SetData64 with field (param1) and data (param2) target's
 36 = ACTION_T_UPDATE_TEMPLATE:
 ------------------------------
 Parameter 1: TemplateId - The creature template ID. The value here must be a valid creature template ID.
-Parameter 2: Team - Use model_id from team : Alliance(0) or Horde (1).
+Parameter 2: Team       - Use model_id from team : Alliance(0) or Horde (1).
 
 This function temporarily changes creature entry to new entry, display is changed, loot is changed, but AI is not changed. At respawn creature will be reverted to original entry.
 Changes the creature to a new creature template of (param1) with team = Alliance if (param2) = false or Horde if (param2) = true
@@ -928,7 +933,23 @@ Read at bottom for documentation of creature_ai_texts-table.
 -----------------------------
 45 = ACTION_T_THROW_AI_EVENT:
 -----------------------------
+
 Parameter 1: EventType - What AIEvent to throw, supported types see CreatureAI.h enum AIEventType
+
+Currently supported are:
+    AI_EVENT_JUST_DIED          = 0,                        // Sender = Killed Npc, Invoker = Killer
+    AI_EVENT_CRITICAL_HEALTH    = 1,                        // Sender = Hurt Npc, Invoker = DamageDealer - Expected to be sent by 10% health
+    AI_EVENT_LOST_HEALTH        = 2,                        // Sender = Hurt Npc, Invoker = DamageDealer - Expected to be sent by 50% health
+    AI_EVENT_LOST_SOME_HEALTH   = 3,                        // Sender = Hurt Npc, Invoker = DamageDealer - Expected to be sent by 90% health
+    AI_EVENT_GOT_FULL_HEALTH    = 4,                        // Sender = Healed Npc, Invoker = Healer
+    AI_EVENT_CUSTOM_EVENTAI_A   = 5,                        // Sender = Npc that throws custom event, Invoker = TARGET_T_ACTION_INVOKER (if exists)
+    AI_EVENT_CUSTOM_EVENTAI_B   = 6,                        // Sender = Npc that throws custom event, Invoker = TARGET_T_ACTION_INVOKER (if exists)
+    AI_EVENT_GOT_CCED           = 7,                        // Sender = CCed Npc, Invoker = Caster that CCed
+    AI_EVENT_CUSTOM_EVENTAI_C   = 8,                        // Sender = Npc that throws custom event, Invoker = TARGET_T_ACTION_INVOKER (if exists)
+    AI_EVENT_CUSTOM_EVENTAI_D   = 9,                        // Sender = Npc that throws custom event, Invoker = TARGET_T_ACTION_INVOKER (if exists)
+    AI_EVENT_CUSTOM_EVENTAI_E   = 10,                       // Sender = Npc that throws custom event, Invoker = TARGET_T_ACTION_INVOKER (if exists)
+    AI_EVENT_CUSTOM_EVENTAI_F   = 11,                       // Sender = Npc that throws custom event, Invoker = TARGET_T_ACTION_INVOKER (if exists)
+
 Parameter 2: Radius    - Throw the AIEvent to nearby friendly creatures within this range
 Parameter 3: Target    - The thrown AIEvent uses selected target as Invoker
 Each event, be it C++ or DB has 3 parties, Sender, Receiver and Invoker. Sender is EAI creature owner, Receiver is creatures found in radius, and Invoker is the one who triggered the event. Invoker can be specified
@@ -1015,29 +1036,46 @@ Attacks targeted creature. This has particular use when we want to attack specif
 Parameter 1: Entry ID of guardian to be despawned (can also be 0)
 If a given entry is valid and found, despawns guardian with given entry. If parameter 1 is 0, despawns all guardians (which is the more common script action).
 
+--------------------------------
+57 = ACTION_T_SET_RANGED_MODE:
+--------------------------------
+Parameter 1: Type of Ranged Mode - enum RangeModeType
+Parameter 2: Distance at which creature will chase during ranged mode
+Meant to enter a state which simulates Casters, be it normal mana casters or ranged bow/thrown attackers. Take note of: EFLAG_RANGED_MODE_ONLY, EFLAG_MELEE_MODE_ONLY, EFLAG_COMBAT_ACTION, CAST_MAIN_SPELL and CAST_DISTANCE_YOURSELF
+
+RangeModeType -
+TYPE_NONE - Basic melee mode and setting it also forcibly turns off ranged mode.
+TYPE_FULL_CASTER - Creature will use spells and not melee, until going OOM, interrupted or silenced. When one of those conditions is valid, creature will come into melee mode and attack until enough mana for spells.
+TYPE_PROXIMITY - Creature will use spells and not melee until target comes within 8 yards, OOM, interrupted or silenced.
+TYPE_NO_MELEE_MODE - Creature will never melee. If OOM, interrupted or silenced, it will stand there and do nothing.
+
 =========================================
 Target Types
 =========================================
 Below is the list of current Target types that EventAI can handle.
 Target types are used by certain actions and may effect actions differently
 
-#    Internal Name                         Description
----------------------------------------------------
-0    TARGET_T_SELF                      Self Cast
-1    TARGET_T_HOSTILE                   Current Target (ie: Highest Aggro)
-2    TARGET_T_HOSTILE_SECOND_AGGRO      Second Highest Aggro (Generaly used for Cleaves and some special attacks)
-3    TARGET_T_HOSTILE_LAST_AGGRO        Dead Last on Aggro (no idea what this could be used for)
-4    TARGET_T_HOSTILE_RANDOM            Random Target on The Threat List
-5    TARGET_T_HOSTILE_RANDOM_NOT_TOP    Any Random Target Except Top Threat
-6    TARGET_T_ACTION_INVOKER            Unit Who Caused This Event to Occur (only works for EVENT_T_AGGRO, EVENT_T_KILL, EVENT_T_DEATH, EVENT_T_SPELLHIT, EVENT_T_OOC_LOS, EVENT_T_FRIENDLY_HP, EVENT_T_FRIENDLY_IS_CC, EVENT_T_FRIENDLY_MISSING_BUFF, EVENT_T_RECEIVE_EMOTE, EVENT_T_RECEIVE_AI_EVENT)
-7    TARGET_T_ACTION_INVOKER_OWNER      Unit who is responsible for Event to occur (only works for EVENT_T_AGGRO, EVENT_T_KILL, EVENT_T_DEATH, EVENT_T_SPELLHIT, EVENT_T_OOC_LOS, EVENT_T_FRIENDLY_HP, EVENT_T_FRIENDLY_IS_CC, EVENT_T_FRIENDLY_MISSING_BUFF, EVENT_T_RECEIVE_EMOTE, EVENT_T_RECEIVE_AI_EVENT)
-8    TARGET_T_HOSTILE_RANDOM_PLAYER          Random Player on The Threat List
-9    TARGET_T_HOSTILE_RANDOM_NOT_TOP_PLAYER  Any Random Player Except Top Threat
-10   TARGET_T_EVENT_SENDER              Creature who sent a received AIEvent - only triggered by EVENT_T_RECEIVE_AI_EVENT
-11   TARGET_T_SPAWNER                   Spawner of given Unit if it has one
-12   TARGET_T_EVENT_SPECIFIC            Filled by Event - EVENT_T_SELECT_ATTACKING_TARGET fills target selected
-13   TARGET_T_PLAYER_INVOKER            Player who initiated hostile contact with this npc
-14   TARGET_T_PLAYER_TAPPED             Player who currently holds the kill credit for the npc
+#   Internal Name                               Description
+--------------------------------------------------------------
+0   TARGET_T_SELF                               Self Cast
+1   TARGET_T_HOSTILE                            Current Target (ie: Highest Aggro)
+2   TARGET_T_HOSTILE_SECOND_AGGRO               Second Highest Aggro (Generaly used for Cleaves and some special attacks)
+3   TARGET_T_HOSTILE_LAST_AGGRO                 Dead Last on Aggro (no idea what this could be used for)
+4   TARGET_T_HOSTILE_RANDOM                     Random Target on The Threat List
+5   TARGET_T_HOSTILE_RANDOM_NOT_TOP             Any Random Target Except Top Threat
+6   TARGET_T_ACTION_INVOKER                     Unit Who Caused This Event to Occur (only works for EVENT_T_AGGRO, EVENT_T_KILL, EVENT_T_DEATH, EVENT_T_SPELLHIT, EVENT_T_OOC_LOS, EVENT_T_FRIENDLY_HP, EVENT_T_FRIENDLY_IS_CC, EVENT_T_FRIENDLY_MISSING_BUFF, EVENT_T_RECEIVE_EMOTE, EVENT_T_RECEIVE_AI_EVENT)
+7   TARGET_T_ACTION_INVOKER_OWNER               Unit who is responsible for Event to occur (only works for EVENT_T_AGGRO, EVENT_T_KILL, EVENT_T_DEATH, EVENT_T_SPELLHIT, EVENT_T_OOC_LOS, EVENT_T_FRIENDLY_HP, EVENT_T_FRIENDLY_IS_CC, EVENT_T_FRIENDLY_MISSING_BUFF, EVENT_T_RECEIVE_EMOTE, EVENT_T_RECEIVE_AI_EVENT)
+8   TARGET_T_HOSTILE_RANDOM_PLAYER              TARGET_T_HOSTILE_RANDOM + CAST_PLAYER_ONLY
+9   TARGET_T_HOSTILE_RANDOM_NOT_TOP_PLAYER      TARGET_T_HOSTILE_RANDOM_NOT_TOP + CAST_PLAYER_ONLY
+10  TARGET_T_EVENT_SENDER                       Creature who sent a received AIEvent - only triggered by EVENT_T_RECEIVE_AI_EVENT
+11  TARGET_T_SPAWNER                            Spawner of given Unit if it has one
+12  TARGET_T_EVENT_SPECIFIC                     Filled by Event - EVENT_T_SELECT_ATTACKING_TARGET fills target selected
+13  TARGET_T_PLAYER_INVOKER                     Player who initiated hostile contact with this npc
+14  TARGET_T_PLAYER_TAPPED                      Player who currently holds the kill credit for the npc
+15  TARGET_T_NONE                               Fills nullptr. For most spells thats the valid input. This translates to no target in SMSG_SPELL_START. TARGET_SELF spells are such example.
+16  TARGET_T_HOSTILE_RANDOM_MANA                Random target with mana
+17  TARGET_T_NEAREST_AOE_TARGET                 Selects nearest target and checks if its valid for AOE. To be only used with spells which are only used in proximity to caster like Arcane Explosion or Frost Nova.
+18  TARGET_T_HOSTILE_FARTHEST_AWAY              Selects farthest away target
 
 =========================================
 Cast Flags
@@ -1047,36 +1085,43 @@ Cast flags are handled bitwise. Bit 0 is Interrupt Previous, bit 1 is triggered,
 So for example the number "3" (11 in Binary, selecting first 2 options) would mean that this cast has both CAST_INTURRUPT_PREVIOUS and CAST_TRIGGERED.
 Another example: the number "5" (101 in Binary, selecting first and third options) would mean that this cast has CAST_INTURRUPT_PREVIOUS and CAST_FORCE_CAST.
 
-#       Decimal     Internal Name                  Description
+#   Decimal     Internal Name                       Description
 --------------------------------------------------------------
-0       1           CAST_INTURRUPT_PREVIOUS        Interrupts any previous spell casting (basicaly makes sure that this spell goes off)
-1       2           CAST_TRIGGERED                 Forces the spell to be instant cast and require no mana/reagents.
-2       4           CAST_FORCE_CAST                Forces spell to cast even if the target is possibly out of range or the creature is possibly out of mana
-3       8           CAST_NO_MELEE_IF_OOM           Prevents creature from entering melee if out of mana or out of range
-4       16          CAST_FORCE_TARGET_SELF         Forces the target to cast this spell on itself
-5       32          CAST_AURA_NOT_PRESENT          Only casts the spell on the target if the target does not have the aura from that spell on itself already.
+1   1           CAST_INTURRUPT_PREVIOUS             Interrupts any previous spell casting (basicaly makes sure that this spell goes off)
+2   2           CAST_TRIGGERED                      Forces the spell to be instant cast and require no mana/reagents.
+3   4           CAST_FORCE_CAST                     Forces spell to cast even if the target is possibly out of range or the creature is possibly out of mana
+4   8           CAST_NO_MELEE_IF_OOM                Prevents creature from entering melee if out of mana or out of range
+5   16          CAST_FORCE_TARGET_SELF              Forces the target to cast this spell on itself
+6   32          CAST_AURA_NOT_PRESENT               Only casts the spell on the target if the target does not have the aura from that spell on itself already.
+7   64          CAST_IGNORE_UNSELECTABLE_TARGET     Deprecated - Can target UNIT_FLAG_NOT_SELECTABLE
+8   128         CAST_SWITCH_CASTER_TARGET           Switches target and caster for spell cast - enables casting by spawner on AI owner for example
+9   256         CAST_MAIN_SPELL                     Marks main spell for ranged mode. When this spell is interrupted or goes OOM, the AI owner goes into melee mode. Connected to ACTION_T_SET_RANGED_MODE
+10  512         CAST_PLAYER_ONLY                    To be used in connection with targets. Restricts targeting to player only
+11  1024        CAST_DISTANCE_YOURSELF              Marks spell which stuns or immobilizes, so that creature distances itself from target, when main aggro target is hit (getVictim()). Connected to ACTION_T_SET_RANGED_MODE.
 
 NOTE: You can add the numbers in the decimal column to combine flags.
- For example if you wanted to use CAST_NO_MELEE_IF_OOM(8) and CAST_TRIGGERED(2) you would simply use 10 in the cast flags field (8 + 2 = 10).
+For example if you wanted to use CAST_NO_MELEE_IF_OOM(8) and CAST_TRIGGERED(2) you would simply use 10 in the cast flags field (8 + 2 = 10).
 
 =========================================
 Event Flags
 =========================================
 Below is the list of current Event Flags that EventAI can handle. Event flags are handled bitwise.
 
-#       Decimal   Internal Name                  Description
+#   Decimal     Internal Name                   Description
 ------------------------------------------------------------
-0       1         EFLAG_REPEATABLE               Event repeats (Does not repeat if this flag is not set)
-1       2         EFLAG_NORMAL                   Event occurs in Normal instance difficulty (will not occur in Normal if not set)
-2       4         EFLAG_HEROIC                   Event occurs in Heroic instance difficulty (will not occur in Heroic if not set)
-3       8
-4       16
-5       32        EFLAG_RANDOM_ACTION            At event occur execute one random action from event actions instead all actions.
-6       64
-7       128       EFLAG_DEBUG_ONLY              Prevents events from occuring on Release builds. Useful for testing new features.
+1   1           EFLAG_REPEATABLE                Event repeats (Does not repeat if this flag is not set)
+2   2           EFLAG_NORMAL                    Event occurs in Normal instance difficulty (will not occur in Normal if not set)
+3   4           EFLAG_HEROIC                    Event occurs in Heroic instance difficulty (will not occur in Heroic if not set)
+4   8           EFLAG_RESERVED_4                Used in cmangos wotlk for difficulty 2
+5   16          EFLAG_RESERVED_5                Used in cmangos wotlk for difficulty 3
+6   32          EFLAG_RANDOM_ACTION             At event occur execute one random action from event actions instead all actions.
+7   64          EFLAG_RESERVED_7
+8   128         EFLAG_DEBUG_ONLY                Prevents events from occuring on Release builds. Useful for testing new features.
+9   256         EFLAG_RANGED_MODE_ONLY          Event only occurs in ranged mode - to be used in connection with ACTION_T_SET_RANGED_MODE
+10  512         EFLAG_MELEE_MODE_ONLY           Event only occurs in melee mode - to be used in connection with ACTION_T_SET_RANGED_MODE
+11  1024        EFLAG_COMBAT_ACTION             Event timer only resets when action1 succeeds. At the moment only Action 11 - Cast can fail.
 
 NOTE: You can add the numbers in the decimal column to combine flags.
-
 
 =========================================
 Basic Structure of creature_ai_texts

--- a/sql/base/mangos.sql
+++ b/sql/base/mangos.sql
@@ -816,6 +816,8 @@ CREATE TABLE `creature_ai_scripts` (
   `event_param2` int(11) NOT NULL DEFAULT '0',
   `event_param3` int(11) NOT NULL DEFAULT '0',
   `event_param4` int(11) NOT NULL DEFAULT '0',
+  `event_param5` int(11) NOT NULL DEFAULT '0',
+  `event_param6` int(11) NOT NULL DEFAULT '0',
   `action1_type` tinyint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Action Type',
   `action1_param1` int(11) NOT NULL DEFAULT '0',
   `action1_param2` int(11) NOT NULL DEFAULT '0',

--- a/sql/updates/mangos/s0000_01_mangos_event_ai.sql
+++ b/sql/updates/mangos/s0000_01_mangos_event_ai.sql
@@ -1,0 +1,10 @@
+-- ALTER TABLE creature_ai_scripts DROP event_param5;
+-- ALTER TABLE creature_ai_scripts DROP event_param6;
+ALTER TABLE creature_ai_scripts ADD event_param5 int(11) NOT NULL DEFAULT '0' AFTER event_param4;
+ALTER TABLE creature_ai_scripts ADD event_param6 int(11) NOT NULL DEFAULT '0' AFTER event_param5;
+
+UPDATE `creature_ai_scripts` SET `action1_param2` = 12 WHERE `action1_param2` = 6 AND `action1_type` = 11 AND event_type IN(14,15,16);
+UPDATE `creature_ai_scripts` SET `action2_param2` = 12 WHERE `action2_param2` = 6 AND `action2_type` = 11 AND event_type IN(14,15,16);
+UPDATE `creature_ai_scripts` SET `action3_param2` = 12 WHERE `action3_param2` = 6 AND `action3_type` = 11 AND event_type IN(14,15,16);
+
+UPDATE creature_ai_scripts SET event_param3=1 WHERE event_type=5;

--- a/src/game/AI/BaseAI/CritterAI.h
+++ b/src/game/AI/BaseAI/CritterAI.h
@@ -32,5 +32,7 @@ class CritterAI : public CreatureAI
         void UpdateAI(const uint32 /*diff*/) override;
 
         static int Permissible(const Creature* creature);
+    protected:
+        std::string GetAIName() override { return "CritterAI"; }
 };
 #endif

--- a/src/game/AI/BaseAI/GuardAI.h
+++ b/src/game/AI/BaseAI/GuardAI.h
@@ -40,5 +40,7 @@ class GuardAI : public CreatureAI
 
         void UpdateAI(const uint32 diff) override;
         static int Permissible(const Creature* creature);
+    protected:
+        std::string GetAIName() override { return "GuardAI"; }
 };
 #endif

--- a/src/game/AI/BaseAI/GuardianAI.cpp
+++ b/src/game/AI/BaseAI/GuardianAI.cpp
@@ -51,7 +51,7 @@ void GuardianAI::UpdateAI(const uint32 diff)
     {
         case REACT_AGGRESSIVE:
         case REACT_DEFENSIVE:
-            if (!m_creature->isInCombat() && owner->isInCombat())
+            if (!m_creature->isInCombat() && owner->isInCombat() && !(m_creature->IsPet() && ((Pet*)m_creature)->getPetType() == MINI_PET))
                 AttackStart(owner->getAttackerForHelper());   // check for getAttackerForHelper() == nullpter in AttackStart()
             break;
         default:
@@ -67,106 +67,6 @@ int GuardianAI::Permissible(const Creature* creature)
         return PERMIT_BASE_SPECIAL;
 
     return PERMIT_BASE_NO;
-}
-
-bool GuardianAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionInvoker, Unit* AIEventSender /*=nullptr*/)
-{
-    if (!holder.Enabled || holder.Time)
-        return false;
-
-    // Check the inverse phase mask (event doesn't trigger if current phase bit is set in mask)
-    if (holder.Event.event_inverse_phase_mask & (1 << m_Phase))
-    {
-        if (!IsTimerBasedEvent(holder.Event.event_type))
-            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "CreatureEventAI: Event %u skipped because of phasemask %u. Current phase %u", holder.Event.event_id, holder.Event.event_inverse_phase_mask, m_Phase);
-        return false;
-    }
-
-    if (!IsTimerBasedEvent(holder.Event.event_type))
-        LOG_PROCESS_EVENT;
-
-    CreatureEventAI_Event const& event = holder.Event;
-
-    // Check event conditions based on the event type, also reset events
-    switch (event.event_type)
-    {
-        case EVENT_T_FRIENDLY_HP:
-        {
-            Unit* pUnit = DoSelectLowestHpFriendly((float)event.friendly_hp.radius, event.friendly_hp.hpDeficit, false);
-            if (!pUnit)
-                return false;
-
-            actionInvoker = pUnit;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.friendly_hp.repeatMin, event.friendly_hp.repeatMax);
-            break;
-        }
-        default:
-            return CreatureEventAI::ProcessEvent(holder, actionInvoker, AIEventSender);
-    }
-
-    // Disable non-repeatable events
-    if (!(holder.Event.event_flags & EFLAG_REPEATABLE))
-        holder.Enabled = false;
-
-    // Store random here so that all random actions match up
-    uint32 rnd = urand();
-
-    // Return if chance for event is not met
-    if (holder.Event.event_chance <= rnd % 100)
-        return false;
-
-    // Process actions, normal case
-    if (!(holder.Event.event_flags & EFLAG_RANDOM_ACTION))
-    {
-        for (uint32 j = 0; j < MAX_ACTIONS; ++j)
-            ProcessAction(holder.Event.action[j], rnd, holder.Event.event_id, actionInvoker, AIEventSender);
-    }
-    // Process actions, random case
-    else
-    {
-        // amount of real actions
-        uint32 count = 0;
-        for (uint32 j = 0; j < MAX_ACTIONS; ++j)
-            if (holder.Event.action[j].type != ACTION_T_NONE)
-                ++count;
-
-        if (count)
-        {
-            // select action number from found amount
-            uint32 idx = rnd % count;
-
-            // find selected action, skipping not used
-            uint32 j = 0;
-            for (; ; ++j)
-            {
-                if (holder.Event.action[j].type != ACTION_T_NONE)
-                {
-                    if (!idx)
-                        break;
-                    --idx;
-                }
-            }
-
-            rnd = urand(); // need to randomize again to prevent always same result when both event and action are randomized
-
-            ProcessAction(holder.Event.action[j], rnd, holder.Event.event_id, actionInvoker, AIEventSender);
-        }
-    }
-    return true;
-}
-
-void GuardianAI::ProcessAction(CreatureEventAI_Action const& action, uint32 rnd, uint32 EventId, Unit* actionInvoker, Unit* AIEventSender)
-{
-    if (action.type == ACTION_T_NONE)
-        return;
-
-    DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "GuardianAI: Process action %u (script %u) triggered for %s (invoked by %s)",
-                     action.type, EventId, m_creature->GetGuidStr().c_str(), actionInvoker ? actionInvoker->GetGuidStr().c_str() : "<no invoker>");
-
-    CreatureEventAI::ProcessAction(action, rnd, EventId, actionInvoker, AIEventSender);
 }
 
 void GuardianAI::CombatStop()
@@ -189,28 +89,11 @@ void GuardianAI::EnterEvadeMode()
     m_creature->TriggerEvadeEvents();
 
     // Handle Evade events
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        if (i->Event.event_type == EVENT_T_EVADE)
-            ProcessEvent(*i);
+        if (i->event.event_type == EVENT_T_EVADE)
+            CheckAndReadyEventForExecution(*i);
     }
-}
-
-Unit* GuardianAI::DoSelectLowestHpFriendly(float range, uint32 MinHPDiff, bool onlyInCombat) const
-{
-    Unit* owner = m_creature->GetOwner();
-
-    if (!owner)
-        return nullptr;
-
-    Unit* pUnit = nullptr;
-
-    MaNGOS::MostHPMissingInRangeCheck u_check(m_creature, range, MinHPDiff, onlyInCombat);
-    MaNGOS::UnitLastSearcher<MaNGOS::MostHPMissingInRangeCheck> searcher(pUnit, u_check);
-
-    if (owner->GetTypeId() == TYPEID_PLAYER)
-        Cell::VisitWorldObjects(m_creature, searcher, range);   // search all friendly unit including players
-    else
-        Cell::VisitGridObjects(m_creature, searcher, range);    // search only friendly creatures
-    return pUnit;
+    ProcessEvents();
 }

--- a/src/game/AI/BaseAI/GuardianAI.h
+++ b/src/game/AI/BaseAI/GuardianAI.h
@@ -40,9 +40,7 @@ class GuardianAI : public CreatureEventAI
         virtual void EnterEvadeMode() override;
         virtual void UpdateAI(const uint32 diff) override;
         virtual void CombatStop() override;
-
-        virtual bool ProcessEvent(CreatureEventAIHolder& holder, Unit* actionInvoker = nullptr, Unit* AIEventSender = nullptr) override;
-        virtual void ProcessAction(CreatureEventAI_Action const& action, uint32 rnd, uint32 eventId, Unit* actionInvoker, Unit* AIEventSender) override;
-        Unit* DoSelectLowestHpFriendly(float range, uint32 minHPDiff, bool onlyInCombat) const;
+    protected:
+        std::string GetAIName() override { return "GuardianAI"; }
 };
 #endif

--- a/src/game/AI/BaseAI/NullCreatureAI.h
+++ b/src/game/AI/BaseAI/NullCreatureAI.h
@@ -36,5 +36,7 @@ class NullCreatureAI : public CreatureAI
 
         void UpdateAI(const uint32) override {}
         static int Permissible(const Creature*) { return PERMIT_BASE_IDLE;  }
+    protected:
+        std::string GetAIName() override { return "NullAI"; }
 };
 #endif

--- a/src/game/AI/BaseAI/PetAI.h
+++ b/src/game/AI/BaseAI/PetAI.h
@@ -42,6 +42,7 @@ class PetAI : public UnitAI
         static int Permissible(const Creature* creature);
 
     protected:
+        std::string GetAIName() override { return "PetAI"; }
         Creature* m_creature; // TODO: Make PetAI only available for creatures
 
     private:

--- a/src/game/AI/BaseAI/PossessedAI.h
+++ b/src/game/AI/BaseAI/PossessedAI.h
@@ -41,5 +41,8 @@ class PossessedAI : public UnitAI
         {
             DoMeleeAttackIfReady();
         }
+
+    protected:
+        std::string GetAIName() override { return "PossessedAI"; }
 };
 #endif

--- a/src/game/AI/BaseAI/TotemAI.cpp
+++ b/src/game/AI/BaseAI/TotemAI.cpp
@@ -46,52 +46,18 @@ void TotemAI::EnterEvadeMode()
     m_creature->CombatStop(true);
 
     // Handle Evade events
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        if (i->Event.event_type == EVENT_T_EVADE)
-            ProcessEvent(*i);
+        if (i->event.event_type == EVENT_T_EVADE)
+            CheckAndReadyEventForExecution(*i);
     }
+    ProcessEvents();
 }
 
 void TotemAI::UpdateAI(const uint32 diff)
 {
-    // Events are only updated once every EVENT_UPDATE_TIME ms to prevent lag with large amount of events
-    if (m_EventUpdateTime < diff)
-    {
-        m_EventDiff += diff;
-
-        // Check for time based events
-        for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
-        {
-            // Decrement Timers
-            if (i->Time)
-            {
-                // Do not decrement timers if event cannot trigger in this phase
-                if (!(i->Event.event_inverse_phase_mask & (1 << m_Phase)))
-                {
-                    if (i->Time > m_EventDiff)
-                        i->Time -= m_EventDiff;
-                    else
-                        i->Time = 0;
-                }
-            }
-
-            // Skip processing of events that have time remaining or are disabled
-            if (!(i->Enabled) || i->Time)
-                continue;
-
-            if (IsTimerBasedEvent(i->Event.event_type))
-                ProcessEvent(*i);
-        }
-
-        m_EventDiff = 0;
-        m_EventUpdateTime = EVENT_UPDATE_TIME;
-    }
-    else
-    {
-        m_EventDiff += diff;
-        m_EventUpdateTime -= diff;
-    }
+    UpdateEventTimers(diff);
 
     if (getTotem().GetTotemType() != TOTEM_ACTIVE)
         return;

--- a/src/game/AI/BaseAI/TotemAI.h
+++ b/src/game/AI/BaseAI/TotemAI.h
@@ -41,6 +41,7 @@ class TotemAI : public CreatureEventAI
         void UpdateAI(const uint32 diff) override;
         static int Permissible(const Creature* creature);
     protected:
+        std::string GetAIName() override { return "TotemAI"; }
         Totem& getTotem() const;
 
     private:

--- a/src/game/AI/BaseAI/UnitAI.h
+++ b/src/game/AI/BaseAI/UnitAI.h
@@ -432,6 +432,7 @@ class UnitAI
         virtual void JustStoppedMovementOfTarget(SpellEntry const* spellInfo, Unit* victim) {}
 
     protected:
+        virtual std::string GetAIName() { return "UnitAI"; }
 
         ///== Fields =======================================
 

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -29,17 +29,18 @@
 #include "Chat/Chat.h"
 #include "Tools/Language.h"
 #include "Entities/TemporarySpawn.h"
+#include "Spells/Spell.h"
 
 bool CreatureEventAIHolder::UpdateRepeatTimer(Creature* creature, uint32 repeatMin, uint32 repeatMax)
 {
     if (repeatMin == repeatMax)
-        Time = repeatMin;
+        timer = repeatMin;
     else if (repeatMax > repeatMin)
-        Time = urand(repeatMin, repeatMax);
+        timer = urand(repeatMin, repeatMax);
     else
     {
-        sLog.outErrorEventAI("Creature %u using Event %u (Type = %u) has RandomMax < RandomMin. Event repeating disabled.", creature->GetEntry(), Event.event_id, Event.event_type);
-        Enabled = false;
+        sLog.outErrorEventAI("Creature %u using Event %u (Type = %u) has RandomMax < RandomMin. Event repeating disabled.", creature->GetEntry(), event.event_id, event.event_type);
+        enabled = false;
         return false;
     }
 
@@ -72,12 +73,12 @@ void CreatureEventAI::GetAIInformation(ChatHandler& reader)
     reader.PSendSysMessage("Current events of this creature:");
     for (CreatureEventAIList::const_iterator itr = m_CreatureEventAIList.begin(); itr != m_CreatureEventAIList.end(); ++itr)
     {
-        if (itr->Event.action[2].type != ACTION_T_NONE)
-            reader.PSendSysMessage("%u Type%3u (%s) Timer(%3us) actions[type(param1)]: %2u(%5u)  --  %2u(%u)  --  %2u(%5u)", itr->Event.event_id, uint32(itr->Event.event_type), itr->Enabled ? "On" : "Off", itr->Time / 1000, itr->Event.action[0].type, itr->Event.action[0].raw.param1, itr->Event.action[1].type, itr->Event.action[1].raw.param1, itr->Event.action[2].type, itr->Event.action[2].raw.param1);
-        else if (itr->Event.action[1].type != ACTION_T_NONE)
-            reader.PSendSysMessage("%u Type%3u (%s) Timer(%3us) actions[type(param1)]: %2u(%5u)  --  %2u(%5u)", itr->Event.event_id, uint32(itr->Event.event_type), itr->Enabled ? "On" : "Off", itr->Time / 1000, itr->Event.action[0].type, itr->Event.action[0].raw.param1, itr->Event.action[1].type, itr->Event.action[1].raw.param1);
+        if (itr->event.action[2].type != ACTION_T_NONE)
+            reader.PSendSysMessage("%u Type%3u (%s) Timer(%3us) actions[type(param1)]: %2u(%5u)  --  %2u(%u)  --  %2u(%5u)", itr->event.event_id, uint32(itr->event.event_type), itr->enabled ? "On" : "Off", itr->timer / 1000, itr->event.action[0].type, itr->event.action[0].raw.param1, itr->event.action[1].type, itr->event.action[1].raw.param1, itr->event.action[2].type, itr->event.action[2].raw.param1);
+        else if (itr->event.action[1].type != ACTION_T_NONE)
+            reader.PSendSysMessage("%u Type%3u (%s) Timer(%3us) actions[type(param1)]: %2u(%5u)  --  %2u(%5u)", itr->event.event_id, uint32(itr->event.event_type), itr->enabled ? "On" : "Off", itr->timer / 1000, itr->event.action[0].type, itr->event.action[0].raw.param1, itr->event.action[1].type, itr->event.action[1].raw.param1);
         else
-            reader.PSendSysMessage("%u Type%3u (%s) Timer(%3us) action[type(param1)]:  %2u(%5u)", itr->Event.event_id, uint32(itr->Event.event_type), itr->Enabled ? "On" : "Off", itr->Time / 1000, itr->Event.action[0].type, itr->Event.action[0].raw.param1);
+            reader.PSendSysMessage("%u Type%3u (%s) Timer(%3us) action[type(param1)]:  %2u(%5u)", itr->event.event_id, uint32(itr->event.event_type), itr->enabled ? "On" : "Off", itr->timer / 1000, itr->event.action[0].type, itr->event.action[0].raw.param1);
     }
 }
 
@@ -95,7 +96,17 @@ CreatureEventAI::CreatureEventAI(Creature* creature) : CreatureAI(creature),
     m_InvinceabilityHpLevel(0),
     m_throwAIEventMask(0),
     m_throwAIEventStep(0),
-    m_LastSpellMaxRange(0)
+    m_LastSpellMaxRange(0),
+    m_rangedMode(false),
+    m_rangedModeSetting(TYPE_NONE),
+    m_currentRangedMode(false),
+    m_chaseDistance(0.f),
+    m_depth(0)
+{
+    InitAI();
+}
+
+void CreatureEventAI::InitAI()
 {
     // Need make copy for filter unneeded steps and safe in case table reload
     CreatureEventAI_Event_Map::const_iterator creatureEventsItr = sEventAIMgr.GetCreatureEventAIMap().find(m_creature->GetEntry());
@@ -160,6 +171,21 @@ CreatureEventAI::CreatureEventAI(Creature* creature) : CreatureAI(creature),
                     // Cache for fast use
                     if (i->event_type == EVENT_T_OOC_LOS)
                         m_HasOOCLoSEvent = true;
+
+                    for (uint32 actionIdx = 0; actionIdx < MAX_ACTIONS; ++actionIdx)
+                        if (i->action[actionIdx].type == ACTION_T_CAST)
+                        {
+                            if (i->action[actionIdx].cast.castFlags & CAST_MAIN_SPELL)
+                            {
+                                m_mainSpellId = i->action[actionIdx].cast.spellId;
+                                SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(m_mainSpellId);
+                                m_mainSpellCost = Spell::CalculatePowerCost(spellInfo, m_creature, nullptr, nullptr);
+                                m_mainSpells.insert(i->action[actionIdx].cast.spellId);
+                            }
+
+                            if (i->action[actionIdx].cast.castFlags & CAST_DISTANCE_YOURSELF)
+                                m_distanceSpells.insert(i->action[actionIdx].cast.spellId);
+                        }
                 }
             }
         }
@@ -167,15 +193,15 @@ CreatureEventAI::CreatureEventAI(Creature* creature) : CreatureAI(creature),
     else
     {
         std::string aiName = m_creature->GetAIName();
-        if (aiName == "EventAI") // don't show error on GuardiansAI
+        if (aiName == "EventAI") // Only show error on explicitly assigned EAI in DB
         {
             sLog.outErrorEventAI("EventMap for Creature Id: %u, %s is empty but creature is using CreatureEventAI: '%s'.",
-                                 m_creature->GetEntry(), m_creature->GetGuidStr().c_str(), aiName.c_str());
+                m_creature->GetEntry(), m_creature->GetGuidStr().c_str(), aiName.c_str());
         }
     }
 }
 
-bool CreatureEventAI::IsTimerBasedEvent(EventAI_Type type) const
+bool CreatureEventAI::IsTimerExecutedEvent(EventAI_Type type) const
 {
     switch (type)
     {
@@ -219,23 +245,87 @@ bool CreatureEventAI::IsRepeatableEvent(EventAI_Type type) const
     }
 }
 
-bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionInvoker, Unit* AIEventSender /*=nullptr*/)
+bool CreatureEventAI::IsTimerBasedEvent(EventAI_Type type) const
 {
-    if (!holder.Enabled || holder.Time)
+    switch (type)
+    {
+        case EVENT_T_TIMER_IN_COMBAT:
+        case EVENT_T_TIMER_OOC:
+        case EVENT_T_TIMER_GENERIC:
+        case EVENT_T_HP:
+        case EVENT_T_MANA:
+        case EVENT_T_KILL:
+        case EVENT_T_SPELLHIT:
+        case EVENT_T_RANGE:
+        case EVENT_T_OOC_LOS:
+        case EVENT_T_TARGET_HP:
+        case EVENT_T_TARGET_CASTING:
+        case EVENT_T_FRIENDLY_HP:
+        case EVENT_T_FRIENDLY_IS_CC:
+        case EVENT_T_FRIENDLY_MISSING_BUFF:
+        case EVENT_T_SUMMONED_UNIT:
+        case EVENT_T_SUMMONED_JUST_DIED:
+        case EVENT_T_SUMMONED_JUST_DESPAWN:
+        case EVENT_T_TARGET_MANA:
+        case EVENT_T_AURA:
+        case EVENT_T_TARGET_AURA:
+        case EVENT_T_MISSING_AURA:
+        case EVENT_T_TARGET_MISSING_AURA:
+        case EVENT_T_ENERGY:
+        case EVENT_T_SELECT_ATTACKING_TARGET:
+        case EVENT_T_FACING_TARGET:
+            return true;
+        default: return false;
+    }
+}
+
+void CreatureEventAI::ProcessEvents(Unit* actionInvoker, Unit* AIEventSender)
+{
+    const int curDepth = m_depth;
+    ++m_depth;
+    for (CreatureEventAIHolder& event : m_creatureEventAITempList[curDepth])
+        ProcessEvent(event, actionInvoker, AIEventSender);
+
+    m_creatureEventAITempList[m_depth - 1].clear();
+    --m_depth;
+}
+
+bool CreatureEventAI::CheckEvent(CreatureEventAIHolder& holder, Unit* actionInvoker, Unit* AIEventSender /*=nullptr*/)
+{
+    if (!holder.enabled || holder.timer || holder.inProgress)
+        return false;
+
+    if (holder.event.event_flags & EFLAG_COMBAT_ACTION && GetCombatScriptStatus())
         return false;
 
     // Check the inverse phase mask (event doesn't trigger if current phase bit is set in mask)
-    if (holder.Event.event_inverse_phase_mask & (1 << m_Phase))
+    if (holder.event.event_inverse_phase_mask & (1 << m_Phase))
     {
-        if (!IsTimerBasedEvent(holder.Event.event_type))
-            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "CreatureEventAI: Event %u skipped because of phasemask %u. Current phase %u", holder.Event.event_id, holder.Event.event_inverse_phase_mask, m_Phase);
+        if (!IsTimerExecutedEvent(holder.event.event_type))
+            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "%s: Event %u skipped because of phasemask %u. Current phase %u", GetAIName().data(), holder.event.event_id, holder.event.event_inverse_phase_mask, m_Phase);
         return false;
     }
 
-    if (!IsTimerBasedEvent(holder.Event.event_type))
-        LOG_PROCESS_EVENT;
+    if (m_currentRangedMode)
+    {
+        if (holder.event.event_flags & EFLAG_MELEE_MODE_ONLY)
+            return false;
+    }
+    else
+    {
+        if (holder.event.event_flags & EFLAG_RANGED_MODE_ONLY)
+            return false;
+    }
 
-    CreatureEventAI_Event const& event = holder.Event;
+    LOG_PROCESS_EVENT;
+
+    CreatureEventAI_Event const& event = holder.event;
+
+    uint32 rnd = urand();
+
+    // Return if chance for event is not met
+    if (holder.event.event_chance <= rnd % 100)
+        return false;
 
     // Check event conditions based on the event type, also reset events
     switch (event.event_type)
@@ -243,23 +333,12 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
         case EVENT_T_TIMER_IN_COMBAT:
             if (!m_creature->isInCombat())
                 return false;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.timer.repeatMin, event.timer.repeatMax);
             break;
         case EVENT_T_TIMER_OOC:
             if (m_creature->isInCombat() || m_creature->IsInEvadeMode())
                 return false;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.timer.repeatMin, event.timer.repeatMax);
             break;
         case EVENT_T_TIMER_GENERIC:
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.timer.repeatMin, event.timer.repeatMax);
             break;
         case EVENT_T_HP:
         {
@@ -270,32 +349,24 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
 
             if (perc > event.percent_range.percentMax || perc < event.percent_range.percentMin)
                 return false;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.percent_range.repeatMin, event.percent_range.repeatMax);
             break;
         }
         case EVENT_T_MANA:
         {
-            if (!m_creature->isInCombat() || !m_creature->GetMaxPower(POWER_MANA))
+            if (!m_creature->isInCombat() || !m_creature->HasMana() || !m_creature->GetMaxPower(POWER_MANA))
                 return false;
 
             uint32 perc = (m_creature->GetPower(POWER_MANA) * 100) / m_creature->GetMaxPower(POWER_MANA);
 
             if (perc > event.percent_range.percentMax || perc < event.percent_range.percentMin)
                 return false;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.percent_range.repeatMin, event.percent_range.repeatMax);
             break;
         }
         case EVENT_T_AGGRO:
             break;
         case EVENT_T_KILL:
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.kill.repeatMin, event.kill.repeatMax);
+            if (event.kill.playerOnly == 1 && actionInvoker->GetTypeId() != TYPEID_PLAYER)
+                return false;
             break;
         case EVENT_T_DEATH:
             if (event.death.conditionId)
@@ -306,25 +377,19 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
         case EVENT_T_EVADE:
             break;
         case EVENT_T_SPELLHIT:
-            // Spell hit is special case, param1 and param2 handled within CreatureEventAI::SpellHit
-
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.spell_hit.repeatMin, event.spell_hit.repeatMax);
             break;
         case EVENT_T_RANGE:
             if (!m_creature->isInCombat() || !m_creature->getVictim() || !m_creature->IsInMap(m_creature->getVictim()))
                 return false;
 
-            // DISCUSS TODO - Likely replace IsInRange check with CombatReach checks (as used rather for such checks)
-            if (!m_creature->IsInRange(m_creature->getVictim(), (float)event.range.minDist, (float)event.range.maxDist))
+            if (!m_creature->IsInRange(m_creature->getVictim(), (float)event.range.minDist, (float)event.range.maxDist, true, true))
                 return false;
-
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.range.repeatMin, event.range.repeatMax);
             break;
         case EVENT_T_OOC_LOS:
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.ooc_los.repeatMin, event.ooc_los.repeatMax);
+            if (event.ooc_los.conditionId)
+                if (Player* player = actionInvoker->GetBeneficiaryPlayer())
+                    if (!sObjectMgr.IsPlayerMeetToCondition(event.ooc_los.conditionId, player, player->GetMap(), m_creature, CONDITION_FROM_EVENTAI))
+                        return false;
             break;
         case EVENT_T_SPAWNED:
             break;
@@ -337,19 +402,11 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
 
             if (perc > event.percent_range.percentMax || perc < event.percent_range.percentMin)
                 return false;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.percent_range.repeatMin, event.percent_range.repeatMax);
             break;
         }
         case EVENT_T_TARGET_CASTING:
             if (!m_creature->isInCombat() || !m_creature->getVictim() || !m_creature->getVictim()->IsNonMeleeSpellCasted(false, false, true))
                 return false;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.target_casting.repeatMin, event.target_casting.repeatMax);
             break;
         case EVENT_T_FRIENDLY_HP:
         {
@@ -360,11 +417,7 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
             if (!pUnit)
                 return false;
 
-            actionInvoker = pUnit;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.friendly_hp.repeatMin, event.friendly_hp.repeatMax);
+            holder.eventTarget = pUnit;
             break;
         }
         case EVENT_T_FRIENDLY_IS_CC:
@@ -380,15 +433,14 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
                 return false;
 
             // We don't really care about the whole list, just return first available
-            actionInvoker = *(pList.begin());
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.friendly_is_cc.repeatMin, event.friendly_is_cc.repeatMax);
+            holder.eventTarget = *(pList.begin());
             break;
         }
         case EVENT_T_FRIENDLY_MISSING_BUFF:
         {
+            if (!m_creature->isInCombat())
+                return false;
+
             std::list<Creature*> pList;
             DoFindFriendlyMissingBuff(pList, (float)event.friendly_buff.radius, event.friendly_buff.spellId);
 
@@ -397,10 +449,7 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
                 return false;
 
             // We don't really care about the whole list, just return first available
-            actionInvoker = *(pList.begin());
-
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.friendly_buff.repeatMin, event.friendly_buff.repeatMax);
+            holder.eventTarget = *(pList.begin());
             break;
         }
         case EVENT_T_SUMMONED_UNIT:
@@ -412,39 +461,35 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
                 return false;
 
             // Creature id doesn't match up
-            if (((Creature*)actionInvoker)->GetEntry() != event.summoned.creatureId)
+            if (actionInvoker->GetEntry() != event.summoned.creatureId)
                 return false;
-
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.summoned.repeatMin, event.summoned.repeatMax);
             break;
         }
         case EVENT_T_TARGET_MANA:
         {
-            if (!m_creature->isInCombat() || !m_creature->getVictim() || !m_creature->getVictim()->GetMaxPower(POWER_MANA))
+            if (!m_creature->isInCombat() || !m_creature->getVictim() || !m_creature->getVictim()->HasMana() || !m_creature->getVictim()->GetMaxPower(POWER_MANA))
                 return false;
 
             uint32 perc = (m_creature->getVictim()->GetPower(POWER_MANA) * 100) / m_creature->getVictim()->GetMaxPower(POWER_MANA);
 
             if (perc > event.percent_range.percentMax || perc < event.percent_range.percentMin)
                 return false;
-
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.percent_range.repeatMin, event.percent_range.repeatMax);
             break;
         }
         case EVENT_T_REACHED_HOME:
+            break;
         case EVENT_T_RECEIVE_EMOTE:
+            if (event.receive_emote.conditionId)
+                if (Player* player = actionInvoker->GetBeneficiaryPlayer())
+                    if (!sObjectMgr.IsPlayerMeetToCondition(event.receive_emote.conditionId, player, player->GetMap(), m_creature, CONDITION_FROM_EVENTAI))
+                        return false;
+
             break;
         case EVENT_T_AURA:
         {
             SpellAuraHolder* auraHolder = m_creature->GetSpellAuraHolder(event.buffed.spellId);
             if (!auraHolder || auraHolder->GetStackAmount() < event.buffed.amount)
                 return false;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.buffed.repeatMin, event.buffed.repeatMax);
             break;
         }
         case EVENT_T_TARGET_AURA:
@@ -455,10 +500,6 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
             SpellAuraHolder* auraHolder = m_creature->getVictim()->GetSpellAuraHolder(event.buffed.spellId);
             if (!auraHolder || auraHolder->GetStackAmount() < event.buffed.amount)
                 return false;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.buffed.repeatMin, event.buffed.repeatMax);
             break;
         }
         case EVENT_T_MISSING_AURA:
@@ -466,10 +507,6 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
             SpellAuraHolder* auraHolder = m_creature->GetSpellAuraHolder(event.buffed.spellId);
             if (auraHolder && auraHolder->GetStackAmount() >= event.buffed.amount)
                 return false;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.buffed.repeatMin, event.buffed.repeatMax);
             break;
         }
         case EVENT_T_TARGET_MISSING_AURA:
@@ -480,10 +517,6 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
             SpellAuraHolder* auraHolder = m_creature->getVictim()->GetSpellAuraHolder(event.buffed.spellId);
             if (auraHolder && auraHolder->GetStackAmount() >= event.buffed.amount)
                 return false;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.buffed.repeatMin, event.buffed.repeatMax);
             break;
         }
         case EVENT_T_RECEIVE_AI_EVENT:
@@ -497,10 +530,6 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
 
             if (perc > event.percent_range.percentMax || perc < event.percent_range.percentMin)
                 return false;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.percent_range.repeatMin, event.percent_range.repeatMax);
             break;
         }
         case EVENT_T_SELECT_ATTACKING_TARGET:
@@ -509,12 +538,9 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
             parameters.range.minRange = event.selectTarget.minRange;
             parameters.range.maxRange = event.selectTarget.maxRange;
             if (Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, nullptr, SELECT_FLAG_RANGE_RANGE, parameters))
-                m_eventTarget = target;
+                holder.eventTarget = target;
             else
                 return false;
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.percent_range.repeatMin, event.percent_range.repeatMax);
             break;
         }
         case EVENT_T_FACING_TARGET:
@@ -528,33 +554,66 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
             // Creature expected in front of target (melee range)
             else if (event.facingTarget.backOrFront == 1 && !m_creature->getVictim()->isInFrontInMap(m_creature, 5.0f))
                 return false;
-
-            LOG_PROCESS_EVENT;
-            // Repeat Timers
-            holder.UpdateRepeatTimer(m_creature, event.facingTarget.repeatMin, event.facingTarget.repeatMax);
             break;
         }
         default:
-            sLog.outErrorEventAI("Creature %u using Event %u has invalid Event Type(%u), missing from ProcessEvent() Switch.", m_creature->GetEntry(), holder.Event.event_id, holder.Event.event_type);
-            break;
+            sLog.outErrorEventAI("Creature %u using Event %u has invalid Event Type(%u), missing from ProcessEvent() Switch.", m_creature->GetEntry(), holder.event.event_id, holder.event.event_type);
+            return false;
+    }
+
+    return true;
+}
+
+void GetRepeatTimers(CreatureEventAIHolder& holder, uint32& repeatMin, uint32& repeatMax)
+{
+    switch (holder.event.event_type)
+    {
+        // 0th and 1st index
+        case EVENT_T_KILL:
+        case EVENT_T_TARGET_CASTING: repeatMin = holder.event.raw.params[0]; repeatMax = holder.event.raw.params[1]; return;
+        // 1st and 2nd index
+        case EVENT_T_SUMMONED_UNIT:
+        case EVENT_T_SUMMONED_JUST_DIED:
+        case EVENT_T_SUMMONED_JUST_DESPAWN: repeatMin = holder.event.raw.params[1]; repeatMax = holder.event.raw.params[2]; return;
+        // Most events are on 2nd and 3rd index - TODO: completely unify this
+        default: repeatMin = holder.event.raw.params[2]; repeatMax = holder.event.raw.params[3]; return;
+    }
+}
+
+void CreatureEventAI::ResetEvent(CreatureEventAIHolder& holder)
+{
+    if (IsTimerBasedEvent(holder.event.event_type))
+    {
+        uint32 repeatMin, repeatMax;
+        GetRepeatTimers(holder, repeatMin, repeatMax);
+        holder.UpdateRepeatTimer(m_creature, repeatMin, repeatMax);
     }
 
     // Disable non-repeatable events
-    if (IsRepeatableEvent(holder.Event.event_type) && !(holder.Event.event_flags & EFLAG_REPEATABLE))
-        holder.Enabled = false;
+    if (IsRepeatableEvent(holder.event.event_type) && !(holder.event.event_flags & EFLAG_REPEATABLE))
+        holder.enabled = false;
+}
 
-    // Store random here so that all random actions match up
-    uint32 rnd = urand();
-
-    // Return if chance for event is not met
-    if (holder.Event.event_chance <= rnd % 100)
-        return false;
-
-    // Process actions, normal case
-    if (!(holder.Event.event_flags & EFLAG_RANDOM_ACTION))
+void CreatureEventAI::CheckAndReadyEventForExecution(CreatureEventAIHolder& holder, Unit* actionInvoker, Unit* AIEventSender)
+{
+    if (CheckEvent(holder, actionInvoker, AIEventSender))
     {
-        for (uint32 j = 0; j < MAX_ACTIONS; ++j)
-            ProcessAction(holder.Event.action[j], rnd, holder.Event.event_id, actionInvoker, AIEventSender);
+        holder.inProgress = true;
+        m_creatureEventAITempList[m_depth].push_back(holder);
+    }
+}
+
+bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionInvoker, Unit* AIEventSender /*=nullptr*/)
+{
+    bool actionSuccess = false;
+    uint32 rnd = urand();
+    // Process actions, normal case
+    if (!(holder.event.event_flags & EFLAG_RANDOM_ACTION))
+    {
+        actionSuccess = ProcessAction(holder.event.action[0], rnd, holder.event.event_id, actionInvoker, AIEventSender, holder.eventTarget);
+
+        for (uint32 j = 1; j < MAX_ACTIONS; ++j)
+            ProcessAction(holder.event.action[j], rnd, holder.event.event_id, actionInvoker, AIEventSender, holder.eventTarget);
     }
     // Process actions, random case
     else
@@ -562,7 +621,7 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
         // amount of real actions
         uint32 count = 0;
         for (uint32 j = 0; j < MAX_ACTIONS; ++j)
-            if (holder.Event.action[j].type != ACTION_T_NONE)
+            if (holder.event.action[j].type != ACTION_T_NONE)
                 ++count;
 
         if (count)
@@ -574,7 +633,7 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
             uint32 j = 0;
             for (; ; ++j)
             {
-                if (holder.Event.action[j].type != ACTION_T_NONE)
+                if (holder.event.action[j].type != ACTION_T_NONE)
                 {
                     if (!idx)
                         break;
@@ -583,29 +642,33 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& holder, Unit* actionIn
             }
 
             rnd = urand(); // need to randomize again to prevent always same result when both event and action are randomized
-
-            ProcessAction(holder.Event.action[j], rnd, holder.Event.event_id, actionInvoker, AIEventSender);
+            actionSuccess = ProcessAction(holder.event.action[j], rnd, holder.event.event_id, actionInvoker, AIEventSender, holder.eventTarget);
         }
     }
+
+    if (!(holder.event.event_flags & EFLAG_COMBAT_ACTION) || actionSuccess)
+        ResetEvent(holder);
+
+    holder.inProgress = false;
     return true;
 }
 
-void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32 rnd, uint32 eventId, Unit* actionInvoker, Unit* AIEventSender)
+bool CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32 rnd, uint32 eventId, Unit* actionInvoker, Unit* AIEventSender, Unit* eventTarget)
 {
     if (action.type == ACTION_T_NONE)
-        return;
+        return false;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "CreatureEventAI: Process action %u (script %u) triggered for %s (invoked by %s)",
+    DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "%s: Process action %u (script %u) triggered for %s (invoked by %s)", GetAIName().data(),
                      action.type, eventId, m_creature->GetGuidStr().c_str(), actionInvoker ? actionInvoker->GetGuidStr().c_str() : "<no invoker>");
 
-    bool reportTargetError = false;
+    bool failedTargetSelection = false;
     switch (action.type)
     {
         case ACTION_T_TEXT:
         case ACTION_T_CHANCED_TEXT:
         {
             if (!action.text.TextId[0])
-                return;
+                return false;
 
             int32 textId = 0;
 
@@ -713,20 +776,46 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                 spellId = action.cast.spellId;
                 SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(spellId);
                 if (!spellInfo)
-                    return;
-                if (!IsIgnoreLosSpell(spellInfo))
+                    return false;
+                if (!IsIgnoreLosSpellCast(spellInfo))
                     selectFlags = SELECT_FLAG_IN_LOS;
+                if (action.cast.castFlags & CAST_PLAYER_ONLY)
+                    selectFlags |= SELECT_FLAG_PLAYER;
             }
 
-            Unit* target = GetTargetByType(action.cast.target, actionInvoker, AIEventSender, reportTargetError, spellId, selectFlags);
-            if (!target)
-            {
-                if (reportTargetError)
-                    sLog.outErrorEventAI("nullptr target for ACTION_T_CAST creature entry %u casting spell id %u", m_creature->GetEntry(), action.cast.spellId);
-                return;
-            }
-
+            Unit* target = GetTargetByType(action.cast.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection, spellId, selectFlags);
+            if (failedTargetSelection)
+                return false;
+            uint32 castFlags = action.cast.castFlags &~ (CAST_MAIN_SPELL | CAST_PLAYER_ONLY | CAST_DISTANCE_YOURSELF);
             CanCastResult castResult = DoCastSpellIfCan(target, action.cast.spellId, action.cast.castFlags);
+
+            if (m_rangedMode)
+            {
+                if (m_currentRangedMode)
+                {
+                    if (CAST_MAIN_SPELL)
+                    {
+                        switch (castResult)
+                        {
+                            case CAST_FAIL_COOLDOWN:
+                            case CAST_FAIL_POWER:
+                                SetCurrentRangedMode(false);
+                                break;
+                            case CAST_OK:
+                            default:
+                                break;
+                        }
+                    }
+                }
+                else
+                {
+                    if (CAST_MAIN_SPELL)
+                    {
+                        if (castResult == CAST_OK && m_rangedModeSetting == TYPE_FULL_CASTER)
+                            SetCurrentRangedMode(true);
+                    }
+                }
+            }
 
             switch (castResult)
             {
@@ -751,29 +840,29 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                 case CAST_FAIL_POWER:
                 case CAST_FAIL_NOT_IN_LOS:
                 {
-                    if (!m_creature->hasUnitState(UNIT_STAT_NO_COMBAT_MOVEMENT))
+                    if (!m_rangedMode) // dont want prototypes to clash
                     {
-                        // Melee current victim if flag not set
-                        if (!(action.cast.castFlags & CAST_NO_MELEE_IF_OOM))
+                        if (!m_creature->hasUnitState(UNIT_STAT_NO_COMBAT_MOVEMENT))
                         {
-                            switch (m_creature->GetMotionMaster()->GetCurrentMovementGeneratorType())
+                            // Melee current victim if flag not set
+                            if (!(action.cast.castFlags & CAST_NO_MELEE_IF_OOM))
                             {
-                                case CHASE_MOTION_TYPE:
-                                case FOLLOW_MOTION_TYPE:
-                                    m_attackDistance = 0.0f;
-                                    m_attackAngle = 0.0f;
-
-                                    m_creature->GetMotionMaster()->Clear(false);
-                                    m_creature->GetMotionMaster()->MoveChase(m_creature->getVictim(), m_attackDistance, m_attackAngle);
-                                    break;
-                                default:
-                                    break;
+                                m_attackDistance = 0.0f;
+                                m_attackAngle = 0.0f;
+                                switch (m_creature->GetMotionMaster()->GetCurrentMovementGeneratorType())
+                                {
+                                    case CHASE_MOTION_TYPE:
+                                    case FOLLOW_MOTION_TYPE:
+                                        m_creature->GetMotionMaster()->Clear(false);
+                                        m_creature->GetMotionMaster()->MoveChase(m_creature->getVictim(), m_attackDistance, m_attackAngle);
+                                        break;
+                                    default:
+                                        break;
+                                }
                             }
                         }
-                    }
-                    else if (m_DynamicMovement)
-                    {
-                        m_LastSpellMaxRange = 0.0f;
+                        else if (m_DynamicMovement)
+                            m_LastSpellMaxRange = 0.0f;
                     }
                     break;
                 }
@@ -781,12 +870,16 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                     break;
             }
 
+            // If spellcast fails, action did not succeed
+            if (castResult != CAST_OK)
+                return false;
+
             break;
         }
         case ACTION_T_SPAWN:
         {
-            Unit* target = GetTargetByType(action.summon.target, actionInvoker, AIEventSender, reportTargetError);
-            if (!target && reportTargetError)
+            Unit* target = GetTargetByType(action.summon.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection);
+            if (!target && failedTargetSelection)
                 sLog.outErrorEventAI("Event %u - nullptr target for ACTION_T_SPAWN (%u), target-type %u", eventId, action.type, action.summon.target);
 
             Creature* pCreature;
@@ -796,15 +889,15 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                 pCreature = m_creature->SummonCreature(action.summon.creatureId, 0.0f, 0.0f, 0.0f, 0.0f, TEMPSPAWN_TIMED_OOC_DESPAWN, 0);
 
             if (!pCreature)
-                sLog.outErrorEventAI("failed to spawn creature %u. Spawn event %d is on creature %d", action.summon.creatureId, eventId, m_creature->GetEntry());
+                sLog.outErrorEventAI("Failed to spawn creature %u. Spawn event %d is on creature %d", action.summon.creatureId, eventId, m_creature->GetEntry());
             else if (action.summon.target != TARGET_T_SELF && target)
                 pCreature->AI()->AttackStart(target);
             break;
         }
         case ACTION_T_THREAT_SINGLE_PCT:
-            if (Unit* target = GetTargetByType(action.threat_single_pct.target, actionInvoker, AIEventSender, reportTargetError))
+            if (Unit* target = GetTargetByType(action.threat_single_pct.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection))
                 m_creature->getThreatManager().modifyThreatPercent(target, action.threat_single_pct.percent);
-            else if (reportTargetError)
+            else if (failedTargetSelection)
                 sLog.outErrorEventAI("Event %u - nullptr target for ACTION_T_THREAT_SINGLE_PCT(%u), target-type %u", eventId, action.type, action.threat_single_pct.target);
             break;
         case ACTION_T_THREAT_ALL_PCT:
@@ -817,7 +910,7 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
         }
         case ACTION_T_QUEST_EVENT:
         {
-            if (Unit* target = GetTargetByType(action.quest_event.target, actionInvoker, AIEventSender, reportTargetError))
+            if (Unit* target = GetTargetByType(action.quest_event.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection))
             {
                 if (target->GetTypeId() == TYPEID_PLAYER)
                 {
@@ -828,48 +921,48 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                         playerTarget->AreaExploredOrEventHappens(action.quest_event.questId);
                 }
             }
-            else if (reportTargetError)
+            else if (failedTargetSelection)
                 sLog.outErrorEventAI("Event %u - nullptr target for ACTION_T_QUEST_EVENT(%u), target-type %u", eventId, action.type, action.quest_event.target);
             break;
         }
         case ACTION_T_CAST_EVENT:
-            if (Unit* target = GetTargetByType(action.cast_event.target, actionInvoker, AIEventSender, reportTargetError, 0, SELECT_FLAG_PLAYER))
+            if (Unit* target = GetTargetByType(action.cast_event.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection, 0, SELECT_FLAG_PLAYER))
             {
                 if (target->GetTypeId() == TYPEID_PLAYER)
                     ((Player*)target)->CastedCreatureOrGO(action.cast_event.creatureId, m_creature->GetObjectGuid(), action.cast_event.spellId);
             }
-            else if (reportTargetError)
+            else if (failedTargetSelection)
                 sLog.outErrorEventAI("Event %u - nullptr target for ACTION_T_CST_EVENT(%u), target-type %u", eventId, action.type, action.cast_event.target);
             break;
         case ACTION_T_SET_UNIT_FIELD:
         {
-            Unit* target = GetTargetByType(action.set_unit_field.target, actionInvoker, AIEventSender, reportTargetError);
+            Unit* target = GetTargetByType(action.set_unit_field.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection);
 
             // not allow modify important for integrity object fields
             if (action.set_unit_field.field < OBJECT_END || action.set_unit_field.field >= UNIT_END)
-                return;
+                return false;
 
             if (target)
                 target->SetUInt32Value(action.set_unit_field.field, action.set_unit_field.value);
-            else if (reportTargetError)
+            else if (failedTargetSelection)
                 sLog.outErrorEventAI("Event %u - nullptr target for ACTION_T_SET_UNIT_FIELD(%u), target-type %u", eventId, action.type, action.set_unit_field.target);
 
             break;
         }
         case ACTION_T_SET_UNIT_FLAG:
-            if (Unit* target = GetTargetByType(action.unit_flag.target, actionInvoker, AIEventSender, reportTargetError))
+            if (Unit* target = GetTargetByType(action.unit_flag.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection))
                 target->SetFlag(UNIT_FIELD_FLAGS, action.unit_flag.value);
-            else if (reportTargetError)
+            else if (failedTargetSelection)
                 sLog.outErrorEventAI("Event %u - nullptr target for ACTION_T_SET_UNIT_FLAG(%u), target-type %u", eventId, action.type, action.unit_flag.target);
             break;
         case ACTION_T_REMOVE_UNIT_FLAG:
-            if (Unit* target = GetTargetByType(action.unit_flag.target, actionInvoker, AIEventSender, reportTargetError))
+            if (Unit* target = GetTargetByType(action.unit_flag.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection))
                 target->RemoveFlag(UNIT_FIELD_FLAGS, action.unit_flag.value);
-            else if (reportTargetError)
+            else if (failedTargetSelection)
                 sLog.outErrorEventAI("Event %u - nullptr target for ACTION_T_REMOVE_UNIT_FLAG(%u), target-type %u", eventId, action.type, action.unit_flag.target);
             break;
         case ACTION_T_AUTO_ATTACK:
-            m_meleeEnabled = action.auto_attack.state != 0;
+            SetMeleeEnabled(action.auto_attack.state != 0);
             break;
         case ACTION_T_COMBAT_MOVEMENT:
         {
@@ -877,7 +970,7 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
 
             // ignore no affect case
             if (hasCombatMovement == (action.combat_movement.state != 0) || m_creature->IsNonMeleeSpellCasted(false))
-                return;
+                return false;
 
             SetCombatMovement(action.combat_movement.state != 0, true);
 
@@ -889,7 +982,7 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
         }
         case ACTION_T_SET_PHASE:
             m_Phase = action.set_phase.phase;
-            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "CreatureEventAI: ACTION_T_SET_PHASE - script %u for %s, phase is now %u", eventId, m_creature->GetGuidStr().c_str(), m_Phase);
+            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "%s: ACTION_T_SET_PHASE - script %u for %s, phase is now %u", GetAIName().data(), eventId, m_creature->GetGuidStr().c_str(), m_Phase);
             break;
         case ACTION_T_INC_PHASE:
         {
@@ -907,7 +1000,7 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             else
                 m_Phase = new_phase;
 
-            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "CreatureEventAI: ACTION_T_INC_PHASE - script %u for %s, phase is now %u", eventId, m_creature->GetGuidStr().c_str(), m_Phase);
+            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "%s: ACTION_T_INC_PHASE - script %u for %s, phase is now %u", GetAIName().data(), eventId, m_creature->GetGuidStr().c_str(), m_Phase);
             break;
         }
         case ACTION_T_EVADE:
@@ -936,9 +1029,9 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             break;
         }
         case ACTION_T_REMOVEAURASFROMSPELL:
-            if (Unit* target = GetTargetByType(action.remove_aura.target, actionInvoker, AIEventSender, reportTargetError))
+            if (Unit* target = GetTargetByType(action.remove_aura.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection))
                 target->RemoveAurasDueToSpell(action.remove_aura.spellId);
-            else if (reportTargetError)
+            else if (failedTargetSelection)
                 sLog.outErrorEventAI("Event %u - nullptr target for ACTION_T_REMOVEAURASFROMSPELL(%u), target-type %u", eventId, action.type, action.remove_aura.target);
             break;
         case ACTION_T_RANGED_MOVEMENT:
@@ -957,25 +1050,25 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             break;
         case ACTION_T_RANDOM_PHASE:
             m_Phase = GetRandActionParam(rnd, action.random_phase.phase1, action.random_phase.phase2, action.random_phase.phase3);
-            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "CreatureEventAI: ACTION_T_RANDOM_PHASE - script %u for %s, phase is now %u", eventId, m_creature->GetGuidStr().c_str(), m_Phase);
+            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "%s: ACTION_T_RANDOM_PHASE - script %u for %s, phase is now %u", GetAIName().data(), eventId, m_creature->GetGuidStr().c_str(), m_Phase);
             break;
         case ACTION_T_RANDOM_PHASE_RANGE:
             if (action.random_phase_range.phaseMax > action.random_phase_range.phaseMin)
-                m_Phase = action.random_phase_range.phaseMin + (rnd % (action.random_phase_range.phaseMax - action.random_phase_range.phaseMin));
+                m_Phase = rnd % (action.random_phase_range.phaseMax - action.random_phase_range.phaseMin + 1) + action.random_phase_range.phaseMin;
             else
                 sLog.outErrorEventAI("ACTION_T_RANDOM_PHASE_RANGE cannot have Param2 <= Param1. Divide by Zero. Event = %d. CreatureEntry = %d", eventId, m_creature->GetEntry());
             break;
         case ACTION_T_SUMMON_ID:
         {
-            Unit* target = GetTargetByType(action.summon_id.target, actionInvoker, AIEventSender, reportTargetError);
-            if (!target && reportTargetError)
+            Unit* target = GetTargetByType(action.summon_id.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection);
+            if (!target && failedTargetSelection)
                 sLog.outErrorEventAI("Event %u - nullptr target for ACTION_T_SUMMON_ID(%u), target-type %u", eventId, action.type, action.summon_id.target);
 
             CreatureEventAI_Summon_Map::const_iterator i = sEventAIMgr.GetCreatureEventAISummonMap().find(action.summon_id.spawnId);
             if (i == sEventAIMgr.GetCreatureEventAISummonMap().end())
             {
-                sLog.outErrorEventAI("failed to spawn creature %u. Summon map index %u does not exist. EventID %d. CreatureID %d", action.summon_id.creatureId, action.summon_id.spawnId, eventId, m_creature->GetEntry());
-                return;
+                sLog.outErrorEventAI("Failed to spawn creature %u. Summon map index %u does not exist. EventID %d. CreatureID %d", action.summon_id.creatureId, action.summon_id.spawnId, eventId, m_creature->GetEntry());
+                return false;
             }
 
             Creature* pCreature;
@@ -986,7 +1079,7 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                 pCreature = m_creature->SummonCreature(action.summon_id.creatureId, cEventAI->position_x, cEventAI->position_y, cEventAI->position_z, cEventAI->orientation, TEMPSPAWN_TIMED_OOC_DESPAWN, 0);
 
             if (!pCreature)
-                sLog.outErrorEventAI("failed to spawn creature %u. EventId %d.Creature %d", action.summon_id.creatureId, eventId, m_creature->GetEntry());
+                sLog.outErrorEventAI("Failed to spawn creature %u. EventId %d.Creature %d", action.summon_id.creatureId, eventId, m_creature->GetEntry());
             else if (action.summon_id.target != TARGET_T_SELF && target)
                 pCreature->AI()->AttackStart(target);
 
@@ -999,12 +1092,12 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             else
             {
                 // if not available, use pActionInvoker
-                if (Unit* pTarget = GetTargetByType(action.killed_monster.target, actionInvoker, AIEventSender, reportTargetError, 0, SELECT_FLAG_PLAYER))
+                if (Unit* pTarget = GetTargetByType(action.killed_monster.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection, 0, SELECT_FLAG_PLAYER))
                 {
                     if (Player* pPlayer2 = pTarget->GetBeneficiaryPlayer())
                         pPlayer2->RewardPlayerAndGroupAtEventCredit(action.killed_monster.creatureId, m_creature);
                 }
-                else if (reportTargetError)
+                else if (failedTargetSelection)
                     sLog.outErrorEventAI("Event %u - nullptr target for ACTION_T_KILLED_MONSTER(%u), target-type %u", eventId, action.type, action.killed_monster.target);
             }
             break;
@@ -1014,7 +1107,7 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             if (!pInst)
             {
                 sLog.outErrorEventAI("Event %d attempt to set instance data without instance script. Creature %d", eventId, m_creature->GetEntry());
-                return;
+                return false;
             }
 
             pInst->SetData(action.set_inst_data.field, action.set_inst_data.value);
@@ -1022,19 +1115,19 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
         }
         case ACTION_T_SET_INST_DATA64:
         {
-            Unit* target = GetTargetByType(action.set_inst_data64.target, actionInvoker, AIEventSender, reportTargetError);
+            Unit* target = GetTargetByType(action.set_inst_data64.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection);
             if (!target)
             {
-                if (reportTargetError)
+                if (failedTargetSelection)
                     sLog.outErrorEventAI("Event %d attempt to set instance data64 but Target == nullptr. Creature %d", eventId, m_creature->GetEntry());
-                return;
+                return false;
             }
 
             InstanceData* pInst = m_creature->GetInstanceData();
             if (!pInst)
             {
                 sLog.outErrorEventAI("Event %d attempt to set instance data64 without instance script. Creature %d", eventId, m_creature->GetEntry());
-                return;
+                return false;
             }
 
             pInst->SetData64(action.set_inst_data64.field, target->GetObjectGuid().GetRawValue());
@@ -1044,19 +1137,21 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             if (m_creature->GetEntry() == action.update_template.creatureId)
             {
                 sLog.outErrorEventAI("Event %d ACTION_T_UPDATE_TEMPLATE call with param1 == current entry. Creature %d", eventId, m_creature->GetEntry());
-                return;
+                return false;
             }
 
             m_creature->UpdateEntry(action.update_template.creatureId, action.update_template.team ? HORDE : ALLIANCE);
             break;
         case ACTION_T_DIE:
+        {
             if (m_creature->isDead())
             {
                 sLog.outErrorEventAI("Event %d ACTION_T_DIE on dead creature. Creature %d", eventId, m_creature->GetEntry());
-                return;
+                return false;
             }
             m_creature->DealDamage(m_creature, m_creature->GetMaxHealth(), nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, nullptr, false);
             break;
+        }
         case ACTION_T_ZONE_COMBAT_PULSE:
         {
             m_creature->SetInCombatWithZone();
@@ -1109,14 +1204,14 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
         }
         case ACTION_T_THROW_AI_EVENT:
         {
-            Unit* target = GetTargetByType(action.throwEvent.target, actionInvoker, AIEventSender, reportTargetError);
+            Unit* target = GetTargetByType(action.throwEvent.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection);
             if (!target)
             {
-                if (reportTargetError)
+                if (failedTargetSelection)
                     sLog.outErrorEventAI("Event %d attempt to start relay script but Target == nullptr. Creature %d", eventId, m_creature->GetEntry());
-                return;
+                return false;
             }
-            SendAIEventAround(AIEventType(action.throwEvent.eventType), actionInvoker, 0, action.throwEvent.radius);
+            SendAIEventAround(AIEventType(action.throwEvent.eventType), target, 0, action.throwEvent.radius);
             break;
         }
         case ACTION_T_SET_THROW_MASK:
@@ -1140,6 +1235,8 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                     m_creature->GetMotionMaster()->MoveRandomAroundPoint(m_creature->GetPositionX(), m_creature->GetPositionY(), m_creature->GetPositionZ(), float(action.changeMovement.wanderORpathID));
                     break;
                 case WAYPOINT_MOTION_TYPE:
+                    m_creature->StopMoving();
+                    m_creature->GetMotionMaster()->Clear(false, true);
                     m_creature->GetMotionMaster()->MoveWaypoint(action.changeMovement.wanderORpathID);
                     break;
             }
@@ -1175,12 +1272,12 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
         }
         case ACTION_T_START_RELAY_SCRIPT:
         {
-            Unit* target = GetTargetByType(action.relayScript.target, actionInvoker, AIEventSender, reportTargetError);
+            Unit* target = GetTargetByType(action.relayScript.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection);
             if (!target)
             {
-                if (reportTargetError)
+                if (failedTargetSelection)
                     sLog.outErrorEventAI("Event %d attempt to start relay script but Target == nullptr. Creature %d", eventId, m_creature->GetEntry());
-                return;
+                return false;
             }
 
             if (action.relayScript.relayId < 0)
@@ -1196,12 +1293,12 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
         }
         case ACTION_T_TEXT_NEW:
         {
-            Unit* target = GetTargetByType(action.textNew.target, actionInvoker, AIEventSender, reportTargetError);
+            Unit* target = GetTargetByType(action.textNew.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection);
             if (!target)
             {
-                if (reportTargetError)
+                if (failedTargetSelection)
                     sLog.outErrorEventAI("Event %d attempt to start relay script but Target == nullptr. Creature %d", eventId, m_creature->GetEntry());
-                return;
+                return false;
             }
 
             int32 textId = 0;
@@ -1221,12 +1318,12 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
         }
         case ACTION_T_ATTACK_START:
         {
-            Unit* target = GetTargetByType(action.attackStart.target, actionInvoker, AIEventSender, reportTargetError);
+            Unit* target = GetTargetByType(action.attackStart.target, actionInvoker, AIEventSender, eventTarget, failedTargetSelection);
             if (!target)
             {
-                if (reportTargetError)
+                if (failedTargetSelection)
                     sLog.outErrorEventAI("Event %d attempt to start relay script but Target == nullptr. Creature %d", eventId, m_creature->GetEntry());
-                return;
+                return false;
             }
             AttackStart(target);
             break;
@@ -1246,10 +1343,17 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                 m_creature->RemoveGuardians();
             break;
         }
-        default:
-            sLog.outError("CreatureEventAi::ProcessAction(): action(%u) not implemented", static_cast<uint32>(action.type));
+        case ACTION_T_SET_RANGED_MODE:
+        {
+            SetRangedMode(action.rangedMode.type != TYPE_NONE, float(action.rangedMode.chaseDistance), RangeModeType(action.rangedMode.type));
             break;
+        }
+        default:
+            sLog.outError("%s::ProcessAction(): action(%u) not implemented", GetAIName().data(), static_cast<uint32>(action.type));
+            return false;
     }
+
+    return true;
 }
 
 void CreatureEventAI::JustRespawned()                       // NOTE that this is called from the AI's constructor as well
@@ -1259,28 +1363,30 @@ void CreatureEventAI::JustRespawned()                       // NOTE that this is
     m_throwAIEventStep = 0;
     m_LastSpellMaxRange = 0;
 
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        CreatureEventAI_Event const& event = i->Event;
+        CreatureEventAI_Event const& event = i->event;
         switch (event.event_type)
         {
             // Handle Spawned Events
             case EVENT_T_SPAWNED:
-                if (SpawnedEventConditionsCheck(i->Event))
-                    ProcessEvent(*i);
+                if (SpawnedEventConditionsCheck(i->event))
+                    CheckAndReadyEventForExecution(*i);
                 break;
             case EVENT_T_TIMER_IN_COMBAT:
             case EVENT_T_TIMER_OOC:
             case EVENT_T_TIMER_GENERIC:
-                if (i->UpdateRepeatTimer(m_creature, i->Event.timer.initialMin, i->Event.timer.initialMax))
-                    i->Enabled = true;
+                if (i->UpdateRepeatTimer(m_creature, i->event.timer.initialMin, i->event.timer.initialMax))
+                    i->enabled = true;
                 break;
             default: // reset all events with initialMin/Max here
-                i->Enabled = true;
-                i->Time = 0;
+                i->enabled = true;
+                i->timer = 0;
                 break;
         }
     }
+    ProcessEvents();
 }
 
 void CreatureEventAI::Reset()
@@ -1289,11 +1395,13 @@ void CreatureEventAI::Reset()
     m_EventDiff = 0;
     m_throwAIEventStep = 0;
     m_LastSpellMaxRange = 0;
+    m_currentRangedMode = m_rangedMode;
+    m_attackDistance = m_chaseDistance;
 
     // Reset all events to enabled
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        CreatureEventAI_Event const& event = i->Event;
+        CreatureEventAI_Event const& event = i->event;
         switch (event.event_type)
         {
             // Dont reset any combat timers
@@ -1303,11 +1411,11 @@ void CreatureEventAI::Reset()
                 break;
             case EVENT_T_TIMER_OOC:
                 if (i->UpdateRepeatTimer(m_creature, event.timer.initialMin, event.timer.initialMax))
-                    i->Enabled = true;
+                    i->enabled = true;
                 break;
             default: // reset all events here, was previously done on enter combat
-                i->Enabled = true;
-                i->Time = 0;
+                i->enabled = true;
+                i->timer = 0;
                 break;
         }
     }
@@ -1315,11 +1423,13 @@ void CreatureEventAI::Reset()
 
 void CreatureEventAI::JustReachedHome()
 {
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        if (i->Event.event_type == EVENT_T_REACHED_HOME)
-            ProcessEvent(*i);
+        if (i->event.event_type == EVENT_T_REACHED_HOME)
+            CheckAndReadyEventForExecution(*i);
     }
+    ProcessEvents();
 
     Reset();
 }
@@ -1335,33 +1445,30 @@ void CreatureEventAI::EnterEvadeMode()
     UnitAI::EnterEvadeMode();
 
     // Handle Evade events
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        if (i->Event.event_type == EVENT_T_EVADE)
-            ProcessEvent(*i);
+        if (i->event.event_type == EVENT_T_EVADE)
+            CheckAndReadyEventForExecution(*i);
     }
+    ProcessEvents();
 }
 
 void CreatureEventAI::JustDied(Unit* killer)
 {
     Reset();
 
-    if (m_creature->IsGuard())
-    {
-        // Send Zone Under Attack message to the LocalDefense and WorldDefense Channels
-        if (Player* pKiller = killer->GetBeneficiaryPlayer())
-            m_creature->SendZoneUnderAttackMessage(pKiller);
-    }
-
     if (m_throwAIEventMask & (1 << AI_EVENT_JUST_DIED))
         SendAIEventAround(AI_EVENT_JUST_DIED, killer, 0, AIEVENT_DEFAULT_THROW_RADIUS);
 
     // Handle On Death events
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        if (i->Event.event_type == EVENT_T_DEATH)
-            ProcessEvent(*i, killer);
+        if (i->event.event_type == EVENT_T_DEATH)
+            CheckAndReadyEventForExecution(*i, killer);
     }
+    ProcessEvents(killer);
 
     // reset phase after any death state events
     m_Phase = 0;
@@ -1369,81 +1476,90 @@ void CreatureEventAI::JustDied(Unit* killer)
 
 void CreatureEventAI::KilledUnit(Unit* victim)
 {
-    if (victim->GetTypeId() != TYPEID_PLAYER)
-        return;
-
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        if (i->Event.event_type == EVENT_T_KILL)
-            ProcessEvent(*i, victim);
+        if (i->event.event_type == EVENT_T_KILL)
+            CheckAndReadyEventForExecution(*i, victim);
     }
+    ProcessEvents(victim);
 }
 
 void CreatureEventAI::JustSummoned(Creature* summoned)
 {
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        if (i->Event.event_type == EVENT_T_SUMMONED_UNIT)
-            ProcessEvent(*i, summoned);
+        if (i->event.event_type == EVENT_T_SUMMONED_UNIT)
+            CheckAndReadyEventForExecution(*i, summoned);
     }
+    ProcessEvents(summoned);
 }
 
 void CreatureEventAI::SummonedCreatureJustDied(Creature* summoned)
 {
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        if (i->Event.event_type == EVENT_T_SUMMONED_JUST_DIED)
-            ProcessEvent(*i, summoned);
+        if (i->event.event_type == EVENT_T_SUMMONED_JUST_DIED)
+            CheckAndReadyEventForExecution(*i, summoned);
     }
+    ProcessEvents(summoned);
 }
 
 void CreatureEventAI::SummonedCreatureDespawn(Creature* summoned)
 {
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        if (i->Event.event_type == EVENT_T_SUMMONED_JUST_DESPAWN)
-            ProcessEvent(*i, summoned);
+        if (i->event.event_type == EVENT_T_SUMMONED_JUST_DESPAWN)
+            CheckAndReadyEventForExecution(*i, summoned);
     }
+    ProcessEvents(summoned);
 }
 
 void CreatureEventAI::ReceiveAIEvent(AIEventType eventType, Unit* sender, Unit* invoker, uint32 /*miscValue*/)
 {
     MANGOS_ASSERT(sender);
 
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator itr = m_CreatureEventAIList.begin(); itr != m_CreatureEventAIList.end(); ++itr)
     {
-        if (itr->Event.event_type == EVENT_T_RECEIVE_AI_EVENT &&
-                itr->Event.receiveAIEvent.eventType == eventType && (!itr->Event.receiveAIEvent.senderEntry || itr->Event.receiveAIEvent.senderEntry == sender->GetEntry()))
-            ProcessEvent(*itr, invoker, sender);
+        if (itr->event.event_type == EVENT_T_RECEIVE_AI_EVENT &&
+                itr->event.receiveAIEvent.eventType == eventType && (!itr->event.receiveAIEvent.senderEntry || itr->event.receiveAIEvent.senderEntry == sender->GetEntry()))
+            CheckAndReadyEventForExecution(*itr, invoker, sender);
     }
+    ProcessEvents(invoker, sender);
 }
 
 void CreatureEventAI::EnterCombat(Unit* enemy)
 {
     // Check for on combat start events
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
     {
-        CreatureEventAI_Event const& event = i->Event;
+        CreatureEventAI_Event const& event = i->event;
         switch (event.event_type)
         {
             case EVENT_T_AGGRO:
-                i->Enabled = true;
-                ProcessEvent(*i, enemy);
+                i->enabled = true;
+                CheckAndReadyEventForExecution(*i, enemy);
                 break;
             // Reset all in combat timers
             case EVENT_T_TIMER_IN_COMBAT:
                 if (i->UpdateRepeatTimer(m_creature, event.timer.initialMin, event.timer.initialMax))
-                    i->Enabled = true;
+                    i->enabled = true;
                 break;
             // Reset some special combat timers using repeatMin/Max
             case EVENT_T_SELECT_ATTACKING_TARGET:
                 if (i->UpdateRepeatTimer(m_creature, event.timer.repeatMin, event.timer.repeatMax))
-                    i->Enabled = true;
+                    i->enabled = true;
                 break;
             default:
                 break;
         }
     }
+    ProcessEvents(enemy);
 
     m_EventUpdateTime = EVENT_UPDATE_TIME;
     m_EventDiff = 0;
@@ -1454,38 +1570,47 @@ void CreatureEventAI::EnterCombat(Unit* enemy)
 void CreatureEventAI::MoveInLineOfSight(Unit* who)
 {
     // Check for OOC LOS Event
+    IncreaseDepthIfNecessary();
     if (m_HasOOCLoSEvent && !m_creature->getVictim())
     {
         for (CreatureEventAIList::iterator itr = m_CreatureEventAIList.begin(); itr != m_CreatureEventAIList.end(); ++itr)
         {
-            if (itr->Event.event_type == EVENT_T_OOC_LOS)
+            if (itr->event.event_type == EVENT_T_OOC_LOS)
             {
                 // can trigger if closer than fMaxAllowedRange
-                float fMaxAllowedRange = (float)itr->Event.ooc_los.maxRange;
+                float fMaxAllowedRange = (float)itr->event.ooc_los.maxRange;
 
-                // if friendly event && who is not hostile OR hostile event && who is hostile
-                if ((itr->Event.ooc_los.noHostile && !m_creature->IsEnemy(who)) ||
-                        ((!itr->Event.ooc_los.noHostile) && m_creature->IsEnemy(who)))
+                // who must be player type if this option is turned on
+                if (!itr->event.ooc_los.playerOnly || who->GetTypeId() == TYPEID_PLAYER)
                 {
-                    // if range is ok and we are actually in LOS
-                    if (m_creature->IsWithinDistInMap(who, fMaxAllowedRange) && m_creature->IsWithinLOSInMap(who))
-                        ProcessEvent(*itr, who);
+                    // if friendly event && who is not hostile OR hostile event && who is hostile
+                    if ((itr->event.ooc_los.noHostile && !m_creature->IsEnemy(who)) ||
+                            ((!itr->event.ooc_los.noHostile) && m_creature->IsEnemy(who)))
+                    {
+                        // if range is ok and we are actually in LOS
+                        if (m_creature->IsWithinDistInMap(who, fMaxAllowedRange) && m_creature->IsWithinLOSInMap(who))
+                            CheckAndReadyEventForExecution(*itr, who);
+                    }
                 }
             }
         }
+        ProcessEvents(who);
     }
 
     UnitAI::MoveInLineOfSight(who);
 }
 
-void CreatureEventAI::SpellHit(Unit* pUnit, const SpellEntry* spellInfo)
+void CreatureEventAI::SpellHit(Unit* unit, const SpellEntry* spellInfo)
 {
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
-        if (i->Event.event_type == EVENT_T_SPELLHIT)
+        if (i->event.event_type == EVENT_T_SPELLHIT)
             // If spell id matches (or no spell id) & if spell school matches (or no spell school)
-            if (!i->Event.spell_hit.spellId || spellInfo->Id == i->Event.spell_hit.spellId)
-                if (spellInfo->SchoolMask & i->Event.spell_hit.schoolMask)
-                    ProcessEvent(*i, pUnit);
+            if (!i->event.spell_hit.spellId || spellInfo->Id == i->event.spell_hit.spellId)
+                if (spellInfo->SchoolMask & i->event.spell_hit.schoolMask)
+                    CheckAndReadyEventForExecution(*i, unit);
+
+    ProcessEvents(unit);
 }
 
 void CreatureEventAI::UpdateAI(const uint32 diff)
@@ -1493,48 +1618,18 @@ void CreatureEventAI::UpdateAI(const uint32 diff)
     // Check if we are in combat (also updates calls threat update code)
     bool Combat = m_creature->SelectHostileTarget() && m_creature->getVictim();
 
-    // Events are only updated once every EVENT_UPDATE_TIME ms to prevent lag with large amount of events
-    if (m_EventUpdateTime < diff)
-    {
-        m_EventDiff += diff;
-
-        // Check for time based events
-        for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
-        {
-            // Decrement Timers
-            if (i->Time)
-            {
-                // Do not decrement timers if event cannot trigger in this phase
-                if (!(i->Event.event_inverse_phase_mask & (1 << m_Phase)))
-                {
-                    if (i->Time > m_EventDiff)
-                        i->Time -= m_EventDiff;
-                    else
-                        i->Time = 0;
-                }
-            }
-
-            // Skip processing of events that have time remaining or are disabled
-            if (!(i->Enabled) || i->Time)
-                continue;
-
-            if (IsTimerBasedEvent(i->Event.event_type))
-                ProcessEvent(*i);
-        }
-
-        m_EventDiff = 0;
-        m_EventUpdateTime = EVENT_UPDATE_TIME;
-    }
-    else
-    {
-        m_EventDiff += diff;
-        m_EventUpdateTime -= diff;
-    }
+    UpdateEventTimers(diff);
 
     Unit* victim = m_creature->getVictim();
     // Melee Auto-Attack
-    if (Combat && victim && !(m_creature->IsNonMeleeSpellCasted(false) || m_creature->hasUnitState(UNIT_STAT_CAN_NOT_REACT)))
+    if (Combat && victim && !(m_creature->IsNonMeleeSpellCasted(false) || m_creature->hasUnitState(UNIT_STAT_CAN_NOT_REACT)) && !m_combatScriptHappening)
     {
+        if (m_rangedMode)
+        {
+            if (m_currentRangedMode && m_rangedModeSetting == TYPE_PROXIMITY && m_creature->IsWithinCombatDist(victim, 8.f))
+                SetCurrentRangedMode(false);
+        }
+
         // Update creature dynamic movement position before doing anything else
         if (m_DynamicMovement)
         {
@@ -1552,7 +1647,7 @@ void CreatureEventAI::UpdateAI(const uint32 diff)
             else
                 SetCombatMovement(true, true);
         }
-        else if (m_meleeEnabled && !(m_creature->GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_NO_MELEE))
+        else if (m_meleeEnabled && !m_currentRangedMode)
             DoMeleeAttackIfReady();
     }
 }
@@ -1579,7 +1674,7 @@ inline int32 CreatureEventAI::GetRandActionParam(uint32 rnd, int32 param1, int32
     return 0;
 }
 
-inline Unit* CreatureEventAI::GetTargetByType(uint32 target, Unit* actionInvoker, Unit* AIEventSender, bool& isError, uint32 forSpellId, uint32 selectFlags) const
+inline Unit* CreatureEventAI::GetTargetByType(uint32 target, Unit* actionInvoker, Unit* AIEventSender, Unit* eventTarget, bool& isError, uint32 forSpellId, uint32 selectFlags) const
 {
     Unit* resTarget;
     switch (target)
@@ -1593,22 +1688,22 @@ inline Unit* CreatureEventAI::GetTargetByType(uint32 target, Unit* actionInvoker
             return resTarget;
         case TARGET_T_HOSTILE_SECOND_AGGRO:
             resTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_TOPAGGRO, 1, forSpellId, selectFlags);
-            if (!resTarget && ((forSpellId == 0 && selectFlags == 0 && m_creature->getThreatManager().getThreatList().size() > 1) || m_creature->getThreatManager().getThreatList().empty()))
+            if (!resTarget)
                 isError = true;
             return resTarget;
         case TARGET_T_HOSTILE_LAST_AGGRO:
             resTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_BOTTOMAGGRO, 0, forSpellId, selectFlags);
-            if (!resTarget && m_creature->getThreatManager().getThreatList().empty())
+            if (!resTarget)
                 isError = true;
             return resTarget;
         case TARGET_T_HOSTILE_RANDOM:
             resTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, forSpellId, selectFlags);
-            if (!resTarget && m_creature->getThreatManager().getThreatList().empty())
+            if (!resTarget)
                 isError = true;
             return resTarget;
         case TARGET_T_HOSTILE_RANDOM_NOT_TOP:
             resTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 1, forSpellId, selectFlags);
-            if (!resTarget && ((forSpellId == 0 && selectFlags == 0 && m_creature->getThreatManager().getThreatList().size() > 1) || m_creature->getThreatManager().getThreatList().empty()))
+            if (!resTarget)
                 isError = true;
             return resTarget;
         case TARGET_T_HOSTILE_RANDOM_PLAYER:
@@ -1618,7 +1713,22 @@ inline Unit* CreatureEventAI::GetTargetByType(uint32 target, Unit* actionInvoker
             return resTarget;
         case TARGET_T_HOSTILE_RANDOM_NOT_TOP_PLAYER:
             resTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 1, forSpellId, SELECT_FLAG_PLAYER | selectFlags);
-            if (!resTarget && ((forSpellId == 0 && selectFlags == 0 && m_creature->getThreatManager().getThreatList().size() > 1) || m_creature->getThreatManager().getThreatList().empty()))
+            if (!resTarget)
+                isError = true;
+            return resTarget;
+        case TARGET_T_HOSTILE_RANDOM_MANA:
+            resTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, forSpellId, SELECT_FLAG_POWER_MANA | selectFlags);
+            if (!resTarget)
+                isError = true;
+            return resTarget;
+        case TARGET_T_NEAREST_AOE_TARGET:
+            resTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_NEAREST_BY, 0, forSpellId, SELECT_FLAG_USE_EFFECT_RADIUS | selectFlags);
+            if (!resTarget)
+                isError = true;
+            return nullptr; // Only used to check if it exists
+        case TARGET_T_HOSTILE_FARTHEST_AWAY:
+            resTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_FARTHEST_AWAY, 0, forSpellId, SELECT_FLAG_NOT_IN_MELEE_RANGE | selectFlags);
+            if (!resTarget)
                 isError = true;
             return resTarget;
         case TARGET_T_ACTION_INVOKER:
@@ -1643,9 +1753,9 @@ inline Unit* CreatureEventAI::GetTargetByType(uint32 target, Unit* actionInvoker
             return nullptr;
         }
         case TARGET_T_EVENT_SPECIFIC:
-            if (!m_eventTarget)
+            if (!eventTarget)
                 isError = true;
-            return m_eventTarget;
+            return eventTarget;
         case TARGET_T_PLAYER_INVOKER:
         {
             if (!m_creature->HasLootRecipient())
@@ -1666,6 +1776,8 @@ inline Unit* CreatureEventAI::GetTargetByType(uint32 target, Unit* actionInvoker
 
             return m_creature->GetLootRecipient();
         }
+        case TARGET_T_NONE:
+            return nullptr;
         default:
             isError = true;
             return nullptr;
@@ -1691,21 +1803,18 @@ void CreatureEventAI::DoFindFriendlyMissingBuff(std::list<Creature*>& list, floa
 
 void CreatureEventAI::ReceiveEmote(Player* player, uint32 textEmote)
 {
+    IncreaseDepthIfNecessary();
     for (CreatureEventAIList::iterator itr = m_CreatureEventAIList.begin(); itr != m_CreatureEventAIList.end(); ++itr)
     {
-        if (itr->Event.event_type == EVENT_T_RECEIVE_EMOTE)
+        if (itr->event.event_type == EVENT_T_RECEIVE_EMOTE)
         {
-            if (itr->Event.receive_emote.emoteId != textEmote)
+            if (itr->event.receive_emote.emoteId != textEmote)
                 continue;
 
-            PlayerCondition pcon(0, itr->Event.receive_emote.condition, itr->Event.receive_emote.conditionValue1, itr->Event.receive_emote.conditionValue2);
-            if (pcon.Meets(player, m_creature->GetMap(), m_creature, CONDITION_FROM_EVENTAI))
-            {
-                DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "CreatureEventAI: ReceiveEmote CreatureEventAI: Condition ok, processing");
-                ProcessEvent(*itr, player);
-            }
+            CheckAndReadyEventForExecution(*itr, player);
         }
     }
+    ProcessEvents(player);
 }
 
 #define HEALTH_STEPS            3
@@ -1786,4 +1895,140 @@ bool CreatureEventAI::SpawnedEventConditionsCheck(CreatureEventAI_Event const& e
     }
 
     return false;
+}
+
+void CreatureEventAI::UpdateEventTimers(const uint32 diff)
+{
+    // Events are only updated once every EVENT_UPDATE_TIME ms to prevent lag with large amount of events
+    if (m_EventUpdateTime < diff)
+    {
+        m_EventDiff += diff;
+
+        // Check for time based events
+        IncreaseDepthIfNecessary();
+        for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
+        {
+            // Decrement Timers
+            if (i->timer)
+            {
+                // Do not decrement timers if event cannot trigger in this phase
+                if (!(i->event.event_inverse_phase_mask & (1 << m_Phase)))
+                {
+                    if (i->timer > m_EventDiff)
+                        i->timer -= m_EventDiff;
+                    else
+                        i->timer = 0;
+                }
+            }
+
+            // Skip processing of events that have time remaining or are disabled
+            if (!(i->enabled) || i->timer)
+                continue;
+
+            if (IsTimerExecutedEvent(i->event.event_type))
+                CheckAndReadyEventForExecution(*i);
+        }
+        ProcessEvents();
+
+        m_EventDiff = 0;
+        m_EventUpdateTime = EVENT_UPDATE_TIME;
+    }
+    else
+    {
+        m_EventDiff += diff;
+        m_EventUpdateTime -= diff;
+    }
+}
+
+void CreatureEventAI::SetRangedMode(bool state, float distance, RangeModeType type)
+{
+    if (m_rangedMode == state)
+        return;
+
+    m_rangedMode = state;
+    m_chaseDistance = distance;
+    m_rangedModeSetting = type;
+    m_meleeEnabled = !state;
+
+    if (m_creature->isInCombat())
+        SetCurrentRangedMode(state);
+    else
+    {
+        m_currentRangedMode = true;
+        m_attackDistance = m_chaseDistance;
+    }
+}
+
+void CreatureEventAI::SetCurrentRangedMode(bool state)
+{
+    if (state)
+    {
+        m_currentRangedMode = true;
+        m_meleeEnabled = false;
+        m_attackDistance = m_chaseDistance;
+        m_creature->MeleeAttackStop(m_creature->getVictim());
+        DoStartMovement(m_creature->getVictim());
+    }
+    else
+    {
+        if (m_rangedModeSetting == TYPE_NO_MELEE_MODE)
+            return;
+
+        m_currentRangedMode = false;
+        m_meleeEnabled = true;
+        m_attackDistance = 0.f;
+        m_creature->MeleeAttackStart(m_creature->getVictim());
+        DoStartMovement(m_creature->getVictim());
+    }
+}
+
+enum EAIPoints
+{
+    POINT_MOVE_DISTANCE
+};
+
+void CreatureEventAI::DistanceYourself()
+{
+    Unit* victim = m_creature->getVictim();
+    if (!victim->CanReachWithMeleeAttack(m_creature))
+        return;
+
+    if (m_mainSpellCost * 2 > m_creature->GetPower(POWER_MANA))
+        return;
+
+    SetCombatScriptStatus(true);
+
+    if (!m_currentRangedMode)
+        SetCurrentRangedMode(true);
+
+    float x, y, z;
+    victim->GetNearPoint(m_creature, x, y, z, m_creature->GetObjectBoundingRadius(), 15.f + m_creature->GetCombinedCombatReach(victim), victim->GetAngle(m_creature));
+    m_creature->GetMotionMaster()->MovePoint(POINT_MOVE_DISTANCE, x, y, z);
+}
+
+void CreatureEventAI::JustStoppedMovementOfTarget(SpellEntry const* spellInfo, Unit* victim)
+{
+    if (m_creature->getVictim() != victim)
+        return;
+    if (m_distanceSpells.find(spellInfo->Id) != m_distanceSpells.end())
+        DistanceYourself();
+}
+
+void CreatureEventAI::MovementInform(uint32 uiType, uint32 uiPointId)
+{
+    if (uiType != POINT_MOTION_TYPE)
+        return;
+    if (uiPointId == POINT_MOVE_DISTANCE)
+    {
+        SetCombatScriptStatus(false);
+        if (m_creature->getVictim())
+            DoStartMovement(m_creature->getVictim());
+    }
+}
+
+void CreatureEventAI::OnSpellInterrupt(SpellEntry const* spellInfo)
+{
+    if (m_mainSpells.find(spellInfo->Id) != m_mainSpells.end())
+        if (m_rangedMode && m_rangedModeSetting != TYPE_NO_MELEE_MODE && !m_creature->IsSpellReady(*spellInfo))
+            SetCurrentRangedMode(false);
 }

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -23,6 +23,7 @@
 #include "Entities/Creature.h"
 #include "AI/BaseAI/CreatureAI.h"
 #include "Entities/Unit.h"
+#include <set>
 
 class Player;
 class WorldObject;
@@ -33,7 +34,7 @@ class WorldObject;
 
 #define LOG_PROCESS_EVENT                                                                                                       \
     DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "CreatureEventAI: Event type %u (script %u) triggered for %s (invoked by %s)",    \
-                     holder.Event.event_type, holder.Event.event_id, m_creature->GetGuidStr().c_str(), actionInvoker ? actionInvoker->GetGuidStr().c_str() : "<no invoker>")
+                     holder.event.event_type, holder.event.event_id, m_creature->GetGuidStr().c_str(), actionInvoker ? actionInvoker->GetGuidStr().c_str() : "<no invoker>")
 
 enum EventAI_Type
 {
@@ -42,12 +43,12 @@ enum EventAI_Type
     EVENT_T_HP                      = 2,                    // HPMax%, HPMin%, RepeatMin, RepeatMax
     EVENT_T_MANA                    = 3,                    // ManaMax%,ManaMin% RepeatMin, RepeatMax
     EVENT_T_AGGRO                   = 4,                    // NONE
-    EVENT_T_KILL                    = 5,                    // RepeatMin, RepeatMax
+    EVENT_T_KILL                    = 5,                    // RepeatMin, RepeatMax, PlayerOnly (1)
     EVENT_T_DEATH                   = 6,                    // ConditionId
     EVENT_T_EVADE                   = 7,                    // NONE
     EVENT_T_SPELLHIT                = 8,                    // SpellID, School, RepeatMin, RepeatMax
     EVENT_T_RANGE                   = 9,                    // MinDist, MaxDist, RepeatMin, RepeatMax
-    EVENT_T_OOC_LOS                 = 10,                   // NoHostile, MaxRnage, RepeatMin, RepeatMax
+    EVENT_T_OOC_LOS                 = 10,                   // NoHostile, MaxRange, RepeatMin, RepeatMax, PlayerOnly, ConditionId
     EVENT_T_SPAWNED                 = 11,                   // Condition, CondValue1
     EVENT_T_TARGET_HP               = 12,                   // HPMax%, HPMin%, RepeatMin, RepeatMax
     EVENT_T_TARGET_CASTING          = 13,                   // RepeatMin, RepeatMax
@@ -59,7 +60,7 @@ enum EventAI_Type
     EVENT_T_QUEST_ACCEPT            = 19,                   // QuestID
     EVENT_T_QUEST_COMPLETE          = 20,                   //
     EVENT_T_REACHED_HOME            = 21,                   // NONE
-    EVENT_T_RECEIVE_EMOTE           = 22,                   // EmoteId, Condition, CondValue1, CondValue2
+    EVENT_T_RECEIVE_EMOTE           = 22,                   // EmoteId, ConditionId
     EVENT_T_AURA                    = 23,                   // Param1 = SpellID, Param2 = Number of time stacked, Param3/4 Repeat Min/Max
     EVENT_T_TARGET_AURA             = 24,                   // Param1 = SpellID, Param2 = Number of time stacked, Param3/4 Repeat Min/Max
     EVENT_T_SUMMONED_JUST_DIED      = 25,                   // CreatureId, RepeatMin, RepeatMax
@@ -88,7 +89,7 @@ enum EventAI_ActionType
     ACTION_T_RANDOM_TEXTEMOTE           = 8,                // UNUSED
     ACTION_T_RANDOM_SOUND               = 9,                // SoundId1, SoundId2, SoundId3 (-1 in any field means no output if randomed that field)
     ACTION_T_RANDOM_EMOTE               = 10,               // EmoteId1, EmoteId2, EmoteId3 (-1 in any field means no output if randomed that field)
-    ACTION_T_CAST                       = 11,               // SpellId, Target, CastFlags
+    ACTION_T_CAST                       = 11,               // SpellId, Target - default = 15, CastFlags
     ACTION_T_SPAWN                      = 12,               // CreatureID, Target, Duration in ms
     ACTION_T_THREAT_SINGLE_PCT          = 13,               // Threat%, Target
     ACTION_T_THREAT_ALL_PCT             = 14,               // Threat%
@@ -134,6 +135,7 @@ enum EventAI_ActionType
     ACTION_T_TEXT_NEW                   = 54,               // Text ID, target, template Id
     ACTION_T_ATTACK_START               = 55,               // Target, unused, unused
     ACTION_T_DESPAWN_GUARDIANS          = 56,               // Guardian Entry ID (or 0 to despawn all guardians), unused, unused
+    ACTION_T_SET_RANGED_MODE            = 57,               // type of ranged mode, distance to chase at
 
     ACTION_T_END,
 };
@@ -160,7 +162,7 @@ enum Target
     TARGET_T_HOSTILE_RANDOM_NOT_TOP_PLAYER  = 9,            // Any random player from threat list except top threat
 
     // Summon targeting
-    TARGET_T_SPAWNER                       = 11,           // Owner of unit if exists
+    TARGET_T_SPAWNER                        = 11,           // Owner of unit if exists
 
     // Event specific targeting
     TARGET_T_EVENT_SPECIFIC                 = 12,           // Filled by specific event
@@ -168,9 +170,16 @@ enum Target
     // Player associations
     TARGET_T_PLAYER_INVOKER                 = 13,           // Player who initiated hostile contact with this npc
     TARGET_T_PLAYER_TAPPED                  = 14,           // Player who currently holds to score the kill credit from the npc
+
+    // Default Spell Target
+    TARGET_T_NONE                           = 15,           // Default spell target - sets nullptr which should be most common spell fill
+
+    TARGET_T_HOSTILE_RANDOM_MANA            = 16,           // Random target with mana
+    TARGET_T_NEAREST_AOE_TARGET             = 17,           // Nearest target for aoe
+    TARGET_T_HOSTILE_FARTHEST_AWAY          = 18,       // Farthest away target, excluding melee range
 };
 
-enum EventFlags
+enum EventFlags : uint32
 {
     EFLAG_REPEATABLE            = 0x01,                     // Event repeats
     EFLAG_NORMAL                = 0x02,                     // Event only occurs in Normal instance difficulty
@@ -180,6 +189,9 @@ enum EventFlags
     EFLAG_RANDOM_ACTION         = 0x20,                     // Event only execute one from existed actions instead each action.
     EFLAG_RESERVED_6            = 0x40,
     EFLAG_DEBUG_ONLY            = 0x80,                     // Event only occurs in debug build
+    EFLAG_RANGED_MODE_ONLY      = 0x100,                    // Event only occurs in ranged mode
+    EFLAG_MELEE_MODE_ONLY       = 0x200,                    // Event only occurs in melee mode
+    EFLAG_COMBAT_ACTION         = 0x400,                    // First action must succeed
     // no free bits, uint8 field
     EFLAG_DIFFICULTY_ALL        = (EFLAG_NORMAL | EFLAG_HEROIC)
 };
@@ -189,6 +201,15 @@ enum SpawnedEventMode
     SPAWNED_EVENT_ALWAY = 0,
     SPAWNED_EVENT_MAP   = 1,
     SPAWNED_EVENT_ZONE  = 2
+};
+
+enum RangeModeType : uint32 // maybe can be substituted for class checks
+{
+    TYPE_NONE           = 0,
+    TYPE_FULL_CASTER    = 1,
+    TYPE_PROXIMITY      = 2,
+    TYPE_NO_MELEE_MODE  = 3,
+    TYPE_MAX,
 };
 
 struct CreatureEventAI_Action
@@ -467,7 +488,7 @@ struct CreatureEventAI_Action
             uint32 unused1;
             uint32 unused2;
         } interruptSpell;
-        // ACTION_T_START_RELAY_SCRIPT                      = 51
+        // ACTION_T_START_RELAY_SCRIPT                      = 53
         struct
         {
             int32 relayId;                                 // dbscript_on_relay id
@@ -495,6 +516,13 @@ struct CreatureEventAI_Action
             uint32 unused;
             uint32 unused2;
         } despawnGuardians;
+        // ACTION_T_SET_RANGED_MODE
+        struct
+        {
+            uint32 type;                                    // enum RangeModeType
+            uint32 chaseDistance;                           // distance at which the AI will chase
+            uint32 unused;                                  // unused
+        } rangedMode;
         // RAW
         struct
         {
@@ -515,7 +543,7 @@ struct CreatureEventAI_Event
 
     EventAI_Type event_type : 16;
     uint8 event_chance : 8;
-    uint8 event_flags  : 8;
+    uint32 event_flags;
 
     union
     {
@@ -546,6 +574,7 @@ struct CreatureEventAI_Event
         {
             uint32 repeatMin;
             uint32 repeatMax;
+            uint32 playerOnly;
         } kill;
         // EVENT_T_DEATH                                    = 6
         struct
@@ -575,6 +604,8 @@ struct CreatureEventAI_Event
             uint32 maxRange;
             uint32 repeatMin;
             uint32 repeatMax;
+            uint32 playerOnly;
+            uint32 conditionId;
         } ooc_los;
         // EVENT_T_SPAWNED                                  = 11
         struct
@@ -631,9 +662,7 @@ struct CreatureEventAI_Event
         struct
         {
             uint32 emoteId;
-            uint32 condition;
-            uint32 conditionValue1;
-            uint32 conditionValue2;
+            uint32 conditionId;
         } receive_emote;
         // EVENT_T_AURA                                     = 23
         // EVENT_T_TARGET_AURA                              = 24
@@ -673,10 +702,7 @@ struct CreatureEventAI_Event
         // RAW
         struct
         {
-            uint32 param1;
-            uint32 param2;
-            uint32 param3;
-            uint32 param4;
+            uint32 params[6];
         } raw;
     };
 
@@ -705,11 +731,14 @@ typedef std::unordered_map<uint32, CreatureEventAI_Summon> CreatureEventAI_Summo
 
 struct CreatureEventAIHolder
 {
-    CreatureEventAIHolder(CreatureEventAI_Event p) : Event(p), Time(0), Enabled(true) {}
+    CreatureEventAIHolder(CreatureEventAI_Event p) : event(p), timer(0), enabled(true), inProgress(false), eventTarget(nullptr) {}
 
-    CreatureEventAI_Event Event;
-    uint32 Time;
-    bool Enabled;
+    CreatureEventAI_Event event;
+    uint32 timer;
+    bool enabled;
+    bool inProgress;
+
+    Unit* eventTarget; // Target filled on specific event to be used in action
 
     // helper
     bool UpdateRepeatTimer(Creature* creature, uint32 repeatMin, uint32 repeatMax);
@@ -718,11 +747,12 @@ struct CreatureEventAIHolder
 class CreatureEventAI : public CreatureAI
 {
     public:
-        explicit CreatureEventAI(Creature* c);
+        explicit CreatureEventAI(Creature* creature);
         ~CreatureEventAI()
         {
             m_CreatureEventAIList.clear();
         }
+        void InitAI();
 
         void GetAIInformation(ChatHandler& reader) override;
 
@@ -748,21 +778,39 @@ class CreatureEventAI : public CreatureAI
 
         static int Permissible(const Creature* creature);
 
+        void UpdateEventTimers(const uint32 diff);
+        void ProcessEvents(Unit* actionInvoker = nullptr, Unit* AIEventSender = nullptr);
+        bool CheckEvent(CreatureEventAIHolder& holder, Unit* actionInvoker = nullptr, Unit* AIEventSender = nullptr);
+        void ResetEvent(CreatureEventAIHolder& holder);
+        void CheckAndReadyEventForExecution(CreatureEventAIHolder& holder, Unit* actionInvoker = nullptr, Unit* AIEventSender = nullptr);
+        void IncreaseDepthIfNecessary() { if (m_depth >= m_creatureEventAITempList.size()) m_creatureEventAITempList.resize(m_depth + 1); }
         virtual bool ProcessEvent(CreatureEventAIHolder& holder, Unit* actionInvoker = nullptr, Unit* AIEventSender = nullptr);
-        virtual void ProcessAction(CreatureEventAI_Action const& action, uint32 rnd, uint32 eventId, Unit* actionInvoker, Unit* AIEventSender);
+        virtual bool ProcessAction(CreatureEventAI_Action const& action, uint32 rnd, uint32 eventId, Unit* actionInvoker, Unit* AIEventSender, Unit* eventTarget);
         inline uint32 GetRandActionParam(uint32 rnd, uint32 param1, uint32 param2, uint32 param3) const;
         inline int32 GetRandActionParam(uint32 rnd, int32 param1, int32 param2, int32 param3) const;
         /// If the bool& param is true, an error should be reported
-        inline Unit* GetTargetByType(uint32 target, Unit* actionInvoker, Unit* AIEventSender, bool& isError, uint32 forSpellId = 0, uint32 selectFlags = 0) const;
+        inline Unit* GetTargetByType(uint32 target, Unit* actionInvoker, Unit* AIEventSender, Unit* eventTarget, bool& isError, uint32 forSpellId = 0, uint32 selectFlags = 0) const;
 
         bool SpawnedEventConditionsCheck(CreatureEventAI_Event const& event) const;
 
         void DoFindFriendlyMissingBuff(std::list<Creature*>& list, float range, uint32 spellid) const;
         void DoFindFriendlyCC(std::list<Creature*>& list, float range) const;
 
+        void SetRangedMode(bool state, float distance, RangeModeType type);
+        void SetCurrentRangedMode(bool state);
+
+        void JustStoppedMovementOfTarget(SpellEntry const* spell, Unit* victim) override;
+        void MovementInform(uint32 uiType, uint32 uiPointId) override;
+        void OnSpellInterrupt(SpellEntry const* spellInfo) override;
+
     protected:
-        bool IsTimerBasedEvent(EventAI_Type type) const;
+        std::string GetAIName() override { return "EventAI"; }
+        // Event rules specifiers
+        bool IsTimerExecutedEvent(EventAI_Type type) const;
         bool IsRepeatableEvent(EventAI_Type type) const;
+        bool IsTimerBasedEvent(EventAI_Type type) const;
+        // Event rules specifiers end
+        void DistanceYourself();
 
         uint32 m_EventUpdateTime;                           // Time between event updates
         uint32 m_EventDiff;                                 // Time between the last event call
@@ -770,6 +818,8 @@ class CreatureEventAI : public CreatureAI
         // Variables used by Events themselves
         typedef std::vector<CreatureEventAIHolder> CreatureEventAIList;
         CreatureEventAIList m_CreatureEventAIList;          // Holder for events (stores enabled, time, and eventid)
+        std::vector<std::vector<std::reference_wrapper<CreatureEventAIHolder>>> m_creatureEventAITempList; // Holder for events that are ready to go off
+        uint32 m_depth;
 
         uint8  m_Phase;                                     // Current phase, max 32 phases
         bool   m_DynamicMovement;                           // Core will control creatures movement if this is enabled
@@ -782,7 +832,15 @@ class CreatureEventAI : public CreatureAI
         uint32 m_throwAIEventStep;                          // Used for damage taken/ received heal
         float m_LastSpellMaxRange;                          // Maximum spell range that was cast during dynamic movement
 
-        Unit* m_eventTarget;                                // Target filled on specific event to be used in action
+        // Caster ai support
+        bool m_rangedMode;
+        RangeModeType m_rangedModeSetting;
+        float m_chaseDistance;
+        bool m_currentRangedMode;
+        std::unordered_set<uint32> m_mainSpells;
+        std::unordered_set<uint32> m_distanceSpells;
+        uint32 m_mainSpellId;
+        uint32 m_mainSpellCost;
 };
 
 #endif

--- a/src/game/AI/EventAI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/EventAI/CreatureEventAIMgr.cpp
@@ -245,6 +245,10 @@ bool IsValidTargetType(EventAI_Type eventType, EventAI_ActionType actionType, ui
         case TARGET_T_EVENT_SPECIFIC:
         case TARGET_T_PLAYER_INVOKER:
         case TARGET_T_PLAYER_TAPPED:
+        case TARGET_T_NONE:
+        case TARGET_T_HOSTILE_RANDOM_MANA:
+        case TARGET_T_NEAREST_AOE_TARGET:
+        case TARGET_T_HOSTILE_FARTHEST_AWAY:
             return true;
         default:
             sLog.outErrorEventAI("Event %u Action%u uses incorrect Target type", eventId, action);
@@ -261,7 +265,7 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
 
     // Gather event data
     QueryResult* result = WorldDatabase.Query("SELECT id, creature_id, event_type, event_inverse_phase_mask, event_chance, event_flags, "
-                          "event_param1, event_param2, event_param3, event_param4, "
+                          "event_param1, event_param2, event_param3, event_param4, event_param5, event_param6, "
                           "action1_type, action1_param1, action1_param2, action1_param3, "
                           "action2_type, action2_param1, action2_param2, action2_param3, "
                           "action3_type, action3_param1, action3_param2, action3_param3 "
@@ -294,11 +298,9 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
 
             temp.event_inverse_phase_mask = fields[3].GetUInt32();
             temp.event_chance = fields[4].GetUInt8();
-            temp.event_flags  = fields[5].GetUInt8();
-            temp.raw.param1 = fields[6].GetUInt32();
-            temp.raw.param2 = fields[7].GetUInt32();
-            temp.raw.param3 = fields[8].GetUInt32();
-            temp.raw.param4 = fields[9].GetUInt32();
+            temp.event_flags  = fields[5].GetUInt32();
+            for (uint32 i = 0; i < 6; ++i)
+                temp.raw.params[i] = fields[6 + i].GetUInt32();
 
             // Creature does not exist in database
             if (!sCreatureStorage.LookupEntry<CreatureInfo>(temp.creature_id))
@@ -372,6 +374,15 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                         sLog.outErrorEventAI("Creature %u are using repeatable event(%u) with param4 < param3 (RepeatMax < RepeatMin). Event will never repeat.", temp.creature_id, i);
                     break;
                 case EVENT_T_OOC_LOS:
+                    if (temp.ooc_los.conditionId)
+                    {
+                        if (!sConditionStorage.LookupEntry<PlayerCondition>(temp.ooc_los.conditionId))
+                        {
+                            sLog.outErrorDb("Creature %u has `ConditionId` = %u but does not exist. Setting ConditionId to 0 for event %u.", temp.creature_id, temp.ooc_los.conditionId, i);
+                            temp.ooc_los.conditionId = 0;
+                        }
+                    }
+
                     if (temp.ooc_los.repeatMax < temp.ooc_los.repeatMin)
                         sLog.outErrorEventAI("Creature %u are using repeatable event(%u) with param4 < param3 (RepeatMax < RepeatMin). Event will never repeat.", temp.creature_id, i);
                     break;
@@ -442,11 +453,13 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                     continue;
                 case EVENT_T_DEATH:
                 {
-                    if (temp.death.conditionId && !sConditionStorage.LookupEntry<PlayerCondition>(temp.death.conditionId))
+                    if (temp.death.conditionId)
                     {
-                        // condition does not exist for some reason
-                        sLog.outErrorDb("Creature %u has `ConditionId` = %u but does not exist. Setting ConditionId to 0 for event %u.", temp.creature_id, temp.death.conditionId, i);
-                        temp.death.conditionId = 0;
+                        if (!sConditionStorage.LookupEntry<PlayerCondition>(temp.death.conditionId)) // condition does not exist for some reason
+                        {
+                            sLog.outErrorDb("Creature %u has `ConditionId` = %u but does not exist. Setting ConditionId to 0 for event %u.", temp.creature_id, temp.death.conditionId, i);
+                            temp.death.conditionId = 0;
+                        }
                     }
                 }
                 case EVENT_T_AGGRO:
@@ -470,9 +483,10 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                         continue;
                     }
 
-                    if (!PlayerCondition::IsValid(0, ConditionType(temp.receive_emote.condition), temp.receive_emote.conditionValue1, temp.receive_emote.conditionValue2))
+                    if (temp.receive_emote.conditionId && !sConditionStorage.LookupEntry<PlayerCondition>(temp.receive_emote.conditionId))
                     {
-                        sLog.outErrorEventAI("Creature %u using event %u: param2 (Condition: %u) are not valid.", temp.creature_id, i, temp.receive_emote.condition);
+                        sLog.outErrorDb("Creature %u has `ConditionId` = %u but does not exist. Setting ConditionId to 0 for event %u.", temp.creature_id, temp.receive_emote.conditionId, i);
+                        temp.receive_emote.conditionId = 0;
                         continue;
                     }
 
@@ -556,7 +570,7 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
 
             for (uint32 j = 0; j < MAX_ACTIONS; ++j)
             {
-                uint16 action_type = fields[10 + (j * 4)].GetUInt16();
+                uint16 action_type = fields[12 + (j * 4)].GetUInt16();
                 if (action_type >= ACTION_T_END)
                 {
                     sLog.outErrorEventAI("Event %u Action %u has incorrect action type (%u), replace by ACTION_T_NONE.", i, j + 1, action_type);
@@ -567,9 +581,9 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                 CreatureEventAI_Action& action = temp.action[j];
 
                 action.type = EventAI_ActionType(action_type);
-                action.raw.param1 = fields[11 + (j * 4)].GetUInt32();
-                action.raw.param2 = fields[12 + (j * 4)].GetUInt32();
-                action.raw.param3 = fields[13 + (j * 4)].GetUInt32();
+                action.raw.param1 = fields[13 + (j * 4)].GetUInt32();
+                action.raw.param2 = fields[14 + (j * 4)].GetUInt32();
+                action.raw.param3 = fields[15 + (j * 4)].GetUInt32();
 
                 // Report any errors in actions
                 switch (action.type)
@@ -709,6 +723,12 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                             if (spell->HasAttribute(SPELL_ATTR_EX3_TARGET_ONLY_PLAYER) &&
                                     (action.cast.target == TARGET_T_ACTION_INVOKER || action.cast.target == TARGET_T_HOSTILE_RANDOM || action.cast.target == TARGET_T_HOSTILE_RANDOM_NOT_TOP))
                                 sLog.outErrorEventAI("Event %u Action %u uses Target type %u for a spell (%u) that should only target players. This could be wrong.", i, j + 1, action.cast.target, action.cast.spellId);
+
+                            if (spell->Targets != 0 && (action.cast.target == TARGET_T_NONE || action.cast.target == TARGET_T_NEAREST_AOE_TARGET))
+                            {
+                                sLog.outErrorEventAI("Event %u Action %u uses Target type %u for a spell (%u) that needs target for casting. Resetting it to TARGET_T_HOSTILE.", i, j + 1, action.cast.target, action.cast.spellId);
+                                action.cast.target = TARGET_T_HOSTILE;
+                            }
                         }
                         break;
                     }
@@ -997,6 +1017,18 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                         {
                             sLog.outErrorEventAI("Event %u Action %u uses nonexistent Creature entry %u.", i, j + 1, action.despawnGuardians.entryId);
                             action.despawnGuardians.entryId = 0;
+                        }
+                        break;
+                    case ACTION_T_SET_RANGED_MODE:
+                        if (action.rangedMode.type >= TYPE_MAX)
+                        {
+                            sLog.outErrorEventAI("Event %u Action %u uses nonexistent ranged mode type %u. Setting to 0.", i, j + 1, action.rangedMode.type);
+                            action.rangedMode.type = 0;
+                        }
+                        if(action.rangedMode.chaseDistance > 200)
+                        {
+                            sLog.outErrorEventAI("Event %u Action %u uses too large chase distance %u. Setting to 30.", i, j + 1, action.rangedMode.chaseDistance);
+                            action.rangedMode.chaseDistance = 30;
                         }
                         break;
                     default:

--- a/src/game/AI/ScriptDevAI/include/sc_creature.h
+++ b/src/game/AI/ScriptDevAI/include/sc_creature.h
@@ -206,6 +206,9 @@ struct ScriptedAI : public CreatureAI
 
         bool EnterEvadeIfOutOfCombatArea(const uint32 diff);
 
+    protected:
+        std::string GetAIName() override { return m_creature->GetAIName(); }
+
     private:
         uint32 m_uiEvadeCheckCooldown;
 

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -2207,17 +2207,25 @@ bool Creature::MeetsSelectAttackingRequirement(Unit* pTarget, SpellEntry const* 
 
         switch (pSpellInfo->rangeIndex)
         {
-            case SPELL_RANGE_IDX_SELF_ONLY: return false;
             case SPELL_RANGE_IDX_ANYWHERE:  return true;
             case SPELL_RANGE_IDX_COMBAT:    return CanReachWithMeleeAttack(pTarget);
         }
 
-        SpellRangeEntry const* srange = sSpellRangeStore.LookupEntry(pSpellInfo->rangeIndex);
-        float max_range = GetSpellMaxRange(srange);
-        float min_range = GetSpellMinRange(srange);
-        float dist = GetDistance(pTarget, true, DIST_CALC_COMBAT_REACH);
-
-        return dist < max_range && dist >= min_range;
+        if (selectFlags & SELECT_FLAG_USE_EFFECT_RADIUS)
+        {
+            SpellRadiusEntry const* srange = sSpellRadiusStore.LookupEntry(pSpellInfo->EffectRadiusIndex[0]);
+            float max_range = GetSpellRadius(srange);
+            float dist = pTarget->GetDistance(GetPositionX(), GetPositionY(), GetPositionZ());
+            return dist < max_range;
+        }
+        else
+        {
+            SpellRangeEntry const* srange = sSpellRangeStore.LookupEntry(pSpellInfo->rangeIndex);
+            float max_range = GetSpellMaxRange(srange);
+            float min_range = GetSpellMinRange(srange);
+            float dist = GetDistance(pTarget, true, DIST_CALC_COMBAT_REACH);
+            return dist < max_range && dist >= min_range;
+        }
     }
 
     return true;

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -354,6 +354,7 @@ enum SelectFlags
     SELECT_FLAG_RANGE_RANGE         = 0x0400,               // For direct targeted abilities like charge or frostbolt
     SELECT_FLAG_RANGE_AOE_RANGE     = 0x0800,               // For AOE targeted abilities like frost nova
     SELECT_FLAG_POWER_NOT_MANA      = 0x1000,               // Used in some dungeon encounters
+    SELECT_FLAG_USE_EFFECT_RADIUS   = 0x2000,               // For AOE targeted abilities which have correct data in effect index 0
 };
 
 enum RegenStatsFlags

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -1452,6 +1452,7 @@ class Unit : public WorldObject
         int32 ModifyPower(Powers power, int32 val);
         void ApplyPowerMod(Powers power, uint32 val, bool apply);
         void ApplyMaxPowerMod(Powers power, uint32 val, bool apply);
+        bool HasMana() { return GetPowerType() == POWER_MANA; }
 
         uint32 GetAttackTime(WeaponAttackType att) const { return (uint32)(GetFloatValue(UNIT_FIELD_BASEATTACKTIME + att) / m_modAttackSpeedPct[att]); }
         void SetAttackTime(WeaponAttackType att, uint32 val) { SetFloatValue(UNIT_FIELD_BASEATTACKTIME + att, val * m_modAttackSpeedPct[att]); }


### PR DESCRIPTION
List of changes:
Fixes two bugs:
1. When EAI timer expires in combat, it should not reset until the cast is successful - now in line with SD2 == CAST_OK workflow and sniffs
2. Fixes issue when phase changes can chain each other when in subsequent events of same type - found by Grz3s on Spell hit event

New features:
Adds ranged mode which is meant to fully replace dynamic movement
It enables caster like behaviour, with several settings and chase distances
It eliminates stutter step, responds to silence and kick and is able to distance itself from the enemy
Adds support for proximity aoe spells like frost nova, which should only go off if someone is in range
Adds 2 new event parameters enabling some behaviour in LOS event and in the future propably more
Also makes event target more consistent across different events in regards to action invoker

Notes:
Core contains changes which will need to be applied to the ACID files in DB repos.
Will start with tbc-db and once a smooth transition is made will be ported to classic and wotlk.