### PR TITLE
[s2375] Implement trainer greetings

### DIFF
--- a/sql/base/mangos.sql
+++ b/sql/base/mangos.sql
@@ -23,7 +23,7 @@ DROP TABLE IF EXISTS `db_version`;
 CREATE TABLE `db_version` (
   `version` varchar(120) DEFAULT NULL,
   `creature_ai_version` varchar(120) DEFAULT NULL,
-  `required_s2374_01_mangos_quest_template_rewmaxrep` bit(1) DEFAULT NULL
+  `required_s2375_01_mangos_trainer_greeting` bit(1) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Used DB version notes';
 
 --
@@ -3479,6 +3479,24 @@ CREATE TABLE `locales_questgiver_greeting` (
    `Text_loc8` LONGTEXT COMMENT 'Text of the greeting locale 8',
    PRIMARY KEY(`Entry`,`Type`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPACT COMMENT='Quest and Gossip system';
+
+--
+-- Table structure for table `locales_trainer_greeting`
+--
+
+DROP TABLE IF EXISTS `locales_trainer_greeting`;
+CREATE TABLE `locales_trainer_greeting` (
+   `Entry` INT(11) UNSIGNED NOT NULL COMMENT 'Entry of Trainer',
+   `Text_loc1` LONGTEXT COMMENT 'Text of the greeting locale 1',
+   `Text_loc2` LONGTEXT COMMENT 'Text of the greeting locale 2',
+   `Text_loc3` LONGTEXT COMMENT 'Text of the greeting locale 3',
+   `Text_loc4` LONGTEXT COMMENT 'Text of the greeting locale 4',
+   `Text_loc5` LONGTEXT COMMENT 'Text of the greeting locale 5',
+   `Text_loc6` LONGTEXT COMMENT 'Text of the greeting locale 6',
+   `Text_loc7` LONGTEXT COMMENT 'Text of the greeting locale 7',
+   `Text_loc8` LONGTEXT COMMENT 'Text of the greeting locale 8',
+   PRIMARY KEY(`Entry`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPACT COMMENT='Trainer system';
 
 --
 -- Table structure for table `mail_level_reward`
@@ -16605,6 +16623,17 @@ LOCK TABLES `taxi_shortcuts` WRITE;
 /*!40000 ALTER TABLE `taxi_shortcuts` DISABLE KEYS */;
 /*!40000 ALTER TABLE `taxi_shortcuts` ENABLE KEYS */;
 UNLOCK TABLES;
+
+--
+-- Table structure for table `trainer_greeeting`
+--
+
+DROP TABLE IF EXISTS `trainer_greeting`;
+CREATE TABLE `trainer_greeting` (
+   `Entry` INT(11) UNSIGNED NOT NULL COMMENT 'Entry of Trainer',
+   `Text` LONGTEXT COMMENT 'Text of the greeting',
+   PRIMARY KEY(`Entry`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPACT COMMENT='Trainer system';
 
 --
 -- Table structure for table `transports`

--- a/sql/updates/mangos/s2375_01_mangos_trainer_greeting.sql
+++ b/sql/updates/mangos/s2375_01_mangos_trainer_greeting.sql
@@ -1,0 +1,24 @@
+ALTER TABLE db_version CHANGE COLUMN required_s2374_01_mangos_quest_template_rewmaxrep required_s2375_01_mangos_trainer_greeting bit;
+
+DROP TABLE IF EXISTS `trainer_greeting`;
+CREATE TABLE `trainer_greeting` (
+   `Entry` INT(11) UNSIGNED NOT NULL COMMENT 'Entry of Trainer',
+   `Text` LONGTEXT COMMENT 'Text of the greeting',
+   PRIMARY KEY(`Entry`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPACT COMMENT='Trainer system';
+
+DROP TABLE IF EXISTS `locales_trainer_greeting`;
+CREATE TABLE `locales_trainer_greeting` (
+   `Entry` INT(11) UNSIGNED NOT NULL COMMENT 'Entry of Trainer',
+   `Text_loc1` LONGTEXT COMMENT 'Text of the greeting locale 1',
+   `Text_loc2` LONGTEXT COMMENT 'Text of the greeting locale 2',
+   `Text_loc3` LONGTEXT COMMENT 'Text of the greeting locale 3',
+   `Text_loc4` LONGTEXT COMMENT 'Text of the greeting locale 4',
+   `Text_loc5` LONGTEXT COMMENT 'Text of the greeting locale 5',
+   `Text_loc6` LONGTEXT COMMENT 'Text of the greeting locale 6',
+   `Text_loc7` LONGTEXT COMMENT 'Text of the greeting locale 7',
+   `Text_loc8` LONGTEXT COMMENT 'Text of the greeting locale 8',
+   PRIMARY KEY(`Entry`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPACT COMMENT='Trainer system';
+
+

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -566,6 +566,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "locales_points_of_interest",  SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadLocalesPointsOfInterestCommand, "", nullptr },
         { "locales_quest",               SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadLocalesQuestCommand,            "", nullptr },
         { "locales_questgiver_greeting", SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadQuestgiverGreetingLocalesCommand, "", nullptr },
+        { "locales_trainer_greeting",    SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadLocalesTrainerGreetingCommand,  "", nullptr },
         { "locales_areatrigger_teleport", SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadLocalesAreaTriggerCommand, "", nullptr },
         { "mail_level_reward",           SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadMailLevelRewardCommand,         "", nullptr },
         { "mail_loot_template",          SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadLootTemplatesMailCommand,       "", nullptr },
@@ -602,6 +603,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "spell_target_position",       SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadSpellTargetPositionCommand,     "", nullptr },
         { "spell_threats",               SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadSpellThreatsCommand,            "", nullptr },
         { "taxi_shortcuts",              SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadTaxiShortcuts,              "", nullptr },
+        { "trainer_greeting",            SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadTrainerGreetingCommand,         "", nullptr },
 
         { nullptr,                       0,                 false, nullptr,                                                  "", nullptr }
     };

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -433,6 +433,7 @@ class ChatHandler
         bool HandleReloadGameTeleCommand(char* args);
         bool HandleReloadGossipMenuCommand(char* args);
         bool HandleReloadQuestgiverGreetingCommand(char* args);
+        bool HandleReloadTrainerGreetingCommand(char* args);
         bool HandleReloadGOQuestRelationsCommand(char* args);
         bool HandleReloadGOQuestInvRelationsCommand(char* args);
         bool HandleReloadItemEnchantementsCommand(char* args);
@@ -447,6 +448,7 @@ class ChatHandler
         bool HandleReloadLocalesQuestCommand(char* args);
         bool HandleReloadLocalesAreaTriggerCommand(char*);
         bool HandleReloadQuestgiverGreetingLocalesCommand(char* args);
+        bool HandleReloadLocalesTrainerGreetingCommand(char* args);
         bool HandleReloadLootTemplatesCreatureCommand(char* args);
         bool HandleReloadLootTemplatesDisenchantCommand(char* args);
         bool HandleReloadLootTemplatesFishingCommand(char* args);

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -460,6 +460,22 @@ bool ChatHandler::HandleReloadQuestgiverGreetingLocalesCommand(char* /*args*/)
     return true;
 }
 
+bool ChatHandler::HandleReloadTrainerGreetingCommand(char* /*args*/)
+{
+    sLog.outString("Re-Loading Trainer Greetings...");
+    sObjectMgr.LoadTrainerGreetings();
+    SendGlobalSysMessage("DB table `trainer_greeting` reloaded.");
+    return true;
+}
+
+bool ChatHandler::HandleReloadLocalesTrainerGreetingCommand(char* /*args*/)
+{
+    sLog.outString("Re-Loading Trainer Greeting Locales...");
+    sObjectMgr.LoadTrainerGreetingLocales();
+    SendGlobalSysMessage("DB table `locales_trainer_greeting` reloaded.");
+    return true;
+}
+
 bool ChatHandler::HandleReloadGOQuestRelationsCommand(char* /*args*/)
 {
     sLog.outString("Loading Quests Relations... (`gameobject_questrelation`)");

--- a/src/game/Entities/NPCHandler.cpp
+++ b/src/game/Entities/NPCHandler.cpp
@@ -95,12 +95,6 @@ void WorldSession::HandleTrainerListOpcode(WorldPacket& recv_data)
     SendTrainerList(guid);
 }
 
-void WorldSession::SendTrainerList(ObjectGuid guid) const
-{
-    std::string str = GetMangosString(LANG_NPC_TAINER_HELLO);
-    SendTrainerList(guid, str);
-}
-
 
 static void SendTrainerSpellHelper(WorldPacket& data, TrainerSpell const* tSpell, TrainerSpellState state, float fDiscountMod, bool can_learn_primary_prof, uint32 reqLevel)
 {
@@ -123,7 +117,7 @@ static void SendTrainerSpellHelper(WorldPacket& data, TrainerSpell const* tSpell
     data << uint32(0);
 }
 
-void WorldSession::SendTrainerList(ObjectGuid guid, const std::string& strTitle) const
+void WorldSession::SendTrainerList(ObjectGuid guid) const
 {
     DEBUG_LOG("WORLD: SendTrainerList");
 
@@ -153,6 +147,16 @@ void WorldSession::SendTrainerList(ObjectGuid guid, const std::string& strTitle)
 
     uint32 maxcount = (cSpells ? cSpells->spellList.size() : 0) + (tSpells ? tSpells->spellList.size() : 0);
     uint32 trainer_type = cSpells && cSpells->trainerType ? cSpells->trainerType : (tSpells ? tSpells->trainerType : 0);
+
+    std::string strTitle;
+    if (TrainerGreeting const* data = sObjectMgr.GetTrainerGreetingData(guid.GetEntry()))
+    {
+        strTitle = data->text;
+        int loc_idx = GetSessionDbLocaleIndex();
+        sObjectMgr.GetTrainerGreetingLocales(guid.GetEntry(), loc_idx, &strTitle);
+    }
+    else
+        strTitle = GetMangosString(LANG_NPC_TAINER_HELLO); // Fallback in case no trainer greeting found
 
     WorldPacket data(SMSG_TRAINER_LIST, 8 + 4 + 4 + maxcount * 38 + strTitle.size() + 1);
     data << ObjectGuid(guid);

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -5053,6 +5053,110 @@ void ObjectMgr::LoadQuestgiverGreetingLocales()
     sLog.outString();
 }
 
+TrainerGreeting const* ObjectMgr::GetTrainerGreetingData(uint32 entry) const
+{
+    auto itr = m_trainerGreetingMap.find(entry);
+    if (itr == m_trainerGreetingMap.end()) return nullptr;
+    return &itr->second;
+}
+
+void ObjectMgr::LoadTrainerGreetings()
+{
+    m_trainerGreetingMap.clear();                           // need for reload case
+
+    QueryResult* result = WorldDatabase.Query("SELECT Entry, Text FROM trainer_greeting");
+    if (!result)
+    {
+        BarGoLink bar(1);
+        bar.step();
+
+        sLog.outString(">> Loaded 0 trainer greetings. DB table `trainer_greeting` is empty!");
+        sLog.outString();
+
+        return;
+    }
+
+    BarGoLink bar(result->GetRowCount());
+
+    do
+    {
+        Field* fields = result->Fetch();
+        bar.step();
+
+        uint32 entry = fields[0].GetUInt32();
+
+        if (!sCreatureStorage.LookupEntry<CreatureInfo>(entry))
+        {
+            sLog.outErrorDb("Table trainer_greeting uses nonexistent creature entry %u. Skipping.", entry);
+            continue;
+        }
+
+        TrainerGreeting& var = m_trainerGreetingMap[entry];
+        var.text = fields[1].GetString();
+    }
+    while (result->NextRow());
+
+    delete result;
+
+    sLog.outString(">> Loaded %u trainer greetings.", uint32(m_trainerGreetingMap.size()));
+    sLog.outString();
+}
+
+void ObjectMgr::LoadTrainerGreetingLocales()
+{
+    m_trainerGreetingLocaleMap.clear();                     // need for reload case
+
+    QueryResult* result = WorldDatabase.Query("SELECT Entry, Text_loc1, Text_loc2, Text_loc3, Text_loc4, Text_loc5, Text_loc6, Text_loc7, Text_loc8 FROM locales_trainer_greeting");
+    if (!result)
+    {
+        BarGoLink bar(1);
+        bar.step();
+
+        sLog.outString(">> Loaded 0 locales trainer greetings.");
+        return;
+    }
+
+    BarGoLink bar(result->GetRowCount());
+
+    do
+    {
+        Field* fields = result->Fetch();
+        bar.step();
+
+        uint32 entry = fields[0].GetUInt32();
+
+        if (!sCreatureStorage.LookupEntry<CreatureInfo>(entry))
+        {
+            sLog.outErrorDb("Table locales_trainer_greeting uses nonexistent creature entry %u. Skipping.", entry);
+            continue;
+        }
+
+        TrainerGreetingLocale& var = m_trainerGreetingLocaleMap[entry];
+
+        for (int i = 1; i < MAX_LOCALE; ++i)
+        {
+            std::string str = fields[i].GetCppString();
+            if (!str.empty())
+            {
+                int idx = GetOrNewIndexForLocale(LocaleConstant(i));
+                if (idx >= 0)
+                {
+                    if (var.localeText.size() <= static_cast<size_t>(idx))
+                        var.localeText.resize(idx + 1);
+
+                    var.localeText[idx] = str;
+                }
+            }
+        }
+    }
+    while (result->NextRow());
+
+    delete result;
+
+    sLog.outString(">> Loaded %u locales trainer greetings.", uint32(m_trainerGreetingLocaleMap.size()));
+    sLog.outString();
+}
+
 void ObjectMgr::LoadAreatriggerLocales()
 {
     for (uint32 i = 0; i < QUESTGIVER_TYPE_MAX; i++)        // need for reload case
@@ -9687,6 +9791,19 @@ void ObjectMgr::GetQuestgiverGreetingLocales(uint32 entry, uint32 type, int32 lo
             if (titlePtr)
                 if (ql->localeText.size() > (size_t)loc_idx && !ql->localeText[loc_idx].empty())
                     *titlePtr = ql->localeText[loc_idx];
+        }
+    }
+}
+
+void ObjectMgr::GetTrainerGreetingLocales(uint32 entry, int32 loc_idx, std::string* titlePtr) const
+{
+    if (loc_idx >= 0)
+    {
+        if (TrainerGreetingLocale const* tL = GetTrainerGreetingLocale(entry))
+        {
+            if (titlePtr)
+                if (tL->localeText.size() > (size_t)loc_idx && !tL->localeText[loc_idx].empty())
+                    *titlePtr = tL->localeText[loc_idx];
         }
     }
 }

--- a/src/game/Globals/ObjectMgr.h
+++ b/src/game/Globals/ObjectMgr.h
@@ -332,6 +332,19 @@ enum
     QUESTGIVER_TYPE_MAX = 2,
 };
 
+struct TrainerGreeting
+{
+    std::string text;
+};
+
+struct TrainerGreetingLocale
+{
+    std::vector<std::string> localeText;
+};
+
+typedef std::map<uint32, TrainerGreeting> TrainerGreetingMap;
+typedef std::map<uint32, TrainerGreetingLocale> TrainerGreetingLocaleMap;
+
 enum ConditionType
 {
     //                                                      // value1       value2  for the Condition enumed
@@ -594,6 +607,7 @@ class ObjectMgr
         GossipText const* GetGossipText(uint32 Text_ID) const;
 
         QuestgiverGreeting const* GetQuestgiverGreetingData(uint32 entry, uint32 type) const;
+        TrainerGreeting const* GetTrainerGreetingData(uint32 entry) const;
 
         WorldSafeLocsEntry const* GetClosestGraveYard(float x, float y, float z, uint32 MapId, Team team);
         bool AddGraveYardLink(uint32 id, uint32 zone, Team team, bool inDB = true);
@@ -703,6 +717,8 @@ class ObjectMgr
         void LoadGossipTextLocales();
         void LoadQuestgiverGreeting();
         void LoadQuestgiverGreetingLocales();
+        void LoadTrainerGreetings();
+        void LoadTrainerGreetingLocales();
         void LoadPageTextLocales();
         void LoadGossipMenuItemsLocales();
         void LoadPointOfInterestLocales();
@@ -892,6 +908,15 @@ class ObjectMgr
         {
             auto itr = m_questgiverGreetingLocaleMap[type].find(entry);
             if (itr == m_questgiverGreetingLocaleMap[type].end()) return nullptr;
+            return &itr->second;
+        }
+
+        void GetTrainerGreetingLocales(uint32 entry, int32 loc_idx, std::string* titlePtr) const;
+
+        TrainerGreetingLocale const* GetTrainerGreetingLocale(uint32 entry) const
+        {
+            auto itr = m_trainerGreetingLocaleMap.find(entry);
+            if (itr == m_trainerGreetingLocaleMap.end()) return nullptr;
             return &itr->second;
         }
 
@@ -1266,6 +1291,8 @@ class ObjectMgr
 
         QuestgiverGreetingMap m_questgiverGreetingMap[QUESTGIVER_TYPE_MAX];
         QuestgiverGreetingLocaleMap m_questgiverGreetingLocaleMap[QUESTGIVER_TYPE_MAX];
+        TrainerGreetingMap m_trainerGreetingMap;
+        TrainerGreetingLocaleMap m_trainerGreetingLocaleMap;
 
         CreatureModelRaceMap m_mCreatureModelRaceMap;
 

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -220,7 +220,6 @@ class WorldSession
         static void SendNameQueryOpcodeFromDBCallBack(QueryResult* result, uint32 accountId);
 
         void SendTrainerList(ObjectGuid guid) const;
-        void SendTrainerList(ObjectGuid guid, const std::string& strTitle) const;
 
         void SendListInventory(ObjectGuid guid) const;
         bool CheckBanker(ObjectGuid guid) const;

--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -1202,6 +1202,9 @@ void World::SetInitialWorldSettings()
     sLog.outString("Loading Questgiver Greetings...");
     sObjectMgr.LoadQuestgiverGreeting();
 
+    sLog.outString("Loading Trainer Greetings...");
+    sObjectMgr.LoadTrainerGreetings();
+
     ///- Loading localization data
     sLog.outString("Loading Localization strings...");
     sObjectMgr.LoadCreatureLocales();                       // must be after CreatureInfo loading
@@ -1213,6 +1216,7 @@ void World::SetInitialWorldSettings()
     sObjectMgr.LoadGossipMenuItemsLocales();                // must be after gossip menu items loading
     sObjectMgr.LoadPointOfInterestLocales();                // must be after POI loading
     sObjectMgr.LoadQuestgiverGreetingLocales();
+    sObjectMgr.LoadTrainerGreetingLocales();                // must be after CreatureInfo loading
     sLog.outString(">>> Localization strings loaded");
     sLog.outString();
 

--- a/src/shared/revision_sql.h
+++ b/src/shared/revision_sql.h
@@ -2,5 +2,5 @@
 #define __REVISION_SQL_H__
  #define REVISION_DB_REALMD "required_s2367_01_realmd_totp"
  #define REVISION_DB_CHARACTERS "required_s2376_01_characters_taxi_system_format_update"
- #define REVISION_DB_MANGOS "required_s2374_01_mangos_quest_template_rewmaxrep"
+ #define REVISION_DB_MANGOS "required_s2375_01_mangos_trainer_greeting"
 #endif // __REVISION_SQL_H__


### PR DESCRIPTION
The goal of this commit is to properly handle SMSG_TRAINER_LIST, by adding trainer specific greetings at the top of the trainer window. Beforehand, this string was determined by LANG_NPC_TAINER_HELLO, but now an unique greeting for every trainer can be added in 'trainer_greeting' table.

Credits to Wyreth (https://github.com/TrinityCore/TrinityCore/issues/20493) for finding this issue originally and for finding alot of the greetings.

The greetings lines themselves will be added in another commit. But for now, you can see the changes in the images below:

Before:
![before](https://user-images.githubusercontent.com/11392454/43357011-318b0fd2-927b-11e8-9fe7-cc17eafe3017.jpg)

After
![after](https://user-images.githubusercontent.com/11392454/43357013-384094e6-927b-11e8-9b80-a1fa09526c59.jpg)
