### PR TITLE
Fix a crash in SendGold for issue 1947

### DIFF
--- a/src/game/Loot/LootHandler.cpp
+++ b/src/game/Loot/LootHandler.cpp
@@ -118,7 +118,6 @@ void WorldSession::HandleLootReleaseOpcode(WorldPacket& recv_data)
 
     if (Loot* loot = sLootMgr.GetLoot(_player, lguid))
         loot->Release(_player);
-
 }
 
 void WorldSession::HandleLootMasterGiveOpcode(WorldPacket& recv_data)

--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -1147,7 +1147,7 @@ void Loot::SetPlayerIsNotLooting(Player* player)
     }
 }
 
-void Loot::Release(Player* player)
+bool Loot::Release(Player* player)
 {
     bool updateClients = false;
     if (player->GetObjectGuid() == m_currentLooterGuid)
@@ -1251,7 +1251,7 @@ void Loot::Release(Player* player)
         {
             Corpse* corpse = (Corpse*) m_lootTarget;
             if (!corpse || !corpse->IsWithinDistInMap(player, INTERACTION_DISTANCE))
-                return;
+                return false;
 
             if (IsLootedFor(player))
             {
@@ -1302,7 +1302,7 @@ void Loot::Release(Player* player)
                     break;
                 }
             }
-            return;                                         // item can be looted only single player
+            return false; // item can be looted only single player
         }
         case HIGHGUID_UNIT:
         {
@@ -1376,6 +1376,8 @@ void Loot::Release(Player* player)
 
     if (updateClients)
         ForceLootAnimationClientUpdate();
+
+    return updateClients;
 }
 
 // Popup windows with loot content
@@ -2187,9 +2189,7 @@ void Loot::SendGold(Player* player)
     }
     m_gold = 0;
 
-    if (IsLootedFor(player))
-        Release(player);
-    else
+    if(!IsLootedFor(player) || Release(player))
         ForceLootAnimationClientUpdate();
 }
 

--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -1251,7 +1251,7 @@ bool Loot::Release(Player* player)
         {
             Corpse* corpse = (Corpse*) m_lootTarget;
             if (!corpse || !corpse->IsWithinDistInMap(player, INTERACTION_DISTANCE))
-                return false;
+                return true;
 
             if (IsLootedFor(player))
             {
@@ -1377,7 +1377,7 @@ bool Loot::Release(Player* player)
     if (updateClients)
         ForceLootAnimationClientUpdate();
 
-    return updateClients;
+    return true;
 }
 
 // Popup windows with loot content

--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -1375,7 +1375,7 @@ void Loot::Release(Player* player)
     }
 
     if (updateClients)
-        ForceLootAnimationCLientUpdate();
+        ForceLootAnimationClientUpdate();
 }
 
 // Popup windows with loot content
@@ -1633,7 +1633,7 @@ Loot::Loot(Player* player, Creature* creature, LootType type) :
                     creature->SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
                 else
                     creature->SetLootStatus(CREATURE_LOOT_STATUS_LOOTED);
-                ForceLootAnimationCLientUpdate();
+                ForceLootAnimationClientUpdate();
                 break;
             }
 
@@ -2021,7 +2021,7 @@ InventoryResult Loot::SendItem(Player* target, LootItem* lootItem)
         }
         else if (IsLootedFor(target))
             SendReleaseFor(target);
-        ForceLootAnimationCLientUpdate();
+        ForceLootAnimationClientUpdate();
     }
     return msg;
 }
@@ -2077,7 +2077,7 @@ void Loot::Update()
 
 // this will force server to update all client that is showing this object
 // used to update players right to loot or sparkles animation
-void Loot::ForceLootAnimationCLientUpdate() const
+void Loot::ForceLootAnimationClientUpdate() const
 {
     if (!m_lootTarget)
         return;
@@ -2189,7 +2189,8 @@ void Loot::SendGold(Player* player)
 
     if (IsLootedFor(player))
         Release(player);
-    ForceLootAnimationCLientUpdate();
+    else
+        ForceLootAnimationClientUpdate();
 }
 
 bool Loot::IsItemAlreadyIn(uint32 itemId) const

--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -2189,7 +2189,7 @@ void Loot::SendGold(Player* player)
     }
     m_gold = 0;
 
-    if(!IsLootedFor(player) || Release(player))
+    if (!IsLootedFor(player) || Release(player))
         ForceLootAnimationClientUpdate();
 }
 

--- a/src/game/Loot/LootMgr.h
+++ b/src/game/Loot/LootMgr.h
@@ -345,7 +345,7 @@ class Loot
         void SetGroupLootRight(Player* player);
         void GenerateMoneyLoot(uint32 minAmount, uint32 maxAmount);
         bool FillLoot(uint32 loot_id, LootStore const& store, Player* lootOwner, bool personal, bool noEmptyError = false);
-        void ForceLootAnimationCLientUpdate() const;
+        void ForceLootAnimationClientUpdate() const;
         void SetPlayerIsLooting(Player* player);
         void SetPlayerIsNotLooting(Player* player);
         void GetLootContentFor(Player* player, ByteBuffer& buffer);

--- a/src/game/Loot/LootMgr.h
+++ b/src/game/Loot/LootMgr.h
@@ -308,7 +308,7 @@ class Loot
         void ShowContentTo(Player* plr);
         void Update();
         bool IsChanged() const { return m_isChanged; }
-        void Release(Player* player);
+        bool Release(Player* player);
         void GetLootItemsListFor(Player* player, LootItemList& lootList);
         void SetGoldAmount(uint32 _gold);
         void SendGold(Player* player);


### PR DESCRIPTION
## 🍰 Pullrequest
Crashes when you open the quest reward (bag of silver). The issue is that its calling `ForceLootAnimationClientUpdate` after already calling `Release` which handles the client update when required. Instead we ignore `ForceLootAnimationClientUpdate` when releasing in `SendGold`.

### Proof
https://github.com/cmangos/issues/issues/1947

### Issues
https://github.com/cmangos/issues/issues/1947

### How2Test
create an alliance character
.quest add 116
.quest complete 116
.go creature "Barkeep Daniels"

### Todo / Checklist