### PR TITLE
Resolves issues with flag capping in BG's like AB

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -365,7 +365,7 @@ void BattleGround::Update(uint32 diff)
                     {
                         float x, y, z, o;
                         GetTeamStartLoc(player->GetTeam(), x, y, z, o);
-                        if (!player->IsWithinDist3d(x, y, z, maxDist))
+                        if (!player->IsWithinDist3d(x, y, z, maxDist) && !sBattleGroundMgr.isTesting())
                         {
                             player->TeleportTo(GetMapId(), x, y, z, o);
                         }
@@ -529,7 +529,7 @@ void BattleGround::SendObjectUpdatesToPlayer(Player* player)
     if (!player)
         return;
     Map* map = GetBgMap();
-    GuidVector::const_iterator it = m_objUpdates.begin();
+    auto it = m_objUpdates.begin();
     for (; it != m_objUpdates.end(); ++it)
     {
         GameObject* obj = map->GetGameObject(*it);
@@ -542,11 +542,7 @@ void BattleGround::SendObjectUpdatesToPlayer(Player* player)
 
 void BattleGround::AddPlayerUpdateObject(ObjectGuid guid)
 {
-    auto it = std::find(m_objUpdates.begin(), m_objUpdates.end(), guid);
-    if (it == m_objUpdates.end())
-    {
-        m_objUpdates.push_back(guid);
-    }
+    m_objUpdates.insert(guid);
 }
 
 void BattleGround::PlaySoundToAll(uint32 SoundID) const

--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -1581,7 +1581,7 @@ void BattleGround::SpawnBGObject(ObjectGuid guid, uint32 respawntime)
         // The objects state will sometimes not sync correctly with the client
         // since the object is invisible when the state change takes place.
         // In order to maintain its object state on the clients we will keep track.
-        if (respawntime == RESPAWN_ONE_DAY)
+        if (respawntime == RESPAWN_ONE_DAY && GetStatus() == STATUS_IN_PROGRESS)
             AddPlayerUpdateObject(guid);
     }
     else

--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -1561,10 +1561,10 @@ void BattleGround::SpawnEvent(uint8 event1, uint8 event2, bool spawn)
         SpawnBGCreature(*itr, (spawn) ? RESPAWN_IMMEDIATELY : RESPAWN_ONE_DAY);
     GuidVector::const_iterator itr2 = m_EventObjects[MAKE_PAIR32(event1, event2)].gameobjects.begin();
     for (; itr2 != m_EventObjects[MAKE_PAIR32(event1, event2)].gameobjects.end(); ++itr2)
-        SpawnBGObject(*itr2, (spawn) ? RESPAWN_IMMEDIATELY : RESPAWN_ONE_DAY);
+        SpawnBGObject(*itr2, (spawn) ? RESPAWN_IMMEDIATELY : RESPAWN_ONE_DAY, true);
 }
 
-void BattleGround::SpawnBGObject(ObjectGuid guid, uint32 respawntime)
+void BattleGround::SpawnBGObject(ObjectGuid guid, uint32 respawntime, bool storeUpdate/* = false*/)
 {
     Map* map = GetBgMap();
     GameObject* obj = map->GetGameObject(guid);
@@ -1581,7 +1581,7 @@ void BattleGround::SpawnBGObject(ObjectGuid guid, uint32 respawntime)
         // The objects state will sometimes not sync correctly with the client
         // since the object is invisible when the state change takes place.
         // In order to maintain its object state on the clients we will keep track.
-        if (respawntime == RESPAWN_ONE_DAY && GetStatus() == STATUS_IN_PROGRESS)
+        if (storeUpdate && respawntime == RESPAWN_ONE_DAY && GetStatus() == STATUS_IN_PROGRESS)
             AddPlayerUpdateObject(guid);
     }
     else

--- a/src/game/BattleGround/BattleGround.h
+++ b/src/game/BattleGround/BattleGround.h
@@ -415,6 +415,9 @@ class BattleGround
         virtual void EndBattleGround(Team winner);
         static void BlockMovement(Player* plr);
 
+        void SendObjectUpdatesToPlayer(Player* player);
+        void AddPlayerUpdateObject(ObjectGuid guid);
+
         void SendMessageToAll(int32 entry, ChatMsg type, Player const* source = nullptr);
         void SendYellToAll(int32 entry, uint32 language, ObjectGuid guid);
         void PSendMessageToAll(int32 entry, ChatMsg type, Player const* source, ...);
