### PR TITLE
Resolve crash caused by the pet summons

### DIFF
--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -154,7 +154,13 @@ Creature::Creature(CreatureSubtype subtype) : Unit(),
 
 Creature::~Creature()
 {
-    CleanupsBeforeDelete();
+    // Ensure the clean up hasn't already taken place, this can
+    // happen when the map removes an object and requires the 
+    // objects map variable to remain valid for the clean up.
+    if (isDirty())
+    {
+        CleanupsBeforeDelete();
+    }
 }
 
 void Creature::CleanupsBeforeDelete()

--- a/src/game/Entities/Object.cpp
+++ b/src/game/Entities/Object.cpp
@@ -1057,13 +1057,14 @@ void Object::ForceValuesUpdateAtIndex(uint16 index)
 WorldObject::WorldObject() :
     m_transportInfo(nullptr), m_isOnEventNotified(false),
     m_currMap(nullptr), m_mapId(0),
-    m_InstanceId(0), m_isActiveObject(false)
+    m_InstanceId(0), m_isActiveObject(false), m_dirty(true)
 {
 }
 
 void WorldObject::CleanupsBeforeDelete()
 {
     RemoveFromWorld();
+    m_dirty = false;
 }
 
 void WorldObject::_Create(uint32 guidlow, HighGuid guidhigh)

--- a/src/game/Entities/Object.cpp
+++ b/src/game/Entities/Object.cpp
@@ -1061,6 +1061,11 @@ WorldObject::WorldObject() :
 {
 }
 
