### PR TITLE
Fix stacking issues with cast item spells (i.e. Drums of War)

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -4680,14 +4680,14 @@ bool Unit::AddSpellAuraHolder(SpellAuraHolder* holder)
     {
         if (!RemoveNoStackAurasDueToAuraHolder(holder))
         {
-            return false;                                   // couldn't remove conflicting aura with higher rank
+            return false; // couldn't remove conflicting aura with higher rank
         }
     }
 
     // update tracked aura targets list (before aura add to aura list, to prevent unexpected remove recently added aura)
     if (TrackedAuraType trackedType = holder->GetTrackedAuraType())
     {
-        if (Unit* caster = holder->GetCaster())             // caster not in world
+        if (Unit* caster = holder->GetCaster()) // caster not in world
         {
             // Only compare TrackedAuras of same tracking type
             TrackedAuraTargetMap& scTargets = caster->GetTrackedAuraTargets(trackedType);
@@ -4824,11 +4824,8 @@ bool Unit::RemoveNoStackAurasDueToAuraHolder(SpellAuraHolder* holder)
         return false;
 
     // passive spell special case (only non stackable with ranks)
-    if (IsPassiveSpell(spellProto))
-    {
-        if (IsPassiveSpellStackableWithRanks(spellProto))
-            return true;
-    }
+    if (IsPassiveSpell(spellProto) && IsPassiveSpellStackableWithRanks(spellProto))
+        return true;
 
     const uint32 spellId = holder->GetId();
     const SpellSpecific specific = GetSpellSpecific(spellId);
@@ -4857,13 +4854,19 @@ bool Unit::RemoveNoStackAurasDueToAuraHolder(SpellAuraHolder* holder)
         // Experimental: passive abilities dont stack with itself
         if (IsPassiveSpell(existingSpellProto) && (spellId != existingSpellId || !spellProto->HasAttribute(SPELL_ATTR_ABILITY)))
         {
-            // passive non-stackable spells not stackable only for same caster
-            // Experimental: exclude party passive auras from this
-            if (!own && !IsSpellHaveEffect(spellProto, SPELL_EFFECT_APPLY_AREA_AURA_PARTY))
-                continue;
-
-            // passive non-stackable spells not stackable only with another rank of same spell
-            if (!sSpellMgr.IsSpellAnotherRankOfSpell(spellId, existingSpellId))
+            // passive spells aren't stackable from the same caster
+            // Experimental: ensure party passive auras and party item buffs are still being processed
+            if (own)
+            {
+                // passive non-stackable spells not stackable only with another rank of same spell
+                if (!sSpellMgr.IsSpellAnotherRankOfSpell(spellId, existingSpellId))
+                    continue;
+            }
+            // make sure we aren't a friendly aura (these need to be checked still)
+            else if (!IsSpellHaveEffect(spellProto, SPELL_EFFECT_APPLY_AURA)
+                  && !IsSpellHaveEffect(spellProto, SPELL_EFFECT_APPLY_AREA_AURA_PARTY)
+                  && !IsSpellHaveEffect(spellProto, SPELL_EFFECT_APPLY_AREA_AURA_FRIEND)
+                  && !IsSpellHaveEffect(spellProto, SPELL_EFFECT_APPLY_AREA_AURA_PET))
                 continue;
         }
 
@@ -4888,7 +4891,7 @@ bool Unit::RemoveNoStackAurasDueToAuraHolder(SpellAuraHolder* holder)
             unique = diminished;
         }
 
-        const bool stackable = !sSpellMgr.IsNoStackSpellDueToSpell(spellProto, existingSpellProto);
+        const bool stackable = !sSpellMgr.IsNoStackSpellDueToSpellAndCastItem(holder, existing);
         if (unique || !stackable)
         {
             // check if this spell can be triggered by any talent aura

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -7408,7 +7408,7 @@ bool SpellEvent::Execute(uint64 e_time, uint32 p_time)
 
     // spell processing not complete, plan event on the next update interval
     m_Spell->GetCaster()->m_events.AddEvent(this, e_time + 1, false);
-    return false;                                           // event not complete
+    return false; // event not complete
 }
 
 void SpellEvent::Abort(uint64 /*e_time*/)

--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -1301,6 +1301,29 @@ void SpellMgr::LoadSpellThreats()
     sLog.outString();
 }
 
+bool SpellMgr::IsNoStackSpellDueToSpellAndCastItem(SpellAuraHolder const* spellHolder1, SpellAuraHolder const* spellHolder2) const
+{
+    if (!spellHolder1 || !spellHolder2)
+        return false;
+
+    SpellEntry const* spellInfo1 = spellHolder1->GetSpellProto();
+    SpellEntry const* spellInfo2 = spellHolder2->GetSpellProto();
+
+    bool stackable = !IsNoStackSpellDueToSpell(spellInfo1, spellInfo2);
+    const bool own = (spellHolder1->GetCasterGuid() == spellHolder2->GetCasterGuid());
+
+    // lets check if we are an item spell from another player
+    if (stackable && !own && !spellInfo1->HasAttribute(SPELL_ATTR_EX3_STACK_FOR_DIFF_CASTERS))
+    {
+        ObjectGuid castItem1 = spellHolder1->GetCastItemGuid();
+        ObjectGuid castItem2 = spellHolder2->GetCastItemGuid();
+        
+        // check that we have found an item, if we do then we are not stackable
+        stackable = !((castItem1 && !castItem1.IsEmpty()) || (castItem2 && !castItem2.IsEmpty()));
+    }
+    return !stackable;
+}
+
 bool SpellMgr::IsNoStackSpellDueToSpell(SpellEntry const* spellInfo_1, SpellEntry const* spellInfo_2) const
 {
     if (!spellInfo_1 || !spellInfo_2)

--- a/src/game/Spells/SpellMgr.h
+++ b/src/game/Spells/SpellMgr.h
@@ -2559,6 +2559,7 @@ class SpellMgr
             return (spellId1 != spellId2 && GetFirstSpellInChain(spellId1) == GetFirstSpellInChain(spellId2));
         }
 
+        bool IsNoStackSpellDueToSpellAndCastItem(SpellAuraHolder const* spellHolder1, SpellAuraHolder const* spellHolder2) const;
         bool IsNoStackSpellDueToSpell(SpellEntry const* spellInfo_1, SpellEntry const* spellInfo_2) const;
         bool IsSingleTargetSpell(SpellEntry const* entry) const
         {


### PR DESCRIPTION
## 🍰 Pullrequest
Resolves https://github.com/cmangos/issues/issues/1943

Modified the RemoveNoStackAurasDueToAuraHolder check to also account for the cast items, if they ever match we need to avoid stacking when they are from another player. I also fixed some of the passive spell check logic to account for all the SPELL_EFFECT_APPLY_AURA_* spell effects. This will ensure friendly auras are always check.

### Proof
https://github.com/cmangos/issues/issues/1943

### Issues
https://github.com/cmangos/issues/issues/1943

### How2Test
* .learn all_crafts
* .setskill 165 350
* .additem 29528
* login to two character
* join party
* click drum
* .cooldown clear

### Todo / Checklist
