### PR TITLE
WSG flag worldstates & fix flag pickup bug

### DIFF
--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -356,7 +356,7 @@ void BattleGroundWS::EventPlayerClickedOnFlag(Player* source, GameObject* target
         }
         else
         {
-			if(GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_GROUND)
+	        if(GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_GROUND)
                 return;
             message_id = LANG_BG_WS_PICKEDUP_AF;
             type = CHAT_MSG_BG_SYSTEM_HORDE;

--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -356,7 +356,7 @@ void BattleGroundWS::EventPlayerClickedOnFlag(Player* source, GameObject* target
         }
         else
         {
-	    if(GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_GROUND)
+	    if (GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_GROUND)
                 return;
             message_id = LANG_BG_WS_PICKEDUP_AF;
             type = CHAT_MSG_BG_SYSTEM_HORDE;

--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -356,7 +356,7 @@ void BattleGroundWS::EventPlayerClickedOnFlag(Player* source, GameObject* target
         }
         else
         {
-	        if(GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_GROUND)
+	    if(GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_GROUND)
                 return;
             message_id = LANG_BG_WS_PICKEDUP_AF;
             type = CHAT_MSG_BG_SYSTEM_HORDE;

--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -356,6 +356,8 @@ void BattleGroundWS::EventPlayerClickedOnFlag(Player* source, GameObject* target
         }
         else
         {
+			if(GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_GROUND)
+                return;
             message_id = LANG_BG_WS_PICKEDUP_AF;
             type = CHAT_MSG_BG_SYSTEM_HORDE;
             PlaySoundToAll(BG_WS_SOUND_ALLIANCE_FLAG_PICKED_UP);
@@ -384,6 +386,8 @@ void BattleGroundWS::EventPlayerClickedOnFlag(Player* source, GameObject* target
         }
         else
         {
+            if (GetFlagState(ALLIANCE) == BG_WS_FLAG_STATE_ON_GROUND)
+                return;
             message_id = LANG_BG_WS_PICKEDUP_HF;
             type = CHAT_MSG_BG_SYSTEM_ALLIANCE;
             PlaySoundToAll(BG_WS_SOUND_HORDE_FLAG_PICKED_UP);
@@ -581,12 +585,12 @@ void BattleGroundWS::FillInitialWorldStates(WorldPacket& data, uint32& count)
 
     FillInitialWorldState(data, count, BG_WS_FLAG_CAPTURES_MAX, BG_WS_MAX_TEAM_SCORE);
 
-    if (m_FlagState[TEAM_INDEX_HORDE] == BG_WS_FLAG_STATE_ON_PLAYER)
+    if (m_FlagState[TEAM_INDEX_ALLIANCE] == BG_WS_FLAG_STATE_ON_PLAYER)
         FillInitialWorldState(data, count, BG_WS_FLAG_STATE_HORDE, 2);
     else
         FillInitialWorldState(data, count, BG_WS_FLAG_STATE_HORDE, 1);
-
-    if (m_FlagState[TEAM_INDEX_ALLIANCE] == BG_WS_FLAG_STATE_ON_PLAYER)
+    
+    if (m_FlagState[TEAM_INDEX_HORDE] == BG_WS_FLAG_STATE_ON_PLAYER)
         FillInitialWorldState(data, count, BG_WS_FLAG_STATE_ALLIANCE, 2);
     else
         FillInitialWorldState(data, count, BG_WS_FLAG_STATE_ALLIANCE, 1);


### PR DESCRIPTION
## 🍰 Pullrequest
-Improvement to the bug where the flag states switch on area change. https://github.com/cmangos/issues/issues/1872
-Stops a bug where flag pickup code is incorrectly triggered when both flag states have the status on the ground. (i.e Alliance player returns their flag but also gains horde flag.

### Proof
https://github.com/cmangos/issues/issues/1872

### Issues
-Faction/flag holder world states - https://github.com/cmangos/issues/issues/1872
-Flag pickup bug


### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
World states:

- Pick up flag 
- Run into the middle of the map causing area change code to trigger, flag states will switch showing incorreclty which faction has which flag.

Flag pickup:

- Join WSG with 2 chars
- Pick up both flags and drop them at the same time (both flags on the ground)
- With 1 char return your faction flag, you'll gain the other factions flag in the process.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