+WorldObject::~WorldObject()
+{
+    ResetMap();
+}
+
 void WorldObject::CleanupsBeforeDelete()
 {
     RemoveFromWorld();

--- a/src/game/Entities/Object.h
+++ b/src/game/Entities/Object.h
@@ -634,7 +634,7 @@ class WorldObject : public Object
         friend struct WorldObjectChangeAccumulator;
 
     public:
-        virtual ~WorldObject() {}
+        virtual ~WorldObject();
 
         virtual void Update(const uint32 /*diff*/) {}
 

--- a/src/game/Entities/Object.h
+++ b/src/game/Entities/Object.h
@@ -833,6 +833,9 @@ class WorldObject : public Object
         bool isActiveObject() const { return m_isActiveObject || m_viewPoint.hasViewers(); }
         void SetActiveObjectState(bool active);
 
+        bool isDirty() const { return m_dirty; }
+        void SetDirty(bool dirty) { m_dirty = dirty; }
+
         ViewPoint& GetViewPoint() { return m_viewPoint; }
 
         // ASSERT print helper
@@ -898,6 +901,7 @@ class WorldObject : public Object
         Position m_position;
         ViewPoint m_viewPoint;
         bool m_isActiveObject;
+        bool m_dirty;                                       // cleaned for deletion flag
 };
 
 #endif

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -649,7 +649,13 @@ Player::Player(WorldSession* session): Unit(), m_taxiTracker(*this), m_mover(thi
 
 Player::~Player()
 {
-    CleanupsBeforeDelete();
+    // Ensure the clean up hasn't already taken place, this can
+    // happen when the map removes an object and requires the 
+    // objects map variable to remain valid for the clean up.
+    if (isDirty())
+    {
+        CleanupsBeforeDelete();
+    }
 
     // it must be unloaded already in PlayerLogout and accessed only for loggined player
     // m_social = nullptr;

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -719,11 +719,10 @@ void Map::Remove(Player* player, bool remove)
     CellPair p = MaNGOS::ComputeCellPair(player->GetPositionX(), player->GetPositionY());
     if (p.x_coord >= TOTAL_NUMBER_OF_CELLS_PER_MAP || p.y_coord >= TOTAL_NUMBER_OF_CELLS_PER_MAP)
     {
-        // invalid coordinates
-        player->ResetMap();
-
         if (remove)
             DeleteFromWorld(player);
+        else
+            player->ResetMap(); // invalid coordinates
 
         return;
     }
@@ -744,15 +743,15 @@ void Map::Remove(Player* player, bool remove)
 
     SendRemoveTransports(player);
     UpdateObjectVisibility(player, cell, p);
-
-    player->ResetMap();
+   
     if (remove)
         DeleteFromWorld(player);
+    else
+        player->ResetMap();
 }
 
 template<class T>
-void
-Map::Remove(T* obj, bool remove)
+void Map::Remove(T* obj, bool remove)
 {
     CellPair p = MaNGOS::ComputeCellPair(obj->GetPositionX(), obj->GetPositionY());
     if (p.x_coord >= TOTAL_NUMBER_OF_CELLS_PER_MAP || p.y_coord >= TOTAL_NUMBER_OF_CELLS_PER_MAP)
@@ -777,10 +776,11 @@ Map::Remove(T* obj, bool remove)
     else
         obj->RemoveFromWorld();
 
-    UpdateObjectVisibility(obj, cell, p);                   // i think will be better to call this function while object still in grid, this changes nothing but logically is better(as for me)
+    // Might be better to call this function while object still 
+    // in grid, this changes nothing but logically is better (as for me)
+    UpdateObjectVisibility(obj, cell, p);
     RemoveFromGrid(obj, grid, cell);
 
-    obj->ResetMap();
     if (remove)
     {
         // if option set then object already saved at this moment
@@ -789,6 +789,10 @@ Map::Remove(T* obj, bool remove)
 
         // Note: In case resurrectable corpse and pet its removed from global lists in own destructor
         delete obj;
+    }
+    else
+    {
+        obj->ResetMap();
     }
 }
 


### PR DESCRIPTION
Hello! Somewhat new to cmangos core. I have been trying to resolve the crash issue described here: https://github.com/cmangos/issues/issues/1904

We need to ensure that the CleanupsBeforeDelete() method isn't invoked in the deconstructor if it has already been handled outside the deconstructor. i.e Map::Remove where it cleans the object before removing the objects map reference, to enable the ability to perform tasks that require the map still.

This way we will simply retain a dirty flag on the WorldObject and ensure it is checked before invoking CleanupsBeforeDelete in any WorldObject ancestors deconstructor. This will likely help to avoid other crashes like this too.

For a sample case on where this happens, see:
```c++
struct npc_living_flareAI : public ScriptedPetAI
{
    npc_living_flareAI(Creature* pCreature) : ScriptedPetAI(pCreature) { Reset(); }

    bool m_bCheckComplete;
    uint32 m_uiCheckTimer;

    void Reset() override
    {
        m_uiCheckTimer      = 0;
        m_bCheckComplete    = false;

        // HERE WE CALL A SPELL WHICH REQUIRES A MAP INSTANCE
        // Reset() is called from the CleanupsBeforeDelete() call in the deconstructor.
        DoCastSpellIfCan(m_creature, SPELL_LIVING_COSMETIC);
    }
```

Pet object is removed and added to the remove list (where is will be deconstructed by `Map::Remove`:
```
mangosd.exe!Map::AddObjectToRemoveList(WorldObject * obj) Line 1082	C++
mangosd.exe!WorldObject::AddObjectToRemoveList() Line 1807	C++
mangosd.exe!Pet::Unsummon(PetSaveMode mode, Unit * owner) Line 1117	C++
mangosd.exe!Unit::RemoveMiniPet() Line 6652	C++
mangosd.exe!Spell::DoSummonCritter(std::vector<Spell::CreaturePosition,std::allocator<Spell::CreaturePosition> > & list, const SummonPropertiesEntry * prop, SpellEffectIndex effIdx, unsigned int __formal) Line 8285	C++
mangosd.exe!Spell::EffectSummonType(SpellEffectIndex eff_idx) Line 4466	C++
mangosd.exe!Spell::HandleEffects(Unit * pUnitTarget, Item * pItemTarget, GameObject * pGOTarget, SpellEffectIndex i, float DamageMultiplier) Line 4519	C++
mangosd.exe!Spell::DoSpellHitOnUnit(Unit * unit, unsigned int effectMask, bool isReflected) Line 1406	C++
mangosd.exe!Spell::DoAllEffectOnTarget(Spell::TargetInfo * target) Line 1180	C++
mangosd.exe!Spell::handle_immediate() Line 3432	C++
mangosd.exe!Spell::cast(bool skipCheck) Line 3422	C++
mangosd.exe!Spell::Prepare() Line 3127	C++
mangosd.exe!Spell::SpellStart(const SpellCastTargets * targets, Aura * triggeredByAura) Line 3079	C++
mangosd.exe!Player::CastItemUseSpell(Item * item, const SpellCastTargets & targets, unsigned char cast_count, unsigned char spell_index) Line 7725	C++
mangosd.exe!WorldSession::HandleUseItemOpcode(WorldPacket & recvPacket) Line 169	C++
mangosd.exe!WorldSession::ExecuteOpcode(const OpcodeHandler & opHandle, WorldPacket & packet) Line 929	C++
mangosd.exe!WorldSession::Update(PacketFilter & updater) Line 316	C++
mangosd.exe!World::UpdateSessions(unsigned int __formal) Line 1977	C++
mangosd.exe!World::Update(unsigned int diff) Line 1531	C++
mangosd.exe!WorldRunnable::run() Line 59	C++
mangosd.exe!MaNGOS::Thread::ThreadTask(void * param) Line 85	C++
```

`npc_living_flareAI::Remove` is then called when deconstructing, even though the `Map::Remove` has already handled this:
```
mangosd.exe!Map::GetTerrain() Line 282	C++
mangosd.exe!WorldObject::GetTerrain() Line 1802	C++
mangosd.exe!WorldObject::GetZoneAndAreaId(unsigned int & zoneid, unsigned int & areaid) Line 1115	C++
mangosd.exe!Spell::CheckCast(bool strict) Line 4952	C++
mangosd.exe!Spell::PreCastCheck(Aura * triggeredByAura) Line 3025	C++
mangosd.exe!Spell::SpellStart(const SpellCastTargets * targets, Aura * triggeredByAura) Line 3070	C++
mangosd.exe!Unit::CastSpell(Unit * Victim, const SpellEntry * spellInfo, unsigned int triggeredFlags, Item * castItem, Aura * triggeredByAura, ObjectGuid originalCaster, const SpellEntry * triggeredBy) Line 1382	C++
mangosd.exe!UnitAI::DoCastSpellIfCan(Unit * target, unsigned int spellId, unsigned int castFlags, ObjectGuid originalCasterGUID) Line 215	C++
mangosd.exe!npc_living_flareAI::Reset() Line 1185	C++
mangosd.exe!ScriptedPetAI::ResetPetCombat() Line 51	C++
mangosd.exe!ScriptedPetAI::CombatStop() Line 111	C++
mangosd.exe!Unit::CombatStop(bool includingCast, bool includingCombo) Line 6225	C++
mangosd.exe!Unit::CleanupsBeforeDelete() Line 9677	C++
mangosd.exe!Creature::CleanupsBeforeDelete() Line 163	C++
mangosd.exe!Creature::~Creature() Line 157	C++
mangosd.exe!Pet::~Pet() Line 69	C++
[External Code]	
mangosd.exe!Map::Remove<Creature>(Creature * obj, bool remove) Line 791	C++
mangosd.exe!Map::RemoveAllObjectsInRemoveList() Line 1121	C++
mangosd.exe!MapManager::RemoveAllObjectsInRemoveList() Line 223	C++
mangosd.exe!World::Update(unsigned int diff) Line 1590	C++
mangosd.exe!WorldRunnable::run() Line 59	C++
mangosd.exe!MaNGOS::Thread::ThreadTask(void * param) Line 85	C++
```

This PR seemed like the cleanest way to resolve this issue, but feel free to let me know if there's a better way to handle this edge case.