### PR TITLE
fixes phantom casting on some spell cast items

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -4997,6 +4997,18 @@ SpellCastResult Spell::CheckCast(bool strict)
     {
         for (int j = 0; j < MAX_EFFECT_INDEX; ++j)
         {
+            // There are some items that do not reliably filter client-side if they are usable
+            // i.e. a proper target exists.
+            if (m_spellInfo->EffectImplicitTargetA[j] == TARGET_UNIT_ENEMY ||
+                m_spellInfo->EffectImplicitTargetB[j] == TARGET_UNIT_ENEMY)
+            {
+                if (m_caster->GetTarget())
+                    // Explicitly set implicitTarget so other checks have something to work with
+                    m_targets.setUnitTarget(m_caster->GetTarget());
+                else
+                    return SPELL_FAILED_BAD_IMPLICIT_TARGETS;
+            }
+
             if (m_spellInfo->EffectImplicitTargetA[j] == TARGET_UNIT_SCRIPT_NEAR_CASTER ||
                     m_spellInfo->EffectImplicitTargetB[j] == TARGET_UNIT_SCRIPT_NEAR_CASTER ||
                     m_spellInfo->EffectImplicitTargetA[j] == TARGET_LOCATION_SCRIPT_NEAR_CASTER ||


### PR DESCRIPTION
When using the [Netherweave Net](http://db.hellfire-tbc.com/?item=24269) item, **the item would be consumed, no matter if the related spell effect had a target or not.** It should have failed with 'You have no target' or 'Invalid target'.

In tests with similar items it was concluded that both Netherweave Net items lack the proper client-side validations and always invoke `Player::CastItemUseSpell`.

**Reproduce**
```
# Macro
/target player
.setskill 197 325
.additem 24269 1
.additem 4941 1
.cooldown clear
/cleartarget
/use Netherweave Net
```
