### PR TITLE
Only mark auras as unstackable if the item types match

### DIFF
--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -1318,8 +1318,8 @@ bool SpellMgr::IsNoStackSpellDueToSpellAndCastItem(SpellAuraHolder const* spellH
         ObjectGuid castItem1 = spellHolder1->GetCastItemGuid();
         ObjectGuid castItem2 = spellHolder2->GetCastItemGuid();
         
-        // check that we have found an item, if we do then we are not stackable
-        stackable = !((castItem1 && !castItem1.IsEmpty()) || (castItem2 && !castItem2.IsEmpty()));
+        // check that we have found matching items, if we do then we are not stackable
+        stackable = !(castItem1 && castItem2 && castItem1 == castItem2);
     }
     return !stackable;
 }


### PR DESCRIPTION
## 🍰 Pullrequest
Continuation of https://github.com/cmangos/mangos-tbc/pull/293

Needs more testing to confirm.

Modified the RemoveNoStackAurasDueToAuraHolder check to also account for the cast items, if they ever match we need to avoid stacking when they are from another player. I also fixed some of the passive spell check logic to account for all the SPELL_EFFECT_APPLY_AURA_* spell effects. This will ensure friendly auras are always check.

### Proof
https://github.com/cmangos/issues/issues/1943

### Issues
https://github.com/cmangos/issues/issues/1943

### How2Test
* .learn all_crafts
* .setskill 165 350
* .additem 29528
* login to two character
* join party
* click drum
* .cooldown clear

### Todo / Checklist
