### PR TITLE
Chat command .learn all_gm only teaches spells of catergory internal

### DIFF
--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -2075,19 +2075,23 @@ bool ChatHandler::HandleLearnAllGMCommand(char* /*args*/)
 {
     static uint32 gmSpellList[] =
     {
-        24347,                                            // Become A Fish, No Breath Bar
-        35132,                                            // Visual Boom
-        38488,                                            // Attack 4000-8000 AOE
-        38795,                                            // Attack 2000 AOE + Slow Down 90%
-        15712,                                            // Attack 200
-        1852,                                             // GM Spell Silence
-        31899,                                            // Kill
-        31924,                                            // Kill
-        29878,                                            // Kill My Self
-        26644,                                            // More Kill
-
-        28550,                                            // Invisible 24
-        23452                                             // Invisible + Target
+		5,      // Death Touch
+		11,     // Frostbolt of Ages 
+		265,    // Area Death (Test)
+		1908,   // Uber Heal Over Time
+		18209,  // Test Grow
+		18210,  // Test Shrink
+		25565,  // Clear All
+		26368,  // ClearAllo
+		33153,  // LeCraft Test Spell Rank 2
+		35182,  // Banish
+		35874,  // Master Buff Meele
+		35886,  // Windfury Weapon
+		35912,  // Master Buff (Magic)
+		36356,  // Internal Knowledge
+		38505,  // Shackle
+		38734,  // Master Buff (Distance)
+		39258   // Automation Root Spell QAE
     };
 
     for (uint32 spell : gmSpellList)


### PR DESCRIPTION
When entering .learn all_gm (with a security level 3 account) in the chat, the character should only learn spell from category "Internal" (-> good for testing etc). 
I just gathered the most common spell ids from this category - might not be all yet. 

 
