### PR TITLE
Fixes the crash in quest 10451

### DIFF
--- a/src/game/AI/BaseAI/PetAI.cpp
+++ b/src/game/AI/BaseAI/PetAI.cpp
@@ -392,7 +392,7 @@ void PetAI::UpdateAI(const uint32 diff)
             {
                 if (following)
                 {
-                    m_unit->GetMotionMaster()->Clear(false);
+                    m_unit->GetMotionMaster()->Clear(false);    // does this need to be removed since MoveFollow is calling Clear?
                     m_unit->GetMotionMaster()->MoveFollow(owner, m_followDist, m_followAngle);
                 }
             }

--- a/src/game/AI/BaseAI/PetAI.cpp
+++ b/src/game/AI/BaseAI/PetAI.cpp
@@ -391,10 +391,7 @@ void PetAI::UpdateAI(const uint32 diff)
             else if (!m_unit->hasUnitState(UNIT_STAT_FOLLOW_MOVE) && !owner->IsWithinDistInMap(m_unit, (PET_FOLLOW_DIST * 2)))
             {
                 if (following)
-                {
-                    m_unit->GetMotionMaster()->Clear(false);    // does this need to be removed since MoveFollow is calling Clear?
                     m_unit->GetMotionMaster()->MoveFollow(owner, m_followDist, m_followAngle);
-                }
             }
         }
     }

--- a/src/game/AI/ScriptDevAI/scripts/outland/black_temple/boss_supremus.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/black_temple/boss_supremus.cpp
@@ -153,7 +153,6 @@ struct boss_supremusAI : public ScriptedAI
 
             if (pTarget)
             {
-                pSummoned->GetMotionMaster()->Clear();
                 pSummoned->GetMotionMaster()->MoveFollow(pTarget, 0.0f, 0.0f);
                 pSummoned->CastSpell(pSummoned, SPELL_MOLTEN_FLAME, TRIGGERED_NONE, nullptr, nullptr, m_creature->GetObjectGuid());
             }

--- a/src/game/AI/ScriptDevAI/scripts/outland/shadowmoon_valley.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/shadowmoon_valley.cpp
@@ -607,8 +607,7 @@ struct npc_wildaAI : public npc_escortAI
         {
             spirit->RemoveAurasDueToSpell(SPELL_WATER_BUBBLE);
             spirit->StopMoving();
-            spirit->GetMotionMaster()->Clear(false, true);
-            spirit->GetMotionMaster()->MoveFollow(m_creature, m_creature->GetDistance(spirit) * 0.25f, M_PI_F / 2 + m_creature->GetAngle(spirit));
+            spirit->GetMotionMaster()->MoveFollow(m_creature, m_creature->GetDistance(spirit) * 0.25f, M_PI_F / 2 + m_creature->GetAngle(spirit), true);
             spirit->SetFactionTemporary(FACTION_ESCORT_N_FRIEND_ACTIVE, TEMPFACTION_RESTORE_RESPAWN);
             spirit->SetLevitate(false);
         }

--- a/src/game/MotionGenerators/MotionMaster.cpp
+++ b/src/game/MotionGenerators/MotionMaster.cpp
@@ -318,7 +318,7 @@ void MotionMaster::MoveFollow(Unit* target, float dist, float angle, bool asMain
     if (asMain)
         Clear(false, true);
     else
-        Clear();
+        Clear(!empty()); // avoid resetting if we are already empty
 
     // ignore movement request if target not exist
     if (!target)


### PR DESCRIPTION
Resolves https://github.com/cmangos/issues/issues/1593)

This also removes a crash case in boss_supremus.cpp of this same problem.

Wasn't sure if `PetAI::UpdateAI(const uint32 diff)` requires the `Clear(false)` call still?