### PR TITLE
Improve compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,21 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
+# Minimum required cmake version to run the build
+cmake_minimum_required(VERSION 3.0)
+
+# Will cache object files if ccache is available
+# Must be set at top of cmake outside of project header
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 project(CMaNGOS_TBC)
 
 # Define here name of the binaries
 set(CMANGOS_BINARY_SERVER_NAME "mangosd")
 set(CMANGOS_BINARY_REALMD_NAME "realmd")
-
-cmake_minimum_required(VERSION 3.0)
 
 # Function to remove duplicate entries in provided string
 function(RemoveDuplicateSubstring stringIn stringOut)


### PR DESCRIPTION
Improve compile time by caching unchanged object files if ccache is available on the system, otherwise skips this optimization.

Must be set ahead of the project header, pulled cmake min required out also to perform the check on ccache (currently requires cmake 2.8). The setting for linker is ignored.

As documented here:
https://www.virag.si/2015/07/use-ccache-with-cmake-for-faster-compilation/
https://crascit.com/2016/04/09/using-ccache-with-cmake/