### PR TITLE
Warlord Najentus Needle Spell Effects + Targeting

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1250,6 +1250,11 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                     }
                     return;
                 }
+                case 39992:                                 // Needle Spine Targeting
+				{
+					m_caster->CastSpell(unitTarget, 39835, TRIGGERED_OLD_TRIGGERED);
+					return;
+				}
                 case 24019:                                 // Gurubashi Axe Thrower; Axe Flurry.
                 {
                     if (unitTarget && m_caster->IsWithinLOSInMap(unitTarget))
@@ -5957,6 +5962,11 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
         {
             switch (m_spellInfo->Id)
             {
+				case 39835:                                 //Needle Spine
+				{
+					unitTarget->CastSpell(m_caster, 39968, TRIGGERED_OLD_TRIGGERED);
+					return;
+				}
                 case 5249:                                  // Ice Lock
                 {
                     if (unitTarget)

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -5962,11 +5962,11 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
         {
             switch (m_spellInfo->Id)
             {
-				case 39835:                                 //Needle Spine
-				{
-					unitTarget->CastSpell(m_caster, 39968, TRIGGERED_OLD_TRIGGERED);
-					return;
-				}
+		case 39835:                                 //Needle Spine
+		{
+			unitTarget->CastSpell(m_caster, 39968, TRIGGERED_OLD_TRIGGERED);
+			return;
+		}
                 case 5249:                                  // Ice Lock
                 {
                     if (unitTarget)

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1251,10 +1251,10 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                     return;
                 }
                 case 39992:                                 // Needle Spine Targeting
-				{
-					m_caster->CastSpell(unitTarget, 39835, TRIGGERED_OLD_TRIGGERED);
-					return;
-				}
+		{
+		     m_caster->CastSpell(unitTarget, 39835, TRIGGERED_OLD_TRIGGERED);
+		     return;
+		}
                 case 24019:                                 // Gurubashi Axe Thrower; Axe Flurry.
                 {
                     if (unitTarget && m_caster->IsWithinLOSInMap(unitTarget))


### PR DESCRIPTION
boss_warlord_najentus.cpp Black Temple
-SPELL_NEEDLE_SPINE_TARGET(39992) targeting.
-SPELL_NEEDLE_SPINES(39835) spell effect.

According to info online the spell hits targets in a cone area so I think there needs to be more targeting logic to make this pure blizzlike, this is a start though.