@@ -616,6 +619,8 @@ class BattleGround
         float m_TeamStartLocZ[PVP_TEAM_COUNT];
         float m_TeamStartLocO[PVP_TEAM_COUNT];
         float m_startMaxDist;
+
+        GuidVector m_objUpdates;
 };
 
 // helper functions for world state list fill

--- a/src/game/BattleGround/BattleGround.h
+++ b/src/game/BattleGround/BattleGround.h
@@ -500,7 +500,7 @@ class BattleGround
 
         void HandleTriggerBuff(ObjectGuid go_guid);
 
-        void SpawnBGObject(ObjectGuid guid, uint32 respawntime);
+        void SpawnBGObject(ObjectGuid guid, uint32 respawntime, bool storeUpdate = false);
         void SpawnBGCreature(ObjectGuid guid, uint32 respawntime);
 
         void DoorOpen(ObjectGuid guid);

--- a/src/game/BattleGround/BattleGround.h
+++ b/src/game/BattleGround/BattleGround.h
@@ -620,7 +620,7 @@ class BattleGround
         float m_TeamStartLocO[PVP_TEAM_COUNT];
         float m_startMaxDist;
 
-        GuidVector m_objUpdates;
+        std::set<ObjectGuid> m_objUpdates;
 };
 
 // helper functions for world state list fill

--- a/src/game/BattleGround/BattleGroundAB.cpp
+++ b/src/game/BattleGround/BattleGroundAB.cpp
@@ -400,6 +400,9 @@ void BattleGroundAB::EventPlayerClickedOnFlag(Player* source, GameObject* target
             SendMessage2ToAll(LANG_BG_AB_NODE_TAKEN, CHAT_MSG_BG_SYSTEM_HORDE, nullptr, LANG_BG_HORDE, _GetNodeNameId(node));
     }
     PlaySoundToAll(sound);
+
+    // Make sure any objects that require player updates are handled.
+    SendObjectUpdatesToPlayer(source);
 }
 
 void BattleGroundAB::Reset()

--- a/src/game/BattleGround/BattleGroundAV.cpp
+++ b/src/game/BattleGround/BattleGroundAV.cpp
@@ -507,6 +507,9 @@ void BattleGroundAV::EventPlayerClickedOnFlag(Player* source, GameObject* target
         default:
             break;
     }
+
+    // Make sure any objects that require player updates are handled.
+    SendObjectUpdatesToPlayer(source);
 }
 
 void BattleGroundAV::EventPlayerDefendsPoint(Player* player, BG_AV_Nodes node)

--- a/src/game/BattleGround/BattleGroundEY.cpp
+++ b/src/game/BattleGround/BattleGroundEY.cpp
@@ -400,6 +400,9 @@ void BattleGroundEY::EventPlayerDroppedFlag(Player* source)
         UpdateWorldState(WORLD_STATE_EY_NETHERSTORM_FLAG_STATE_HORDE, 1);
         SendMessageToAll(LANG_BG_EY_DROPPED_FLAG, CHAT_MSG_BG_SYSTEM_HORDE, nullptr);
     }
+
+    // Make sure any objects that require player updates are handled.
+    SendObjectUpdatesToPlayer(source);
 }
 
 void BattleGroundEY::EventPlayerClickedOnFlag(Player* source, GameObject* target_obj)
@@ -437,6 +440,9 @@ void BattleGroundEY::EventPlayerClickedOnFlag(Player* source, GameObject* target
         PSendMessageToAll(LANG_BG_EY_HAS_TAKEN_FLAG, CHAT_MSG_BG_SYSTEM_ALLIANCE, nullptr, source->GetName());
     else
         PSendMessageToAll(LANG_BG_EY_HAS_TAKEN_FLAG, CHAT_MSG_BG_SYSTEM_HORDE, nullptr, source->GetName());
+
+    // Make sure any objects that require player updates are handled.
+    SendObjectUpdatesToPlayer(source);
 }
 
 void BattleGroundEY::EventPlayerCapturedFlag(Player* source, EYNodes node)
@@ -472,6 +478,9 @@ void BattleGroundEY::EventPlayerCapturedFlag(Player* source, EYNodes node)
     }
 
     SpawnEvent(EY_EVENT_CAPTURE_FLAG, node, true);
