### PR TITLE
Ban/suspension fixes

### DIFF
--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -5288,9 +5288,6 @@ bool ChatHandler::HandleBanHelper(BanMode mode, char* args)
                 case BAN_CHARACTER:
                     PSendSysMessage(LANG_BAN_NOTFOUND, "character", nameOrIP.c_str());
                     break;
-                case BAN_IP:
-                    PSendSysMessage(LANG_BAN_NOTFOUND, "ip", nameOrIP.c_str());
-                    break;
             }
             SetSentErrorMessage(true);
             return false;

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -404,7 +404,6 @@ bool AuthSocket::_HandleLogonChallenge()
     {
         ///- Get the account details from the account table
         // No SQL injection (escaped user name)
-
         QueryResult* result = LoginDatabase.PQuery("SELECT sha_pass_hash,id,locked,last_ip,gmlevel,v,s,token FROM account WHERE username = '%s'", _safelogin.c_str());
         if (result)
         {
@@ -423,14 +422,10 @@ bool AuthSocket::_HandleLogonChallenge()
                     locked = true;
                 }
                 else
-                {
                     DEBUG_LOG("[AuthChallenge] Account IP matches");
-                }
             }
             else
-            {
                 DEBUG_LOG("[AuthChallenge] Account '%s' is not locked to ip", _login.c_str());
-            }
 
             if (!locked)
             {

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -395,13 +395,9 @@ bool AuthSocket::_HandleLogonChallenge()
     std::unique_ptr<QueryResult> ip_banned_result(LoginDatabase.PQuery("SELECT unbandate FROM ip_banned "
             "WHERE (unbandate = bandate OR unbandate > UNIX_TIMESTAMP()) AND ip = '%s'", m_address.c_str()));
 
-    std::unique_ptr<QueryResult> account_banned_result(LoginDatabase.PQuery(
-                "SELECT ab.unbandate FROM account_banned ab LEFT JOIN account a ON a.id = ab.id "
-                "WHERE active = 1 AND a.username = '%s' AND (ab.unbandate = ab.bandate OR ab.unbandate > UNIX_TIMESTAMP())", _safelogin.c_str()));
-
-    if (ip_banned_result || account_banned_result)
+    if (ip_banned_result)
     {
-        pkt << (uint8)WOW_FAIL_BANNED;
+        pkt << (uint8)WOW_FAIL_FAIL_NOACCESS;
         BASIC_LOG("[AuthChallenge] Banned ip %s tries to login!", m_address.c_str());
     }
     else

--- a/src/shared/Util.cpp
+++ b/src/shared/Util.cpp
@@ -261,7 +261,7 @@ bool IsIPAddress(char const* ipaddress)
     // Drawback: all valid ip address formats are recognized e.g.: 12.23,121234,0xABCD)
     boost::system::error_code ec;
     boost::asio::ip::address::from_string(ipaddress, ec);
-    return ec.value() != 0;
+    return ec.value() == 0;
 }
 
 /// create PID file


### PR DESCRIPTION
Remove duplicate account_banned handling since the first instance was not properly looking if suspended or banned. We do this further down the code with account bans where we properly query the account table for data.

Don't report ip banned/suspended to the client as account banned/suspended

Fix .ban ip as the expected (correct) result of IsIPAddress was inverted in the return.
Note: boost::asio::ip::address::from_string() is deprecated as of boost 1.66 and should be switched to boost::asio::ip::make_address() once we... eventually... stop supporting old boost...

Tidy up code

Fixes issues on current master:
Currently you can't do a sucessful .ban ip with an actual ip address
Currently any type of ban/suspension on ip/account gives out the same 'your account has been banned' message.