### PR TITLE
Earth Shield Aggro should go to the target being healed and not the caster

### DIFF
--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -1868,6 +1868,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(ProcExecutionData& data)
                 basepoints[0] = triggerAmount;
                 target = this;
                 triggered_spell_id = 379;
+                triggeredByAura = nullptr;
                 break;
             }
             // Lightning Overload


### PR DESCRIPTION
Earth shield in TBC shouldn't pass either triggeredByAura or originalCaster, so the aggro goes directly to the target. 