### PR TITLE
Fix NPC's Spawning with 1 hp

### DIFF
--- a/sql/updates/mangos/s2376_01_mangos_creature.sql
+++ b/sql/updates/mangos/s2376_01_mangos_creature.sql
@@ -1,3 +1,5 @@
 ALTER TABLE db_version CHANGE COLUMN required_s2375_01_mangos_trainer_greeting required_s2376_01_mangos_creature bit;
 
 ALTER TABLE `creature` CHANGE COLUMN `curhealth` `curhealth` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `currentwaypoint`;
+
+UPDATE `creature` SET `curhealth` = 0 WHERE `curhealth` = 1;  

--- a/sql/updates/mangos/s2376_01_mangos_creature.sql
+++ b/sql/updates/mangos/s2376_01_mangos_creature.sql
@@ -1,0 +1,3 @@
+ALTER TABLE db_version CHANGE COLUMN required_s2375_01_mangos_trainer_greeting required_s2376_01_mangos_creature bit;
+
+ALTER TABLE `creature` CHANGE COLUMN `curhealth` `curhealth` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `currentwaypoint`;


### PR DESCRIPTION
After commit @1388de1 creatures spawn with 1 hp and regenerate to full because table uses 1 hp as default where new value should be 0

If this doesn't get update many exploits with people killing 1 hp bosses will arrive 🗡 