### PR TITLE
Removed data blob in item_instance

### DIFF
--- a/contrib/iteminstance_converter/README.md
+++ b/contrib/iteminstance_converter/README.md
@@ -1,0 +1,22 @@
+# Item Instance data converter
+Tool to convert the datablob in the item_instance table to extracted format.
+https://github.com/henhouse/ItemInstanceConverter
+
+## Instructions & Usage
+
+##### Warning:
+This script should be run **BEFORE** applying the character-db SQL update. This tool will extract
+the current data inside the `item_instance` table and prepare it in the new format. It will output `INSERT`
+statements for each item to be put back in after you apply the cmangos character-db update, which will `TRUNCATE`
+the table.
+
+BACKUP YOUR CHARACTER DATABASE!
+
+##### Usage:
+- Download and install the latest version of [Go from Google](https://golang.org/dl).
+     - Win10 users with [Scoop](https://scoop.sh) can instead use: `scoop install go`
+     - macOS users with [Homebrew](https://brew.sh) can instead use: `brew install go`
+ - Run `run.sh` inside this folder a bash terminal (Linux/macOS) or Powershell (Windows) and follow the steps.
+
+## Credit
+Inspired from: https://github.com/vmangos/ItemInstance

--- a/contrib/iteminstance_converter/go.mod
+++ b/contrib/iteminstance_converter/go.mod
@@ -1,0 +1,5 @@
+module iteminstance_converter
+
+go 1.13
+
+require github.com/go-sql-driver/mysql v1.5.0

--- a/contrib/iteminstance_converter/go.sum
+++ b/contrib/iteminstance_converter/go.sum
@@ -1,0 +1,2 @@
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=

--- a/contrib/iteminstance_converter/main.go
+++ b/contrib/iteminstance_converter/main.go
@@ -1,0 +1,359 @@
+// Item Instance conversion for cMaNGOS
+// Author: Henhouse
+// Based on C++ project: https://github.com/vmangos/ItemInstance
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+const EntriesPerInsert = 25000
+
+func main() {
+	fmt.Println("\n\n########################################################")
+	fmt.Println("# BACKUP YOUR DATABASE BEFORE RUNNING THIS SCRIPT!     #")
+	fmt.Println("#    If you are migrating existing cmangos data you    #")
+	fmt.Println("#    *MUST* perform this migration BEFORE applying     #")
+	fmt.Println("#    the characters db SQL update script!              #")
+	fmt.Println("########################################################")
+	fmt.Println("#  This script will take your existing item_instance   #")
+	fmt.Println("#  data and convert it to the new format. Then, run    #")
+	fmt.Println("#  the cmangos character db update script as normal.   #")
+	fmt.Println("#  Lastly, run the output script generated from here.  #")
+	fmt.Println("########################################################")
+	fmt.Println()
+
+	PromptExpansionSelection()
+
+	// Prompt user for DB info and connect.
+	db := HandleConnectDB()
+
+	// Count entries to convert so we know what size to make the array.
+	log.Println("Counting entries...")
+	var totalEntries uint
+	row := db.QueryRow("SELECT COUNT(*) FROM `item_instance`")
+	if err := row.Scan(&totalEntries); err != nil {
+		log.Println(err)
+	}
+
+	if totalEntries == 0 {
+		log.Println("No entries in `item_instance`. Exiting.")
+		return
+	}
+	log.Printf("Counted %v entries.\n\n", totalEntries)
+
+	log.Println("Loading all item instance entries...")
+	var query string
+	switch chosenExp {
+	case ExpWotLK:
+		query = "SELECT `guid`, `data`, `text` FROM `item_instance`"
+	default:
+		query = "SELECT `data` FROM `item_instance`"
+	}
+	rows, err := db.Query(query)
+	if err != nil {
+		log.Println(err)
+	}
+
+	// Create slice with capacity for all entries.
+	blobResults := make([]string, 0, totalEntries)
+	texts := make([]string, 0, totalEntries)
+
+	var data string
+	var text sql.NullString
+	var guid uint32
+
+	for rows.Next() {
+		switch chosenExp {
+		case ExpWotLK:
+			err = rows.Scan(&guid, &data, &text)
+		default:
+			err = rows.Scan(&data)
+		}
+		if err != nil {
+			log.Println(err)
+		}
+
+		blobResults = append(blobResults, data)
+		if chosenExp == ExpWotLK {
+			texts = append(texts, text.String)
+		}
+	}
+	log.Printf("Loaded.\n\n")
+
+	parseStart := time.Now()
+	log.Println("Beginning parse... this may take a minute or two.")
+
+	// Way faster than concatenating strings.
+	var entireQuery strings.Builder
+	for i := range blobResults {
+		if i%EntriesPerInsert == 0 {
+			entireQuery.WriteString("INSERT INTO `item_instance` VALUES \n")
+		}
+
+		blob := blobResults[i]
+		text := ""
+
+		if chosenExp == ExpWotLK {
+			text = texts[i]
+		}
+
+		entireQuery.WriteString(ParseDataBlob(blob, text))
+
+		if i == len(blobResults)-1 || (i > 0 && (i+1)%EntriesPerInsert == 0) {
+			entireQuery.WriteString(";\n")
+		} else {
+			entireQuery.WriteString(",")
+		}
+		entireQuery.WriteString("\n")
+	}
+	db.Close()
+
+	timeElapsed := time.Since(parseStart)
+	log.Printf("Done parsing in %v\n\n", timeElapsed.String())
+
+	log.Println("Writing full query to file: item_instance_converted.sql")
+
+	queryAsBytes := bytes.NewBufferString(entireQuery.String()).Bytes()
+	if err = ioutil.WriteFile("item_instance_converted.sql", queryAsBytes, 0644); err != nil {
+		log.Fatal("Failed to write file! Check permissions.")
+	}
+
+	log.Println("Done.")
+}
+
+func ParseDataBlob(blob, text string) string {
+	values := strings.Split(blob, " ")
+	var itemGuid = values[fieldIndex(fieldItemGuid)]
+	var itemEntry = values[fieldIndex(fieldItemEntry)]
+	var ownerGuid = uint64(stringToUint32(values[fieldIndex(fieldOwnerGuid)]))
+	var creatorGuid = uint64(stringToUint32(values[fieldIndex(fieldCreatorGuid)]))
+	var giftCreator = uint64(stringToUint32(values[fieldIndex(fieldGiftCreator)]))
+	var stackCount = values[fieldIndex(fieldStackCount)]
+	var duration = values[fieldIndex(fieldDuration)]
+
+	var spellCharges string
+	for i := fieldIndex(fieldSpellChargesStart); i <= fieldIndex(fieldSpellChargesEnd); i++ {
+		if i != fieldIndex(fieldSpellChargesStart) {
+			spellCharges += " "
+		}
+
+		// Stored as uint32 but we need to cast to int32.
+		spellCharges += fmt.Sprintf("%d", int32(stringToUint32(values[i])))
+	}
+
+	var flags = values[fieldIndex(fieldFlags)]
+
+	var enchantments string
+	for i := fieldIndex(fieldEnchantmentsStart); i <= fieldIndex(fieldEnchantmentsEnd); i++ {
+		if i != fieldIndex(fieldEnchantmentsStart) {
+			enchantments += " "
+		}
+
+		// Use stringValues here since they're already as strings
+		enchantments += values[i]
+	}
+
+	var randomPropertyId = int32(stringToUint32(values[fieldIndex(fieldRandomPropertyId)])) // Stored as uint32, but we want int32 representation.
+	var durability = values[fieldIndex(fieldDurability)]
+
+	var lastField string // Either textId or playedTime depending on expansion.
+	switch chosenExp {
+	case ExpVanilla:
+		fallthrough
+	case ExpTBC:
+		lastField = values[fieldIndex(fieldTextId)]
+	case ExpWotLK:
+		lastField = values[fieldIndex(fieldPlayedTime)] + ", \"" + text + "\""
+	}
+
+	return " (" +
+		itemGuid + ", " +
+		fmt.Sprintf("%d", ownerGuid) + ", " +
+		itemEntry + ", " +
+		fmt.Sprintf("%d", creatorGuid) + ", " +
+		fmt.Sprintf("%d", giftCreator) + ", " +
+		stackCount + ", " +
+		duration + ", " +
+		"'" + spellCharges + "'" + ", " +
+		flags + ", " +
+		"'" + enchantments + "'" + ", " +
+		fmt.Sprintf("%d", randomPropertyId) + ", " +
+		durability + ", " +
+		lastField +
+		")"
+}
+
+func stringToUint32(str string) uint32 {
+	result, err := strconv.ParseUint(str, 10, 32)
+	if err != nil {
+		log.Println(err)
+	}
+
+	return uint32(result)
+}
+
+func PromptExpansionSelection() {
+	fmt.Println("Choose expansion for migration (type 1, 2, or 3 and press Enter):")
+	fmt.Println(" 1. Vanilla (mangos-classic)")
+	fmt.Println(" 2. TBC (mangos-tbc)")
+	fmt.Println(" 3. WotLK (mangos-wotlk)")
+	fmt.Print("> ")
+
+	fmt.Scanf("%d", &chosenExp)
+
+	switch chosenExp {
+	case ExpVanilla:
+	case ExpTBC:
+	case ExpWotLK:
+	default:
+		log.Fatal("Invalid expansion type specified. Please specify between 1 and 3.")
+	}
+	fmt.Println("---------------------------------")
+	fmt.Println()
+}
+
+func HandleConnectDB() *sql.DB {
+	var host, port, user, pass, database string
+
+	fmt.Println("Database connection credentials:")
+	fmt.Println("Host:")
+	fmt.Scanf("%s", &host)
+
+	fmt.Println("Port:")
+	fmt.Scanf("%s", &port)
+
+	fmt.Println("User:")
+	fmt.Scanf("%s", &user)
+
+	fmt.Println("Password:")
+	fmt.Scanf("%s", &pass)
+
+	fmt.Println("Database:")
+	fmt.Scanf("%s", &database)
+
+	fmt.Println()
+	log.Println("Connecting to database...")
+
+	var connStr string
+	connStr += user
+	connStr += ":" + pass
+	connStr += "@tcp(" + host + ":" + port + ")"
+	connStr += "/" + database
+
+	session, err := sql.Open("mysql", connStr)
+	if err != nil {
+		log.Fatal("Couldn't connect to DB: ", err)
+	}
+
+	// sql.Open above does not return connection failure, so we must ping to ensure the session is valid.
+	err = session.Ping()
+	if err != nil {
+		log.Fatal("Couldn't connect to DB:", err)
+	}
+
+	log.Println("Database connection established.\n")
+
+	return session
+}
+
+type expansion uint8
+
+const (
+	ExpVanilla expansion = 1
+	ExpTBC               = 2
+	ExpWotLK             = 3
+)
+
+type field uint8
+
+// Item field references (changes depending on expansion).
+const (
+	fieldItemGuid field = iota
+	fieldItemEntry
+	fieldOwnerGuid
+	fieldCreatorGuid
+	fieldGiftCreator
+	fieldStackCount
+	fieldDuration
+	fieldSpellChargesStart
+	fieldSpellChargesEnd
+	fieldFlags
+	fieldEnchantmentsStart
+	fieldEnchantmentsEnd
+	fieldRandomPropertyId
+	fieldTextId
+	fieldDurability
+	fieldPlayedTime // WotLK only
+)
+
+var fieldExpMapper = map[expansion]map[field]uint8{
+	ExpVanilla: {
+		fieldItemGuid:          0,
+		fieldItemEntry:         3,
+		fieldOwnerGuid:         6,
+		fieldCreatorGuid:       10,
+		fieldGiftCreator:       12,
+		fieldStackCount:        14,
+		fieldDuration:          15,
+		fieldSpellChargesStart: 16,
+		fieldSpellChargesEnd:   20,
+		fieldFlags:             21,
+		fieldEnchantmentsStart: 22,
+		fieldEnchantmentsEnd:   42,
+		fieldRandomPropertyId:  44,
+		fieldTextId:            45,
+		fieldDurability:        46,
+	},
+	ExpTBC: {
+		fieldItemGuid:          0,
+		fieldItemEntry:         3,
+		fieldOwnerGuid:         6,
+		fieldCreatorGuid:       10,
+		fieldGiftCreator:       12,
+		fieldStackCount:        14,
+		fieldDuration:          15,
+		fieldSpellChargesStart: 16,
+		fieldSpellChargesEnd:   20,
+		fieldFlags:             21,
+		fieldEnchantmentsStart: 22,
+		fieldEnchantmentsEnd:   54,
+		fieldRandomPropertyId:  56,
+		fieldTextId:            57,
+		fieldDurability:        58,
+	},
+	ExpWotLK: {
+		fieldItemGuid:          0,
+		fieldItemEntry:         3,
+		fieldOwnerGuid:         6,
+		fieldCreatorGuid:       10,
+		fieldGiftCreator:       12,
+		fieldStackCount:        14,
+		fieldDuration:          15,
+		fieldSpellChargesStart: 16,
+		fieldSpellChargesEnd:   20,
+		fieldFlags:             21,
+		fieldEnchantmentsStart: 22,
+		fieldEnchantmentsEnd:   57,
+		fieldRandomPropertyId:  59,
+		fieldDurability:        60,
+		fieldPlayedTime:        62,
+	},
+}
+
+// Provided by user.
+var chosenExp expansion
+
+// fieldIndex returns the item field index for the chosen expansion.
+func fieldIndex(field field) uint8 {
+	return fieldExpMapper[chosenExp][field]
+}

--- a/contrib/iteminstance_converter/run.sh
+++ b/contrib/iteminstance_converter/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+clear
+
+# Ensure Go is installed on the machine and usable
+if ! [ -x "$(command -v go)" ]; then
+  echo "Error: go is not installed. Aborting" >&2
+  exit 1
+fi
+
+
+echo "Retrieving go dependencies..."
+go mod vendor
+echo "Dependencies vendored."
+
+echo "Beginning conversion script..."
+go run main.go
+
+echo ""

--- a/sql/base/characters.sql
+++ b/sql/base/characters.sql
@@ -1408,7 +1408,17 @@ DROP TABLE IF EXISTS `item_instance`;
 CREATE TABLE `item_instance` (
   `guid` int(11) unsigned NOT NULL DEFAULT '0',
   `owner_guid` int(11) unsigned NOT NULL DEFAULT '0',
-  `data` longtext,
+  `itemEntry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `creatorGuid` int(10) unsigned NOT NULL default '0',
+  `giftCreatorGuid` int(10) unsigned NOT NULL default '0',
+  `count` int(10) unsigned NOT NULL default '1',
+  `duration` int(10) unsigned NOT NULL default '0',
+  `charges` text NOT NULL,
+  `flags` int(8) unsigned NOT NULL default '0',
+  `enchantments` text NOT NULL,
+  `randomPropertyId` smallint(5) NOT NULL default '0',
+  `durability` int(5) unsigned NOT NULL default '0',
+  `itemTextId` mediumint(8) unsigned NOT NULL default '0',
   PRIMARY KEY (`guid`),
   KEY `idx_owner_guid` (`owner_guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Item System';

--- a/src/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -280,8 +280,8 @@ void AuctionHouseMgr::SendAuctionExpiredMail(AuctionEntry* auction)
 
 void AuctionHouseMgr::LoadAuctionItems()
 {
-    // data needs to be at first place for Item::LoadFromDB 0  1        2
-    QueryResult* result = CharacterDatabase.Query("SELECT data,itemguid,item_template FROM auction JOIN item_instance ON itemguid = guid");
+    // data needs to be at first place for Item::LoadFromDB 0        1            2                3      4         5        6      7             8                 9           10          11        12
+    QueryResult* result = CharacterDatabase.Query("SELECT itemEntry, creatorGuid, giftCreatorGuid, count, duration, charges, flags, enchantments, randomPropertyId, durability, itemTextId, itemguid, item_template FROM auction JOIN item_instance ON itemguid = guid");
 
     if (!result)
     {
@@ -300,8 +300,8 @@ void AuctionHouseMgr::LoadAuctionItems()
         bar.step();
 
         Field* fields = result->Fetch();
-        uint32 item_guid        = fields[1].GetUInt32();
-        uint32 item_template    = fields[2].GetUInt32();
+        uint32 item_guid        = fields[11].GetUInt32();
+        uint32 item_template    = fields[12].GetUInt32();
 
         ItemPrototype const* proto = ObjectMgr::GetItemPrototype(item_template);
 

--- a/src/game/Entities/Bag.cpp
+++ b/src/game/Entities/Bag.cpp
@@ -97,6 +97,13 @@ bool Bag::LoadFromDB(uint32 guidLow, Field* fields, ObjectGuid ownerGuid)
     if (!Item::LoadFromDB(guidLow, fields, ownerGuid))
         return false;
 
+        ItemPrototype const* itemProto = sObjectMgr.GetItemPrototype(GetEntry());
+        if (!itemProto || itemProto->ContainerSlots > MAX_BAG_SIZE)
+            return false;
+
+        // Setting the number of Slots the Container has
+        SetUInt32Value(CONTAINER_FIELD_NUM_SLOTS, itemProto->ContainerSlots);
+
     // cleanup bag content related item value fields (its will be filled correctly from `character_inventory`)
     for (int i = 0; i < MAX_BAG_SIZE; ++i)
     {

--- a/src/game/Entities/CharacterHandler.cpp
+++ b/src/game/Entities/CharacterHandler.cpp
@@ -87,7 +87,7 @@ bool LoginQueryHolder::Initialize()
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADWEEKLYQUESTSTATUS, "SELECT quest FROM character_queststatus_weekly WHERE guid = '%u'", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADMONTHLYQUESTSTATUS, "SELECT quest FROM character_queststatus_monthly WHERE guid = '%u'", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADREPUTATION,      "SELECT faction,standing,flags FROM character_reputation WHERE guid = '%u'", m_guid.GetCounter());
-    res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADINVENTORY,       "SELECT data,bag,slot,item,item_template FROM character_inventory JOIN item_instance ON character_inventory.item = item_instance.guid WHERE character_inventory.guid = '%u' ORDER BY bag,slot", m_guid.GetCounter());
+    res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADINVENTORY,       "SELECT itemEntry, creatorGuid, giftCreatorGuid, count, duration, charges, flags, enchantments, randomPropertyId, durability, itemTextId, bag, slot, item, item_template FROM character_inventory JOIN item_instance ON character_inventory.item = item_instance.guid WHERE character_inventory.guid = '%u' ORDER BY bag,slot", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADITEMLOOT,        "SELECT guid,itemid,amount,suffix,property FROM item_loot WHERE owner_guid = '%u'", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADACTIONS,         "SELECT button,action,type FROM character_action WHERE guid = '%u' ORDER BY button", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADSOCIALLIST,      "SELECT friend,flags,note FROM character_social WHERE guid = '%u' LIMIT 255", m_guid.GetCounter());
@@ -102,7 +102,7 @@ bool LoginQueryHolder::Initialize()
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADACCOUNTDATA,     "SELECT type, time, data FROM character_account_data WHERE guid='%u'", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADSKILLS,          "SELECT skill, value, max FROM character_skills WHERE guid = '%u'", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADMAILS,           "SELECT id,messageType,sender,receiver,subject,itemTextId,expire_time,deliver_time,money,cod,checked,stationery,mailTemplateId,has_items FROM mail WHERE receiver = '%u' ORDER BY id DESC", m_guid.GetCounter());
-    res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADMAILEDITEMS,     "SELECT data, mail_id, item_guid, item_template FROM mail_items JOIN item_instance ON item_guid = guid WHERE receiver = '%u'", m_guid.GetCounter());
+    res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADMAILEDITEMS,     "SELECT itemEntry, creatorGuid, giftCreatorGuid, count, duration, charges, flags, enchantments, randomPropertyId, durability, itemTextId, mail_id, item_guid, item_template FROM mail_items JOIN item_instance ON item_guid = guid WHERE receiver = '%u'", m_guid.GetCounter());
 
     return res;
 }

