### PR TITLE
Totemic Mastery Fix (Skyshatter Tier 6 - 2 set)

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1861,14 +1861,14 @@ void Aura::TriggerSpell()
         switch (auraId)
         {
             case 38443:                            // Totemic Mastery (Skyshatter Regalia (Shaman Tier 6) - bonus)
-			{
-				Unit* caster = GetCaster();
-				if (caster->IsAllTotemSlotsUsed())
-					caster->CastSpell(caster, 38437, TRIGGERED_OLD_TRIGGERED);
-				else
-					caster->RemoveAurasDueToSpell(38437);
-				return;
-			}
+            {
+		Unit* caster = GetCaster();
+		if (caster->IsAllTotemSlotsUsed())
+		    caster->CastSpell(caster, 38437, TRIGGERED_OLD_TRIGGERED);
+		else
+		     caster->RemoveAurasDueToSpell(38437);
+		     return;
+	    }
             case 9347:                                      // Mortal Strike
             {
                 if (target->GetTypeId() != TYPEID_UNIT)

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1807,14 +1807,14 @@ void Aura::TriggerSpell()
                         triggerTarget->RemoveAurasDueToSpell(28820);
                         return;
                     }
-                    case 38443:                             // Totemic Mastery (Skyshatter Regalia (Shaman Tier 6) - bonus)
-                    {
-                        if (triggerTarget->IsAllTotemSlotsUsed())
-                            triggerTarget->CastSpell(triggerTarget, 38437, TRIGGERED_OLD_TRIGGERED, nullptr, this);
-                        else
-                            triggerTarget->RemoveAurasDueToSpell(38437);
-                        return;
-                    }
+                    //case 38443:                             // Totemic Mastery (Skyshatter Regalia (Shaman Tier 6) - bonus)
+                    //{
+                    //    if (triggerTarget->IsAllTotemSlotsUsed())
+                    //        triggerTarget->CastSpell(triggerTarget, 38437, TRIGGERED_OLD_TRIGGERED, nullptr, this);
+                    //    else
+                    //        triggerTarget->RemoveAurasDueToSpell(38437);
+                    //    return;
+                    //}
                     default:
                         break;
                 }
@@ -1860,6 +1860,15 @@ void Aura::TriggerSpell()
         // Spell exist but require custom code
         switch (auraId)
         {
+            case 38443:                             // Totemic Mastery (Skyshatter Regalia (Shaman Tier 6) - bonus)
+			{
+				Unit* caster = GetCaster();
+				if (caster->IsAllTotemSlotsUsed())
+					caster->CastSpell(caster, 38437, TRIGGERED_OLD_TRIGGERED);
+				else
+					caster->RemoveAurasDueToSpell(38437);
+				return;
+			}
             case 9347:                                      // Mortal Strike
             {
                 if (target->GetTypeId() != TYPEID_UNIT)

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1860,7 +1860,7 @@ void Aura::TriggerSpell()
         // Spell exist but require custom code
         switch (auraId)
         {
-            case 38443:                             // Totemic Mastery (Skyshatter Regalia (Shaman Tier 6) - bonus)
+            case 38443:                            // Totemic Mastery (Skyshatter Regalia (Shaman Tier 6) - bonus)
 			{
 				Unit* caster = GetCaster();
 				if (caster->IsAllTotemSlotsUsed())

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1866,8 +1866,8 @@ void Aura::TriggerSpell()
 		if (caster->IsAllTotemSlotsUsed())
 		    caster->CastSpell(caster, 38437, TRIGGERED_OLD_TRIGGERED);
 		else
-		     caster->RemoveAurasDueToSpell(38437);
-		     return;
+		    caster->RemoveAurasDueToSpell(38437);
+		    return;
 	    }
             case 9347:                                      // Mortal Strike
             {

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -867,11 +867,11 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                         switch (m_triggeredByAuraSpell->Id)
                         {
                             case 38443:                             // Totemic Mastery (Skyshatter Regalia (Shaman Tier 6) - bonus)
-							{
-								Unit* caster = GetCaster();
-								if (!caster->IsPlayer())
-									return;
-							}
+			    {
+				Unit* caster = GetCaster();
+				if (!caster->IsPlayer())
+				    return;
+			    }
                             case 13810: // Frost Trap Aura
                             {
                                 // Need to check casting of entrapment on every pulse

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -866,6 +866,12 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                     {
                         switch (m_triggeredByAuraSpell->Id)
                         {
+                            case 38443:                             // Totemic Mastery (Skyshatter Regalia (Shaman Tier 6) - bonus)
+							{
+								Unit* caster = GetCaster();
+								if (!caster->IsPlayer())
+									return;
+							}
                             case 13810: // Frost Trap Aura
                             {
                                 // Need to check casting of entrapment on every pulse


### PR DESCRIPTION
Before changes the spell case couldn't be reached in the script. This meant Totemic Mastery(38443) did nothing in terms of applying mod increases and the effect Dummy Trigger(18350) would cause anything the player targeted to instantly aggro onto said player.

Let me know if this is a pepega approach, happy to learn. 