### PR TITLE
Rogue and druid stealth not breaking on env damage

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -1001,8 +1001,6 @@ uint32 Player::EnvironmentalDamage(EnviromentalDamage type, uint32 damage)
     damage = (damage <= malus ? 0 : (damage - malus));
 
     DamageEffectType damageType = SELF_DAMAGE;
-    if (type == DAMAGE_FALL && getClass() == CLASS_ROGUE)
-        damageType = SELF_DAMAGE_ROGUE_FALL;
 
     DealDamageMods(this, damage, &absorb, damageType);
 

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -1113,7 +1113,8 @@ void Unit::HandleDamageDealt(Unit* victim, uint32& damage, CleanDamage const* cl
         }
     }
 
-    if ((damagetype == DIRECT_DAMAGE || damagetype == SPELL_DIRECT_DAMAGE || damagetype == DOT)
+    if ((damagetype == DIRECT_DAMAGE || damagetype == SPELL_DIRECT_DAMAGE
+    		|| damagetype == DOT || damagetype == SELF_DAMAGE )
         && !(spellProto && spellProto->HasAttribute(SPELL_ATTR_EX4_DAMAGE_DOESNT_BREAK_AURAS)))
     {
         int32 auraInterruptFlags = AURA_INTERRUPT_FLAG_DAMAGE;


### PR DESCRIPTION
rogues and druids stealth was not breaking on env damage:
lava, fall damage. Now this type of self damage is taken in
account

proofs of working fix:

https://ibb.co/hHG6ncR
https://ibb.co/k45J597
https://ibb.co/mT5LnWN
https://ibb.co/Y768S44