+
+    // Make sure any objects that require player updates are handled.
+    SendObjectUpdatesToPlayer(source);
 
     UpdatePlayerScore(source, SCORE_FLAG_CAPTURES, 1);
 }

--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -220,6 +220,9 @@ void BattleGroundWS::EventPlayerCapturedFlag(Player* source)
     {
         m_FlagsTimer[GetOtherTeamIndex(GetTeamIndexByTeamId(source->GetTeam()))] = BG_WS_FLAG_RESPAWN_TIME;
     }
+
+    // Make sure any objects that require player updates are handled.
+    SendObjectUpdatesToPlayer(source);
 }
 
 void BattleGroundWS::EventPlayerDroppedFlag(Player* source)
@@ -298,6 +301,9 @@ void BattleGroundWS::EventPlayerDroppedFlag(Player* source)
 
         m_FlagsDropTimer[GetOtherTeamIndex(GetTeamIndexByTeamId(source->GetTeam()))] = BG_WS_FLAG_DROP_TIME;
     }
+
+    // Make sure any objects that require player updates are handled.
+    SendObjectUpdatesToPlayer(source);
 }
 
 void BattleGroundWS::EventPlayerClickedOnFlag(Player* source, GameObject* target_obj)
@@ -403,6 +409,9 @@ void BattleGroundWS::EventPlayerClickedOnFlag(Player* source, GameObject* target
 
     SendMessageToAll(message_id, type, source);
     source->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
+
+    // Make sure any objects that require player updates are handled.
+    SendObjectUpdatesToPlayer(source);
 }
 
 void BattleGroundWS::RemovePlayer(Player* plr, ObjectGuid guid)

--- a/src/game/Entities/Object.cpp
+++ b/src/game/Entities/Object.cpp
@@ -193,6 +193,17 @@ void Object::SendCreateUpdateToPlayer(Player* player) const
     player->GetSession()->SendPacket(packet);
 }
 
+void Object::SendUpdateToPlayer(Player* player) const
+{
+    // send create update to player
+    UpdateData upd;
+    WorldPacket packet;
+
+    BuildValuesUpdateBlockForPlayer(&upd, player);
+    upd.BuildPacket(packet);
+    player->GetSession()->SendPacket(packet);
+}
+
 void Object::BuildValuesUpdateBlockForPlayer(UpdateData* data, Player* target) const
 {
     ByteBuffer buf(500);

--- a/src/game/Entities/Object.h
+++ b/src/game/Entities/Object.h
@@ -373,6 +373,7 @@ class Object
 
         virtual void BuildCreateUpdateBlockForPlayer(UpdateData* data, Player* target) const;
         void SendCreateUpdateToPlayer(Player* player) const;
+        void SendUpdateToPlayer(Player* player) const;
 
         // must be overwrite in appropriate subclasses (WorldObject, Item currently), or will crash
         virtual void AddToClientUpdateList();

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -18848,7 +18848,7 @@ void Player::LeaveBattleground(bool teleportToEntryPoint)
         bg->RemovePlayerAtLeave(GetObjectGuid(), teleportToEntryPoint, true);
 
         // call after remove to be sure that player resurrected for correct cast
-        if (bg->isBattleGround() && !isGameMaster() && sWorld.getConfig(CONFIG_BOOL_BATTLEGROUND_CAST_DESERTER))
+        if (bg->isBattleGround() && !isGameMaster() && !sBattleGroundMgr.isTesting() && sWorld.getConfig(CONFIG_BOOL_BATTLEGROUND_CAST_DESERTER))
         {
             if (bg->GetStatus() == STATUS_IN_PROGRESS || bg->GetStatus() == STATUS_WAIT_JOIN)
             {


### PR DESCRIPTION
## 🍰 Pullrequest
Resolves https://github.com/cmangos/issues/issues/1250 

The solution here is that we need to send a player update for the objects state will sometimes not sync correctly with the client since the object is invisible when the state change takes place.
In order to maintain its object state on the clients we will keep track.

### Proof
https://github.com/cmangos/issues/issues/1250 

### Issues
https://github.com/cmangos/issues/issues/1250 

### How2Test
* login 2 chars of opposite factions
* .debug bg
* join Arathi Basin on each character
* cap the same flag post on each character
* do it forever because its fixed

### Todo / Checklist