### PR TITLE
HashMapHolder: switch from mutex to shared_mutex

### DIFF
--- a/src/game/Globals/ObjectAccessor.cpp
+++ b/src/game/Globals/ObjectAccessor.cpp
@@ -73,8 +73,7 @@ ObjectAccessor::~ObjectAccessor()
     }
 }
 
-Unit*
-ObjectAccessor::GetUnit(WorldObject const& u, ObjectGuid guid)
+Unit* ObjectAccessor::GetUnit(WorldObject const& u, ObjectGuid guid)
 {
     if (!guid)
         return nullptr;
@@ -147,8 +146,7 @@ void ObjectAccessor::KickPlayer(ObjectGuid guid)
     }
 }
 
-Corpse*
-ObjectAccessor::GetCorpseForPlayerGUID(ObjectGuid guid)
+Corpse* ObjectAccessor::GetCorpseForPlayerGUID(ObjectGuid guid)
 {
     Guard guard(i_corpseGuard);
 
@@ -161,8 +159,7 @@ ObjectAccessor::GetCorpseForPlayerGUID(ObjectGuid guid)
     return iter->second;
 }
 
-void
-ObjectAccessor::RemoveCorpse(Corpse* corpse)
+void ObjectAccessor::RemoveCorpse(Corpse* corpse)
 {
     MANGOS_ASSERT(corpse && corpse->GetType() != CORPSE_BONES);
 
@@ -181,8 +178,7 @@ ObjectAccessor::RemoveCorpse(Corpse* corpse)
     i_player2corpse.erase(iter);
 }
 
-void
-ObjectAccessor::AddCorpse(Corpse* corpse)
+void ObjectAccessor::AddCorpse(Corpse* corpse)
 {
     MANGOS_ASSERT(corpse && corpse->GetType() != CORPSE_BONES);
 
@@ -197,8 +193,7 @@ ObjectAccessor::AddCorpse(Corpse* corpse)
     sObjectMgr.AddCorpseCellData(corpse->GetMapId(), cell_id, corpse->GetOwnerGuid().GetCounter(), corpse->GetInstanceId());
 }
 
-void
-ObjectAccessor::AddCorpsesToGrid(GridPair const& gridpair, GridType& grid, Map* map)
+void ObjectAccessor::AddCorpsesToGrid(GridPair const& gridpair, GridType& grid, Map* map)
 {
     Guard guard(i_corpseGuard);
     for (auto& iter : i_player2corpse)
@@ -219,8 +214,7 @@ ObjectAccessor::AddCorpsesToGrid(GridPair const& gridpair, GridType& grid, Map* 
         }
 }
 
-Corpse*
-ObjectAccessor::ConvertCorpseForPlayer(ObjectGuid player_guid, bool insignia)
+Corpse* ObjectAccessor::ConvertCorpseForPlayer(ObjectGuid player_guid, bool insignia)
 {
     Corpse* corpse = GetCorpseForPlayerGUID(player_guid);
     if (!corpse)

--- a/src/game/Globals/ObjectAccessor.cpp
+++ b/src/game/Globals/ObjectAccessor.cpp
@@ -30,6 +30,8 @@
 #include "World/World.h"
 
 #include <mutex>
+#include <boost/thread/locks.hpp>
+#include <boost/thread/shared_mutex.hpp>
 
 #define CLASS_LOCK MaNGOS::ClassLevelLockable<ObjectAccessor, std::mutex>
 INSTANTIATE_SINGLETON_2(ObjectAccessor, CLASS_LOCK);
@@ -297,7 +299,7 @@ void ObjectAccessor::RemoveOldCorpses()
 /// Define the static member of HashMapHolder
 
 template <class T> typename HashMapHolder<T>::MapType HashMapHolder<T>::m_objectMap;
-template <class T> std::mutex HashMapHolder<T>::i_lock;
+template <class T> boost::shared_mutex HashMapHolder<T>::i_lock;
 
 /// Global definitions for the hashmap storage
 

--- a/src/game/Globals/ObjectAccessor.h
+++ b/src/game/Globals/ObjectAccessor.h
@@ -32,6 +32,8 @@
 #include "Entities/Corpse.h"
 
 #include <mutex>
+#include <boost/thread/locks.hpp>
+#include <boost/thread/shared_mutex.hpp>
 
 class Unit;
 class WorldObject;
@@ -42,10 +44,10 @@ class HashMapHolder
 {
     public:
 
-        typedef std::unordered_map<ObjectGuid, T*>   MapType;
-        typedef std::mutex LockType;
-        typedef std::lock_guard<std::mutex> ReadGuard;
-        typedef std::lock_guard<std::mutex> WriteGuard;
+        typedef std::unordered_map<ObjectGuid, T*>      MapType;
+        typedef boost::shared_mutex                     LockType;
+        typedef boost::shared_lock<boost::shared_mutex> ReadGuard;
+        typedef boost::unique_lock<boost::shared_mutex> WriteGuard;
 
         static void Insert(T* o);
 


### PR DESCRIPTION
Go from mutex to shared_mutex and utilize shared_lock for reads and unique_lock for writes. Allows for multiple owners of the mutex (in read cases).

Edit* Uses boost::shared_mutex indstead now for backwards compatibility
std::shared_mutex is part of c++17 so switch to that once we... eventually support c++17..

Fixes https://github.com/cmangos/issues/issues/787 and https://github.com/cmangos/issues/issues/1355