### PR TITLE
1894: allowing npc's to cast heal on allies again

### DIFF
--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -414,7 +414,7 @@ bool CreatureEventAI::CheckEvent(CreatureEventAIHolder& holder, Unit* actionInvo
                 return false;
 
             CreatureEventAI_EventComputedData const& data = (*sEventAIMgr.GetEAIComputedDataMap().find(event.event_id)).second; // always found
-            Unit* pUnit = DoSelectLowestHpFriendly(float(event.friendly_hp.radius), float(event.friendly_hp.hpDeficit), data.friendlyHp.targetSelf);
+            Unit* pUnit = DoSelectLowestHpFriendly(float(event.friendly_hp.radius), float(event.friendly_hp.hpDeficit), false, data.friendlyHp.targetSelf);
             if (!pUnit)
                 return false;
 


### PR DESCRIPTION
- passing 'false' to 'percent' parameter of CreatureEventAI::DoSelectLowestHpFriendly. Optional parameter was being ignored and filled with 'data.friendlyHp.targetSelf' which seems incorrect to me.

Was probably introduced here https://github.com/cmangos/mangos-tbc/commit/b0ca61f35a9a5a1764ea43d3ae3400957a282685#diff-6b0564916a5610086747972410b4e134R417