### PR TITLE
Resolve evading issues with units that have pets

### DIFF
--- a/src/game/AI/BaseAI/GuardianAI.cpp
+++ b/src/game/AI/BaseAI/GuardianAI.cpp
@@ -84,7 +84,7 @@ void GuardianAI::CombatStop()
 void GuardianAI::EnterEvadeMode()
 {
     m_creature->RemoveAllAurasOnEvade();
-    m_creature->CombatStop(true);
+    m_creature->CombatStopWithPets(true);
 
     m_creature->TriggerEvadeEvents();
 

--- a/src/game/AI/BaseAI/TotemAI.cpp
+++ b/src/game/AI/BaseAI/TotemAI.cpp
@@ -43,7 +43,7 @@ void TotemAI::MoveInLineOfSight(Unit* /*who*/)
 
 void TotemAI::EnterEvadeMode()
 {
-    m_creature->CombatStop(true);
+    m_creature->CombatStopWithPets(true);
 
     // Handle Evade events
     IncreaseDepthIfNecessary();

--- a/src/game/AI/BaseAI/UnitAI.cpp
+++ b/src/game/AI/BaseAI/UnitAI.cpp
@@ -84,7 +84,7 @@ void UnitAI::MoveInLineOfSight(Unit* who)
 void UnitAI::EnterEvadeMode()
 {
     m_unit->RemoveAllAurasOnEvade();
-    m_unit->CombatStop(true);
+    m_unit->CombatStopWithPets(true);
 
     // only alive creatures that are not on transport can return to home position
     if (GetReactState() != REACT_PASSIVE && m_unit->isAlive() && !m_unit->IsBoarded())

--- a/src/game/AI/ScriptDevAI/base/follower_ai.cpp
+++ b/src/game/AI/ScriptDevAI/base/follower_ai.cpp
@@ -122,7 +122,7 @@ void FollowerAI::CorpseRemoved(uint32& /*respawnDelay*/)
 void FollowerAI::EnterEvadeMode()
 {
     m_creature->RemoveAllAurasOnEvade();
-    m_creature->CombatStop(true);
+    m_creature->CombatStopWithPets(true);
 
     if (HasFollowState(STATE_FOLLOW_INPROGRESS))
     {

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -6248,15 +6248,15 @@ void Unit::MeleeAttackStop(Unit* victim)
 
 struct CombatStopWithPetsHelper
 {
-    explicit CombatStopWithPetsHelper(bool _includingCast) : includingCast(_includingCast) {}
-    void operator()(Unit* unit) const { unit->CombatStop(includingCast); }
-    bool includingCast;
+    explicit CombatStopWithPetsHelper(bool _includingCast, bool _includingCombo) : includingCast(_includingCast), includingCombo(_includingCombo) {}
+    void operator()(Unit* unit) const { unit->CombatStop(includingCast, includingCombo); }
+    bool includingCast, includingCombo;
 };
 
-void Unit::CombatStopWithPets(bool includingCast)
+void Unit::CombatStopWithPets(bool includingCast, bool includingCombo)
 {
-    CombatStop(includingCast);
-    CallForAllControlledUnits(CombatStopWithPetsHelper(includingCast), CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
+    CombatStop(includingCast, includingCombo);
+    CallForAllControlledUnits(CombatStopWithPetsHelper(includingCast, includingCombo), CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
 }
 
 void Unit::RemoveAllAttackers()
@@ -11614,7 +11614,9 @@ void Unit::Uncharm(Unit* charmed, uint32 spellId)
     Creature* charmedCreature = nullptr;
     CharmInfo* charmInfo = charmed->GetCharmInfo();
 
-    charmed->SetEvade(EVADE_NONE); // if charm expires mid evade clear evade since movement is also cleared - TODO: maybe should be done on HomeMovementGenerator::MovementExpires?
+    // if charm expires mid evade clear evade since movement is also cleared
+    // TODO: maybe should be done on HomeMovementGenerator::MovementExpires
+    charmed->SetEvade(EVADE_NONE); 
 
     if (charmed->GetTypeId() == TYPEID_UNIT)
     {

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -1432,7 +1432,7 @@ class Unit : public WorldObject
 
         Unit* getVictim() const { return m_attacking; }     //< Returns the victim that this unit is currently attacking
         void CombatStop(bool includingCast = false, bool includingCombo = true);        //< Stop this unit from combat, if includingCast==true, also interrupt casting
-        void CombatStopWithPets(bool includingCast = false);
+        void CombatStopWithPets(bool includingCast = false, bool includingCombo = true);
         void StopAttackFaction(uint32 faction_id);
         Unit* SelectRandomUnfriendlyTarget(Unit* except = nullptr, float radius = ATTACK_DISTANCE) const;
         Unit* SelectRandomFriendlyTarget(Unit* except = nullptr, float radius = ATTACK_DISTANCE) const;
@@ -1632,7 +1632,7 @@ class Unit : public WorldObject
         void SetCanParry(const bool flag);
         void SetCanBlock(const bool flag);
 
-        bool CanReactInCombat() const { return (isAlive() && !IsIncapacitated()); }
+        bool CanReactInCombat() const { return (isAlive() && !IsIncapacitated() && !IsEvadingHome()); }
         bool CanDodgeInCombat() const;
         bool CanDodgeInCombat(const Unit* attacker) const;
         bool CanParryInCombat() const;
@@ -2388,6 +2388,7 @@ class Unit : public WorldObject
         void TriggerEvadeEvents();
         void EvadeTimerExpired();
         bool IsInEvadeMode() const { return m_evadeTimer > 0 || m_evadeMode; }
+        bool IsEvadingHome() const { return m_evadeMode == EVADE_HOME; }
         bool IsEvadeRegen() const { return (m_evadeTimer > 0 && m_evadeTimer <= 5000) || m_evadeMode; } // Only regen after 5 seconds, or when in permanent evade
         void StartEvadeTimer() { m_evadeTimer = 10000; } // 10 seconds after which action is taken
         void StopEvade(); // Stops either timer or evade state
@@ -2415,7 +2416,7 @@ class Unit : public WorldObject
         void Uncharm(Unit* charmed, uint32 spellId = 0);
 
         // Combat prevention
-        bool CanEnterCombat() { return m_canEnterCombat && m_evadeMode != EVADE_HOME; }
+        bool CanEnterCombat() { return m_canEnterCombat && !IsEvadingHome(); }
         void SetCanEnterCombat(bool can) { m_canEnterCombat = can; }
 
         void SetTurningOff(bool apply);

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -884,7 +884,7 @@ bool Map::CreatureRespawnRelocation(Creature* c)
     CellPair resp_val = MaNGOS::ComputeCellPair(resp_x, resp_y);
     Cell resp_cell(resp_val);
 
-    c->CombatStop();
+    c->CombatStopWithPets();
     c->GetMotionMaster()->Clear();
 
     DEBUG_FILTER_LOG(LOG_FILTER_CREATURE_MOVES, "Creature (GUID: %u Entry: %u) will moved from grid[%u,%u]cell[%u,%u] to respawn grid[%u,%u]cell[%u,%u].", c->GetGUIDLow(), c->GetEntry(), c->GetCurrentCell().GridX(), c->GetCurrentCell().GridY(), c->GetCurrentCell().CellX(), c->GetCurrentCell().CellY(), resp_cell.GridX(), resp_cell.GridY(), resp_cell.CellX(), resp_cell.CellY());

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -502,7 +502,7 @@ void WorldSession::LogoutPlayer(bool Save)
             _player->RepopAtGraveyard();
         }
         else if (_player->isInCombat())
-            _player->CombatStop(true, true);
+            _player->CombatStopWithPets(true, true);
 
         // drop a flag if player is carrying it
         if (BattleGround* bg = _player->GetBattleGround())


### PR DESCRIPTION
## 🍰 Pullrequest
Resolves https://github.com/cmangos/issues/issues/1941

We need to make sure we are also evading the pets when calling EnterEvadeMode, otherwise the pet will keep attacking and reinvoke you as the target on the owner, causing strange behavior.

There were also other cases where stopping pets combat would also be appropriate that I have updated here too.

### Proof
https://github.com/cmangos/issues/issues/1941

### Issues
https://github.com/cmangos/issues/issues/1941

### How2Test
* Go to npc with pet (for example .go creature id 5617)
* Start combat.
* Try to go out of combat by run from them (try several times)

### Todo / Checklist