### PR TITLE
Resolve all Alterac Valley issues

### DIFF
--- a/src/game/BattleGround/BattleGround.h
+++ b/src/game/BattleGround/BattleGround.h
@@ -498,7 +498,10 @@ class BattleGround
         void HandleTriggerBuff(ObjectGuid go_guid);
 
         void SpawnBGObject(ObjectGuid guid, uint32 respawntime);
+        void DespawnBGObject(ObjectGuid guid);
+
         void SpawnBGCreature(ObjectGuid guid, uint32 respawntime);
+        void DespawnBGCreature(ObjectGuid guid);
 
         void DoorOpen(ObjectGuid guid);
         void DoorClose(ObjectGuid guid);

--- a/src/game/BattleGround/BattleGroundAV.cpp
+++ b/src/game/BattleGround/BattleGroundAV.cpp
@@ -458,7 +458,8 @@ bool BattleGroundAV::PlayerCanDoMineQuest(int32 GOId, Team team)
         return (m_Mine_Owner[BG_AV_NORTH_MINE] == GetAVTeamIndexByTeamId(team));
     if (GOId == BG_AV_OBJECTID_MINE_S)
         return (m_Mine_Owner[BG_AV_SOUTH_MINE] == GetAVTeamIndexByTeamId(team));
-    return true;                                            // cause it's no mine'object it is ok if this is true
+
+    return true; // cause it's no mine'object it is ok if this is true
 }
 
 /// will spawn and despawn creatures around a node
@@ -735,7 +736,7 @@ void BattleGroundAV::InitNode(BG_AV_Nodes node, BattleGroundAVTeamIndex teamIdx,
     m_Nodes[node].Timer      = 0;
     m_Nodes[node].Tower      = tower;
     m_ActiveEvents[node] = teamIdx * BG_AV_MAX_STATES + m_Nodes[node].State;
-    if (IsGrave(node))                                      // grave-creatures are special cause of a quest
+    if (IsGrave(node)) // grave-creatures are special cause of a quest
         m_ActiveEvents[node + BG_AV_NODES_MAX]  = teamIdx * BG_AV_MAX_GRAVETYPES;
 }
 

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -779,7 +779,10 @@ class Creature : public Unit
         void SaveRespawnTime() override;
 
         uint32 GetRespawnDelay() const { return m_respawnDelay; }
-        void SetRespawnDelay(uint32 delay) { m_respawnDelay = delay; }
+        void SetRespawnDelay(uint32 delay, bool allowRandomized = true) {
+            m_respawnRandomized = allowRandomized;
+            m_respawnDelay = delay;
+        }
 
         float GetRespawnRadius() const { return m_respawnradius; }
         void SetRespawnRadius(float dist) { m_respawnradius = dist; }
@@ -853,6 +856,9 @@ class Creature : public Unit
 
         void LockOutSpells(SpellSchoolMask schoolMask, uint32 duration) override;
 
+        bool IsRespawnRandomized() { return m_respawnRandomized; }
+        void SetRespawnRandomized(bool respawnRandomized) { m_respawnRandomized = respawnRandomized; }
+
         bool CanAggro() const { return m_canAggro; }
         void SetCanAggro(bool canAggro) { m_canAggro = canAggro; }
 
@@ -889,6 +895,7 @@ class Creature : public Unit
         time_t m_respawnTime;                               // (secs) time of next respawn
         uint32 m_respawnDelay;                              // (secs) delay between corpse disappearance and respawning
         uint32 m_corpseDelay;                               // (secs) delay between death and corpse disappearance
+        bool m_respawnRandomized;                           // should the respawn be randomized, if so a new respawn value is made each death cycle
         bool m_canAggro;                                    // controls response of creature to attacks
         float m_respawnradius;
 

--- a/src/game/Entities/GameObject.cpp
+++ b/src/game/Entities/GameObject.cpp
@@ -59,6 +59,7 @@ GameObject::GameObject() : WorldObject(),
     m_respawnTime = 0;
     m_respawnDelayTime = 25;
     m_lootState = GO_READY;