--- a/src/game/Entities/Item.cpp
+++ b/src/game/Entities/Item.cpp
@@ -268,7 +268,7 @@ bool Item::Create(uint32 guidlow, uint32 itemid, Player const* owner)
     SetUInt32Value(ITEM_FIELD_MAXDURABILITY, itemProto->MaxDurability);
     SetUInt32Value(ITEM_FIELD_DURABILITY, itemProto->MaxDurability);
 
-    for (int i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
+    for (uint8 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
         SetSpellCharges(i, itemProto->Spells[i].SpellCharges);
 
     SetUInt32Value(ITEM_FIELD_DURATION, itemProto->Duration);
@@ -299,45 +299,59 @@ void Item::SaveToDB()
     switch (uState)
     {
         case ITEM_NEW:
-        {
-            static SqlStatementID delItem ;
-            static SqlStatementID insItem ;
-
-            SqlStatement stmt = CharacterDatabase.CreateStatement(delItem, "DELETE FROM item_instance WHERE guid = ?");
-            stmt.PExecute(guid);
-
-            std::ostringstream ss;
-            for (uint16 i = 0; i < m_valuesCount; ++i)
-                ss << GetUInt32Value(i) << " ";
-
-            stmt = CharacterDatabase.CreateStatement(insItem, "INSERT INTO item_instance (guid,owner_guid,data) VALUES (?, ?, ?)");
-            stmt.PExecute(guid, GetOwnerGuid().GetCounter(), ss.str().c_str());
-        } break;
         case ITEM_CHANGED:
         {
-            static SqlStatementID updInstance ;
-            static SqlStatementID updGifts ;
+            static SqlStatementID insItem;
+            SqlStatement stmt = CharacterDatabase.CreateStatement(insItem, uState == ITEM_NEW ?
+                "REPLACE INTO item_instance (owner_guid, itemEntry, creatorGuid, giftCreatorGuid, count, duration, charges, flags, enchantments, randomPropertyId, durability, itemTextId, guid) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)" :
+                "UPDATE item_instance SET owner_guid = ?, itemEntry = ?, creatorGuid = ?, giftCreatorGuid = ?, count = ?, duration = ?, charges = ?, flags = ?, enchantments = ?, randomPropertyId = ?, durability = ?, itemTextId = ? WHERE guid = ?"
+            );
 
-            SqlStatement stmt = CharacterDatabase.CreateStatement(updInstance, "UPDATE item_instance SET data = ?, owner_guid = ? WHERE guid = ?");
+            stmt.addUInt32(GetOwnerGuid().GetCounter());
+            stmt.addUInt32(GetEntry());
+            stmt.addUInt32(GetGuidValue(ITEM_FIELD_CREATOR).GetCounter());
+            stmt.addUInt32(GetGuidValue(ITEM_FIELD_GIFTCREATOR).GetCounter());
+            stmt.addUInt32(GetCount());
+            stmt.addUInt32(GetUInt32Value(ITEM_FIELD_DURATION));
 
-            std::ostringstream ss;
-            for (uint16 i = 0; i < m_valuesCount; ++i)
-                ss << GetUInt32Value(i) << " ";
+            std::ostringstream ssSpells;
+            for (uint8 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
+                ssSpells << GetSpellCharges(i) << ' ';
+            stmt.addString(ssSpells.str());
 
-            stmt.PExecute(ss.str().c_str(), GetOwnerGuid().GetCounter(), guid);
+            stmt.addUInt32(GetUInt32Value(ITEM_FIELD_FLAGS));
 
-            if (HasFlag(ITEM_FIELD_FLAGS, ITEM_DYNFLAG_WRAPPED))
+            std::ostringstream ssEnchants;
+            for (uint8 i = 0; i < MAX_ENCHANTMENT_SLOT; ++i)
             {
+                ssEnchants << GetEnchantmentId(EnchantmentSlot(i)) << ' ';
+                ssEnchants << GetEnchantmentDuration(EnchantmentSlot(i)) << ' ';
+                ssEnchants << GetEnchantmentCharges(EnchantmentSlot(i)) << ' ';
+            }
+            stmt.addString(ssEnchants.str());
+
+            stmt.addInt16(GetItemRandomPropertyId());
+            stmt.addUInt16(GetUInt32Value(ITEM_FIELD_DURABILITY));
+            stmt.addUInt32(GetUInt32Value(ITEM_FIELD_ITEM_TEXT_ID));
+            stmt.addUInt32(guid);
+
+            stmt.Execute();
+
+            if (uState == ITEM_CHANGED && HasFlag(ITEM_FIELD_FLAGS, ITEM_DYNFLAG_WRAPPED))
+            {
+                static SqlStatementID updGifts;
                 stmt = CharacterDatabase.CreateStatement(updGifts, "UPDATE character_gifts SET guid = ? WHERE item_guid = ?");
                 stmt.PExecute(GetOwnerGuid().GetCounter(), GetGUIDLow());
             }
-        } break;
+
+            break;
+        }
         case ITEM_REMOVED:
         {
             static SqlStatementID delItemText;
-            static SqlStatementID delInst ;
-            static SqlStatementID delGifts ;
-            static SqlStatementID delLoot ;
+            static SqlStatementID delInst;
+            static SqlStatementID delGifts;
+            static SqlStatementID delLoot;
 
             if (uint32 item_text_id = GetUInt32Value(ITEM_FIELD_ITEM_TEXT_ID))
             {
@@ -369,7 +383,7 @@ void Item::SaveToDB()
 
     if (m_lootState == ITEM_LOOT_CHANGED || m_lootState == ITEM_LOOT_REMOVED)
     {
-        static SqlStatementID delLoot ;
+        static SqlStatementID delLoot;
 
         SqlStatement stmt = CharacterDatabase.CreateStatement(delLoot, "DELETE FROM item_loot WHERE guid = ?");
         stmt.PExecute(GetGUIDLow());
@@ -379,8 +393,8 @@ void Item::SaveToDB()
     {
         if (Player* owner = GetOwner())
         {
-            static SqlStatementID saveGold ;
-            static SqlStatementID saveLoot ;
+            static SqlStatementID saveGold;
+            static SqlStatementID saveLoot;
 
             // save money as 0 itemid data
             if (m_loot->GetGoldAmount())
@@ -417,29 +431,45 @@ void Item::SaveToDB()
 
 bool Item::LoadFromDB(uint32 guidLow, Field* fields, ObjectGuid ownerGuid)
 {
+    // 0          1            2                3      4         5        6      7             8                 9           10
+    // itemEntry, creatorGuid, giftCreatorGuid, count, duration, charges, flags, enchantments, randomPropertyId, durability, itemTextId
+
     // create item before any checks for store correct guid
     // and allow use "FSetState(ITEM_REMOVED); SaveToDB();" for deleting item from DB
     Object::_Create(guidLow, 0, HIGHGUID_ITEM);
 
-    if (!LoadValues(fields[0].GetString()))
-    {
-        sLog.outError("Item #%d have broken data in `data` field. Can't be loaded.", guidLow);
-        return false;
-    }
-
-    bool need_save = false;                                 // need explicit save data at load fixes
-
-    // overwrite possible wrong/corrupted guid
-    ObjectGuid new_item_guid = ObjectGuid(HIGHGUID_ITEM, guidLow);
-    if (GetGuidValue(OBJECT_FIELD_GUID) != new_item_guid)
-    {
-        SetGuidValue(OBJECT_FIELD_GUID, new_item_guid);
-        need_save = true;
-    }
+    // Set entry, MUST be before proto check
+    SetEntry(fields[0].GetUInt32());
+    SetObjectScale(1.0f);
 
     ItemPrototype const* proto = GetProto();
     if (!proto)
         return false;
+
+    // set owner (not if item is only loaded for gbank/auction/mail)
+    if (ownerGuid)
+        SetOwnerGuid(ownerGuid);
+
+    bool need_save = false;                                 // need explicit save data at load fixes
+    SetGuidValue(ITEM_FIELD_CREATOR, ObjectGuid(HIGHGUID_PLAYER, fields[1].GetUInt32()));
+    SetGuidValue(ITEM_FIELD_GIFTCREATOR, ObjectGuid(HIGHGUID_PLAYER, fields[2].GetUInt32()));
+    SetCount(fields[3].GetUInt32());
+
+    uint32 duration = fields[4].GetUInt32();
+    SetUInt32Value(ITEM_FIELD_DURATION, duration);
+    // update duration if need, and remove if not need
+    if ((proto->Duration == 0) != (duration == 0))
+    {
+        SetUInt32Value(ITEM_FIELD_DURATION, proto->Duration);
+        need_save = true;
+    }
+
+    Tokens tokens = StrSplit(fields[5].GetCppString(), " ");
+    if (tokens.size() == MAX_ITEM_PROTO_SPELLS)
+        for (uint8 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
+            SetSpellCharges(i, atoi(tokens[i].c_str()));
+
+    SetUInt32Value(ITEM_FIELD_FLAGS, fields[6].GetUInt32());
 
     // update max durability (and durability) if need
     if (proto->MaxDurability != GetUInt32Value(ITEM_FIELD_MAXDURABILITY))
@@ -451,13 +481,6 @@ bool Item::LoadFromDB(uint32 guidLow, Field* fields, ObjectGuid ownerGuid)
         need_save = true;
     }
 
-    // recalculate suffix factor
-    if (GetItemRandomPropertyId() < 0)
-    {
-        if (UpdateItemSuffixFactor())
-            need_save = true;
-    }
-
     // Remove bind flag for items vs NO_BIND set
     if (IsSoulBound() && proto->Bonding == NO_BIND)
     {
@@ -465,19 +488,26 @@ bool Item::LoadFromDB(uint32 guidLow, Field* fields, ObjectGuid ownerGuid)
         need_save = true;
     }
 
-    // update duration if need, and remove if not need
-    if ((proto->Duration == 0) != (GetUInt32Value(ITEM_FIELD_DURATION) == 0))
+    _LoadIntoDataField(fields[7].GetString(), ITEM_FIELD_ENCHANTMENT_1_1, MAX_ENCHANTMENT_SLOT * MAX_ENCHANTMENT_OFFSET);
+     SetInt32Value(ITEM_FIELD_RANDOM_PROPERTIES_ID, fields[8].GetInt16());
+
+    // recalculate suffix factor
+    if (GetItemRandomPropertyId() < 0)
+        UpdateItemSuffixFactor();
+
+    uint32 durability = fields[9].GetUInt16();
+    SetUInt32Value(ITEM_FIELD_DURABILITY, durability);
+    // update max durability (and durability) if need
+    SetUInt32Value(ITEM_FIELD_MAXDURABILITY, proto->MaxDurability);
+
+    // do not overwrite durability for wrapped items
+    if (durability > proto->MaxDurability && !HasFlag(ITEM_FIELD_FLAGS, ITEM_DYNFLAG_WRAPPED))
     {
-        SetUInt32Value(ITEM_FIELD_DURATION, proto->Duration);
+        SetUInt32Value(ITEM_FIELD_DURABILITY, proto->MaxDurability);
         need_save = true;
     }
 
-    // set correct owner
-    if (ownerGuid && GetOwnerGuid() != ownerGuid)
-    {
-        SetOwnerGuid(ownerGuid);
-        need_save = true;
-    }
+    SetUInt32Value(ITEM_FIELD_ITEM_TEXT_ID, fields[10].GetUInt32());
 
     // set correct wrapped state
     if (HasFlag(ITEM_FIELD_FLAGS, ITEM_DYNFLAG_WRAPPED))
@@ -488,7 +518,7 @@ bool Item::LoadFromDB(uint32 guidLow, Field* fields, ObjectGuid ownerGuid)
             RemoveFlag(ITEM_FIELD_FLAGS, ITEM_DYNFLAG_WRAPPED);
             need_save = true;
 
-            static SqlStatementID delGifts ;
+            static SqlStatementID delGifts;
 
             // also cleanup for sure gift table
             SqlStatement stmt = CharacterDatabase.CreateStatement(delGifts, "DELETE FROM character_gifts WHERE item_guid = ?");
@@ -498,17 +528,15 @@ bool Item::LoadFromDB(uint32 guidLow, Field* fields, ObjectGuid ownerGuid)
 
     if (need_save)                                          // normal item changed state set not work at loading
     {
-        static SqlStatementID updItem ;
+        static SqlStatementID updItem;
 
-        SqlStatement stmt = CharacterDatabase.CreateStatement(updItem, "UPDATE item_instance SET data = ?, owner_guid = ? WHERE guid = ?");
+        SqlStatement stmt = CharacterDatabase.CreateStatement(updItem, "UPDATE item_instance SET duration = ?, flags = ?, durability = ? WHERE guid = ?");
 
-        std::ostringstream ss;
-        for (uint16 i = 0; i < m_valuesCount; ++i)
-            ss << GetUInt32Value(i) << " ";
-
-        stmt.addString(ss);
-        stmt.addUInt32(GetOwnerGuid().GetCounter());
+        stmt.addUInt32(GetUInt32Value(ITEM_FIELD_DURATION));
+        stmt.addUInt32(GetUInt32Value(ITEM_FIELD_FLAGS));
+        stmt.addUInt32(GetUInt32Value(ITEM_FIELD_DURABILITY));
         stmt.addUInt32(guidLow);
+
         stmt.Execute();
     }
 
@@ -724,13 +752,14 @@ void Item::SetItemRandomProperties(int32 randomPropId)
     }
 }
 
-bool Item::UpdateItemSuffixFactor()
+void Item::UpdateItemSuffixFactor()
 {
     uint32 suffixFactor = GenerateEnchSuffixFactor(GetEntry());
     if (GetItemSuffixFactor() == suffixFactor)
-        return false;
+        return;
+
     SetUInt32Value(ITEM_FIELD_PROPERTY_SEED, suffixFactor);
-    return true;
+    return;
 }
 
 void Item::SetState(ItemUpdateState state, Player* forplayer)

--- a/src/game/Entities/Item.h
+++ b/src/game/Entities/Item.h
@@ -319,7 +319,7 @@ class Item : public Object
         int32 GetItemRandomPropertyId() const { return GetInt32Value(ITEM_FIELD_RANDOM_PROPERTIES_ID); }
         uint32 GetItemSuffixFactor() const { return GetUInt32Value(ITEM_FIELD_PROPERTY_SEED); }
         void SetItemRandomProperties(int32 randomPropId);
-        bool UpdateItemSuffixFactor();
+        void UpdateItemSuffixFactor();
         static int32 GenerateItemRandomPropertyId(uint32 item_id);
         void SetEnchantment(EnchantmentSlot slot, uint32 id, uint32 duration, uint32 charges, ObjectGuid caster = ObjectGuid());
         void SetEnchantmentDuration(EnchantmentSlot slot, uint32 duration);

--- a/src/game/Entities/Object.cpp
+++ b/src/game/Entities/Object.cpp
@@ -790,23 +790,22 @@ void Object::ClearUpdateMask(bool remove)
     }
 }
 
-bool Object::LoadValues(const char* data)
+void Object::_LoadIntoDataField(const char* data, uint32 startOffset, uint32 count)
 {
-    if (!m_uint32Values) _InitValues();
+    if (!data)
+        return;
 
     Tokens tokens = StrSplit(data, " ");
 
-    if (tokens.size() != m_valuesCount)
-        return false;
+    if (tokens.size() != count)
+        return;
 
-    Tokens::iterator iter;
-    int index;
-    for (iter = tokens.begin(), index = 0; index < m_valuesCount; ++iter, ++index)
+    Tokens::const_iterator iter;
+    uint32 index;
+    for (iter = tokens.begin(), index = 0; index < count; ++iter, ++index)
     {
-        m_uint32Values[index] = std::stoul(*iter);
+        m_uint32Values[startOffset + index] = atol((*iter).c_str());
     }
-
-    return true;
 }
 
 void Object::_SetUpdateBits(UpdateMask* updateMask, Player* /*target*/) const

--- a/src/game/Entities/Object.h
+++ b/src/game/Entities/Object.h
@@ -559,7 +559,7 @@ class Object
 
         void ClearUpdateMask(bool remove);
 
-        bool LoadValues(const char* data);
+        void _LoadIntoDataField(const char* data, uint32 startOffset, uint32 count);
 
         uint16 GetValuesCount() const { return m_valuesCount; }
 

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -4225,16 +4225,16 @@ void Player::DeleteFromDB(ObjectGuid playerguid, uint32 accountId, bool updateRe
                     if (has_items)
                     {
                         // data needs to be at first place for Item::LoadFromDB
-                        //                                                          0    1         2
-                        QueryResult* resultItems = CharacterDatabase.PQuery("SELECT data,item_guid,item_template FROM mail_items JOIN item_instance ON item_guid = guid WHERE mail_id='%u'", mail_id);
+                        //                                                          0          1            2                3      4         5        6      7             8                 9           10          11         12             
+                        QueryResult* resultItems = CharacterDatabase.PQuery("SELECT itemEntry, creatorGuid, giftCreatorGuid, count, duration, charges, flags, enchantments, randomPropertyId, durability, itemTextId, item_guid, item_template FROM mail_items JOIN item_instance ON item_guid = guid WHERE mail_id='%u'", mail_id);
                         if (resultItems)
                         {
                             do
                             {
                                 Field* fields2 = resultItems->Fetch();
 
-                                uint32 item_guidlow = fields2[1].GetUInt32();
-                                uint32 item_template = fields2[2].GetUInt32();
+                                uint32 item_guidlow = fields2[11].GetUInt32();
+                                uint32 item_template = fields2[12].GetUInt32();
 
                                 ItemPrototype const* itemProto = ObjectMgr::GetItemPrototype(item_template);
                                 if (!itemProto)
@@ -15571,7 +15571,8 @@ void Player::LoadCorpse()
 
 void Player::_LoadInventory(QueryResult* result, uint32 timediff)
 {
-    // QueryResult *result = CharacterDatabase.PQuery("SELECT data,bag,slot,item,item_template FROM character_inventory JOIN item_instance ON character_inventory.item = item_instance.guid WHERE character_inventory.guid = '%u' ORDER BY bag,slot", GetGUIDLow());
+    //        0          1            2                3      4         5        6      7             8                 9           10          11   12    13    14
+    // SELECT itemEntry, creatorGuid, giftCreatorGuid, count, duration, charges, flags, enchantments, randomPropertyId, durability, itemTextId, bag, slot, item, item_template FROM character_inventory JOIN item_instance ON character_inventory.item = item_instance.guid WHERE character_inventory.guid = '%u' ORDER BY bag, slot
     std::map<uint32, Bag*> bagMap;                          // fast guid lookup for bags
     // NOTE: the "order by `bag`" is important because it makes sure
     // the bagMap is filled before items in the bags are loaded
@@ -15589,10 +15590,10 @@ void Player::_LoadInventory(QueryResult* result, uint32 timediff)
         do
         {
             Field* fields = result->Fetch();
-            uint32 bag_guid  = fields[1].GetUInt32();
-            uint8  slot      = fields[2].GetUInt8();
-            uint32 item_lowguid = fields[3].GetUInt32();
-            uint32 item_id   = fields[4].GetUInt32();
+            uint32 bag_guid  = fields[11].GetUInt32();
+            uint8  slot      = fields[12].GetUInt8();
+            uint32 item_lowguid = fields[13].GetUInt32();
+            uint32 item_id   = fields[14].GetUInt32();
 
             ItemPrototype const* proto = ObjectMgr::GetItemPrototype(item_id);
 
@@ -15770,18 +15771,17 @@ void Player::_LoadItemLoot(QueryResult* result)
 // load mailed item which should receive current player
 void Player::_LoadMailedItems(QueryResult* result)
 {
-    // data needs to be at first place for Item::LoadFromDB
-    //         0     1        2          3
-    // "SELECT data, mail_id, item_guid, item_template FROM mail_items JOIN item_instance ON item_guid = guid WHERE receiver = '%u'", GUID_LOPART(m_guid)
+    //        0          1            2                3      4         5        6      7             8                 9           10          11       12         13
+    // SELECT itemEntry, creatorGuid, giftCreatorGuid, count, duration, charges, flags, enchantments, randomPropertyId, durability, itemTextId, mail_id, item_guid, item_template FROM mail_items JOIN item_instance ON item_guid = guid WHERE receiver = '%u'", m_guid.GetCounter());
     if (!result)
         return;
 
     do
     {
         Field* fields = result->Fetch();
-        uint32 mail_id       = fields[1].GetUInt32();
-        uint32 item_guid_low = fields[2].GetUInt32();
-        uint32 item_template = fields[3].GetUInt32();
+        uint32 mail_id       = fields[11].GetUInt32();
+        uint32 item_guid_low = fields[12].GetUInt32();
+        uint32 item_template = fields[13].GetUInt32();
 
         Mail* mail = GetMail(mail_id);
         if (!mail)

--- a/src/game/Guilds/Guild.cpp
+++ b/src/game/Guilds/Guild.cpp
@@ -1185,18 +1185,18 @@ void Guild::LoadGuildBankFromDB()
     delete result;
 
     // data needs to be at first place for Item::LoadFromDB
-    //                                        0     1      2       3          4
-    result = CharacterDatabase.PQuery("SELECT data, TabId, SlotId, item_guid, item_entry FROM guild_bank_item JOIN item_instance ON item_guid = guid WHERE guildid='%u' ORDER BY TabId", m_Id);
+    //                                        0          1            2                3      4         5        6      7             8                 9           10          11     12      13         14
+    result = CharacterDatabase.PQuery("SELECT itemEntry, creatorGuid, giftCreatorGuid, count, duration, charges, flags, enchantments, randomPropertyId, durability, itemTextId, TabId, SlotId, item_guid, item_entry FROM guild_bank_item JOIN item_instance ON item_guid = guid WHERE guildid='%u' ORDER BY TabId", m_Id);
     if (!result)
         return;
 
     do
     {
         Field* fields = result->Fetch();
-        uint8 TabId = fields[1].GetUInt8();
-        uint8 SlotId = fields[2].GetUInt8();
-        uint32 ItemGuid = fields[3].GetUInt32();
-        uint32 ItemEntry = fields[4].GetUInt32();
+        uint8 TabId = fields[11].GetUInt8();
+        uint8 SlotId = fields[12].GetUInt8();
+        uint32 ItemGuid = fields[13].GetUInt32();
+        uint32 ItemEntry = fields[14].GetUInt32();
 
         if (TabId >= GetPurchasedTabs())
         {

--- a/src/game/Tools/PlayerDump.cpp
+++ b/src/game/Tools/PlayerDump.cpp
@@ -591,19 +591,10 @@ DumpReturn PlayerDumpReader::LoadDump(const std::string& file, uint32 account, s
             }
             case DTT_ITEM:
             {
-                // item, owner, data field:item, owner guid
+                // item, owner
                 if (!changeGuid(line, 1, items, sObjectMgr.m_ItemGuids.GetNextAfterMaxUsed()))
                     ROLLBACK(DUMP_FILE_BROKEN);             // item_instance.guid update
                 if (!changenth(line, 2, newguid))           // item_instance.owner_guid update
-                    ROLLBACK(DUMP_FILE_BROKEN);
-                std::string vals = getnth(line, 3);         // item_instance.data get
-                if (!changetokGuid(vals, OBJECT_FIELD_GUID + 1, items, sObjectMgr.m_ItemGuids.GetNextAfterMaxUsed()))
-                    ROLLBACK(DUMP_FILE_BROKEN);             // item_instance.data.OBJECT_FIELD_GUID update
-                if (!changetoknth(vals, ITEM_FIELD_OWNER + 1, newguid))
-                    ROLLBACK(DUMP_FILE_BROKEN);             // item_instance.data.ITEM_FIELD_OWNER update
-                if (!changetokGuid(vals, ITEM_FIELD_ITEM_TEXT_ID + 1, itemTexts, sObjectMgr.m_ItemTextIds.GetNextAfterMaxUsed(), true))
-                    ROLLBACK(DUMP_FILE_BROKEN);
-                if (!changenth(line, 3, vals.c_str()))      // item_instance.data update
                     ROLLBACK(DUMP_FILE_BROKEN);
                 break;
             }


### PR DESCRIPTION
Removed the data blob left in item_instance as [removed in TrinityCore](https://github.com/TrinityCore/TrinityCore/commit/77fc91bde85b44298ab6694236d1f6c9ece3cd34) back in 2010.

The `uint32toint32` SQL function for data migration does not appear to work as intended anymore, however, and I need some advice or help on how to go forward with it. I am assuming that in 2010 when this commit was done in TC it was possible to somehow get MySQL to legally overflow an unsigned integer and cast it to signed so that the end result was a -1, but in more modern versions nowadays you're met with an out of bounds error. This is just my guess as to why this was possible before. I am unsure how to proceed with the migration script due to this.

The charges as stored as max uint32 values in the data blob currently and should be -1 as an end result.


Application into the classic and WotLK branches should be relatively similar as WotLK needs 1 additional field and classic is the same, I think, minus the guild bank related code.