### PR TITLE
Fix: #1705 tbc sap

### DIFF
--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -1652,8 +1652,11 @@ void CreatureEventAI::UpdateAI(const uint32 diff)
             else
                 SetCombatMovement(true, true);
         }
-        else if (m_meleeEnabled && !m_currentRangedMode)
-            DoMeleeAttackIfReady();
+		else if (m_meleeEnabled && !m_currentRangedMode)
+		{
+			SetCombatMovement(true, true);
+			DoMeleeAttackIfReady();
+		}
     }
 }
 


### PR DESCRIPTION
Fixed [TBC] Rogue's SAP snares creatures when used followed by an spell
Had to resubmit this pull to build off the latest build changes instead of my own (Ops)

After countless hours of looking where this problem could lie and testing different configurations, I finally found a simple fix that allows mobs to move after being incapacitated. It seems as though there is no UNIT_FLAG enum that defines an incapacitated state. For the future I think that should be implemented to easier break this condition.

Related issue can be found [here](https://github.com/cmangos/issues/issues/1705)