### PR TITLE
fix mass dispel

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -4557,7 +4557,7 @@ void Spell::EffectDispel(SpellEffectIndex eff_idx)
         {
             if (holder->GetSpellProto()->Dispel == DISPEL_MAGIC)
             {
-                bool positive;
+                bool positive = true;
                 if (!holder->IsPositive())
                     positive = false;
 


### PR DESCRIPTION
Simple uninitialized bool.  Seems to fix Issue: '[TBC] Priest Mass Dispel removes _some_ beneficial buffs from friendly/self #1716' - https://github.com/cmangos/issues/issues/1716#issue-367017794 . May fix other related dispel reported issues (did not test others)