+    m_respawnRandomized = true;
     m_spawnedByDefault = true;
     m_useTimes = 0;
     m_spellId = 0;
@@ -561,9 +562,12 @@ void GameObject::Update(const uint32 diff)
             if (!m_respawnDelayTime)
                 return;
 
-            // since pool system can fail to roll unspawned object, this one can remain spawned, so must set respawn nevertheless
-            if (GameObjectData const* data = sObjectMgr.GetGOData(GetObjectGuid().GetCounter()))
-                m_respawnDelayTime = data->GetRandomRespawnTime();
+            if (m_respawnRandomized)
+            {
+                // since pool system can fail to roll unspawned object, this one can remain spawned, so must set respawn nevertheless
+                if (GameObjectData const* data = sObjectMgr.GetGOData(GetObjectGuid().GetCounter()))
+                    m_respawnDelayTime = data->GetRandomRespawnTime();
+            }
 
             m_respawnTime = m_spawnedByDefault ? time(nullptr) + m_respawnDelayTime : 0;
 

--- a/src/game/Entities/GameObject.h
+++ b/src/game/Entities/GameObject.h
@@ -647,8 +647,9 @@ class GameObject : public WorldObject
             return now;
         }
 
-        void SetRespawnTime(time_t respawn)
+        void SetRespawnTime(time_t respawn, bool allowRandomized = true)
         {
+            m_respawnRandomized = allowRandomized;
             m_respawnTime = respawn > 0 ? time(nullptr) + respawn : 0;
             m_respawnDelayTime = respawn > 0 ? uint32(respawn) : 0;
         }
@@ -661,6 +662,10 @@ class GameObject : public WorldObject
         }
         bool IsSpawnedByDefault() const { return m_spawnedByDefault; }
         uint32 GetRespawnDelay() const { return m_respawnDelayTime; }
+
+        bool IsRespawnRandomized() { return m_respawnRandomized; }
+        void SetRespawnRandomized(bool respawnRandomized) { m_respawnRandomized = respawnRandomized;  }
+
         void Refresh();
         void Delete();
 
@@ -765,6 +770,7 @@ class GameObject : public WorldObject
         uint32      m_respawnDelayTime;                     // (secs) if 0 then current GO state no dependent from timer
         LootState   m_lootState;
         bool        m_spawnedByDefault;
+        bool        m_respawnRandomized;                    // should the respawn be randomized, if so a new respawn value is made each spawn
         time_t      m_cooldownTime;                         // used as internal reaction delay time store (not state change reaction).
         // For traps/goober this: spell casting cooldown, for doors/buttons: reset time.
 

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -18848,7 +18848,7 @@ void Player::LeaveBattleground(bool teleportToEntryPoint)
         bg->RemovePlayerAtLeave(GetObjectGuid(), teleportToEntryPoint, true);
 
         // call after remove to be sure that player resurrected for correct cast
-        if (bg->isBattleGround() && !isGameMaster() && sWorld.getConfig(CONFIG_BOOL_BATTLEGROUND_CAST_DESERTER))
+        if (bg->isBattleGround() && !isGameMaster() && !sBattleGroundMgr.isTesting() && sWorld.getConfig(CONFIG_BOOL_BATTLEGROUND_CAST_DESERTER))
         {
             if (bg->GetStatus() == STATUS_IN_PROGRESS || bg->GetStatus() == STATUS_WAIT_JOIN)
             {


### PR DESCRIPTION
## 🍰 Pullrequest
Where to being with this one. Basically the issue here was that the respawn delays on creatures and objects were being ninja reset in each of the objects life cycle methods. To resolve this we need to provide a way to override the randomization functionality of Creatures and GameObjects for the BattleGround system to make use of. Otherwise it will just reset the delay each time it initializes the object.

### Proof
[![avfixed](http://img.youtube.com/vi/S5wKdycxzFY/0.jpg)](https://youtu.be/S5wKdycxzFY)

### Issues
Resolves https://github.com/cmangos/issues/issues/1891
Resolves https://github.com/cmangos/issues/issues/1884
