### PR TITLE
Rework Warsong Gulch Battleground

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -583,6 +583,9 @@ void BattleGround::CastSpellOnTeam(uint32 SpellID, Team teamId)
 
 void BattleGround::RewardHonorToTeam(uint32 Honor, Team teamId)
 {
+    if (teamId == TEAM_NONE)
+        return;
+
     for (BattleGroundPlayerMap::const_iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
     {
         if (itr->second.OfflineRemoveTime)

--- a/src/game/BattleGround/BattleGroundHandler.cpp
+++ b/src/game/BattleGround/BattleGroundHandler.cpp
@@ -223,11 +223,11 @@ void WorldSession::HandleBattleGroundPlayerPositionsOpcode(WorldPacket& /*recv_d
         {
             uint32 flagCarrierCount = 0;
 
-            Player* flagCarrierAlliance = sObjectMgr.GetPlayer(((BattleGroundWS*)bg)->GetAllianceFlagCarrierGuid());
+            Player* flagCarrierAlliance = sObjectMgr.GetPlayer(((BattleGroundWS*)bg)->GetFlagCarrierGuid(TEAM_INDEX_ALLIANCE));
             if (flagCarrierAlliance)
                 ++flagCarrierCount;
 
-            Player* flagCarrierHorde = sObjectMgr.GetPlayer(((BattleGroundWS*)bg)->GetHordeFlagCarrierGuid());
+            Player* flagCarrierHorde = sObjectMgr.GetPlayer(((BattleGroundWS*)bg)->GetFlagCarrierGuid(TEAM_INDEX_HORDE));
             if (flagCarrierHorde)
                 ++flagCarrierCount;
 

--- a/src/game/BattleGround/BattleGroundMgr.h
+++ b/src/game/BattleGround/BattleGroundMgr.h
@@ -280,8 +280,8 @@ class BattleGroundMgr
         static BattleGroundTypeId WeekendHolidayIdToBGType(HolidayIds holiday);
         static bool IsBGWeekend(BattleGroundTypeId bgTypeId);
     private:
-        std::mutex    SchedulerLock;
-        BattleMastersMap    mBattleMastersMap;
+        std::mutex SchedulerLock;
+        BattleMastersMap mBattleMastersMap;
         CreatureBattleEventIndexesMap m_CreatureBattleEventIndexMap;
         GameObjectBattleEventIndexesMap m_GameObjectBattleEventIndexMap;
 

--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -222,10 +222,10 @@ void BattleGroundWS::RespawnDroppedFlag(Team team)
     PvpTeamIndex teamIdx = GetTeamIndexByTeamId(team);
     RespawnFlag(team, false);
 
-    SendMessageToAll(wsMessageIds[teamIdx][BG_WS_FLAG_ACTION_CAPTURED],
-        wsChatMessageTypes[teamIdx][BG_WS_FLAG_ACTION_CAPTURED]);
+    SendMessageToAll(wsMessageIds[teamIdx][BG_WS_FLAG_ACTION_RESPAWN],
+        wsChatMessageTypes[teamIdx][BG_WS_FLAG_ACTION_RESPAWN]);
 
-    PlaySoundToAll(wsSounds[teamIdx][BG_WS_FLAG_ACTION_CAPTURED]);
+    PlaySoundToAll(wsSounds[teamIdx][BG_WS_FLAG_ACTION_RESPAWN]);
 
     GameObject* obj = GetBgMap()->GetGameObject(GetDroppedFlagGuid(team));
     if (obj)
@@ -325,7 +325,7 @@ void BattleGroundWS::EventPlayerDroppedFlag(Player* player)
         UpdateFlagState(team, 1);
 
         SendMessageToAll(wsMessageIds[otherTeamIdx][BG_WS_FLAG_ACTION_DROPPED],
-                         wsChatMessageTypes[TEAM_INDEX_HORDE][BG_WS_FLAG_ACTION_DROPPED], player);
+                         wsChatMessageTypes[otherTeamIdx][BG_WS_FLAG_ACTION_DROPPED], player);
         UpdateWorldState(wsStateUpdateId[otherTeamIdx], uint32(-1));
         m_FlagsDropTimer[otherTeamIdx] = BG_WS_FLAG_DROP_TIME;
     }

--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -243,7 +243,8 @@ void BattleGroundWS::EventPlayerCapturedFlag(Player* player)
 
     player->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
 
-    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(player->GetTeam());
+    Team team = player->GetTeam();
+    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(team);
     uint8 otherTeamIdx = GetOtherTeamIndex(teamIdx);
 
     if (!IsFlagPickedUp(otherTeamIdx))
@@ -260,10 +261,10 @@ void BattleGroundWS::EventPlayerCapturedFlag(Player* player)
         m_TeamScores[teamIdx] += 1;
     
     PlaySoundToAll(wsSounds[teamIdx][BG_WS_FLAG_ACTION_CAPTURED]);
-    RewardReputationToTeam(890, m_ReputationCapture, player->GetTeam());
+    RewardReputationToTeam(890, m_ReputationCapture, team);
 
     // for flag capture is reward 2 honorable kills
-    RewardHonorToTeam(GetBonusHonorFromKill(2), player->GetTeam());
+    RewardHonorToTeam(GetBonusHonorFromKill(2), team);
 
     // despawn flags
     SpawnEvent(WS_EVENT_FLAG_A, 0, false);
@@ -272,8 +273,8 @@ void BattleGroundWS::EventPlayerCapturedFlag(Player* player)
     SendMessageToAll(wsMessageIds[otherTeamIdx][BG_WS_FLAG_ACTION_CAPTURED],
                      wsChatMessageTypes[teamIdx][BG_WS_FLAG_ACTION_CAPTURED], player);
 
-    UpdateFlagState(player->GetTeam(), 1);                  // flag state none
-    UpdateTeamScore(player->GetTeam());
+    UpdateFlagState(team, 1);                  // flag state none
+    UpdateTeamScore(team);
     // only flag capture should be updated
     UpdatePlayerScore(player, SCORE_FLAG_CAPTURES, 1);      // +1 flag captures
 
@@ -298,7 +299,8 @@ void BattleGroundWS::EventPlayerCapturedFlag(Player* player)
 
 void BattleGroundWS::EventPlayerDroppedFlag(Player* player)
 {
-    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(player->GetTeam());
+    Team team = player->GetTeam();
+    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(team);
     PvpTeamIndex otherTeamIdx = GetOtherTeamIndex(teamIdx);
 
     if (GetStatus() != STATUS_IN_PROGRESS)
@@ -320,7 +322,7 @@ void BattleGroundWS::EventPlayerDroppedFlag(Player* player)
         }
 
         player->CastSpell(player, SPELL_RECENTLY_DROPPED_FLAG, TRIGGERED_OLD_TRIGGERED);
-        UpdateFlagState(player->GetTeam(), 1);
+        UpdateFlagState(team, 1);
 
         SendMessageToAll(wsMessageIds[otherTeamIdx][BG_WS_FLAG_ACTION_DROPPED],
                          wsChatMessageTypes[TEAM_INDEX_HORDE][BG_WS_FLAG_ACTION_DROPPED], player);
@@ -331,7 +333,8 @@ void BattleGroundWS::EventPlayerDroppedFlag(Player* player)
 
 void BattleGroundWS::PickUpFlagFromBase(Player* player)
 {
-    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(player->GetTeam());
+    Team team = player->GetTeam();
+    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(team);
     PvpTeamIndex otherTeamIdx = GetOtherTeamIndex(teamIdx);
 
     PlaySoundToAll(wsSounds[otherTeamIdx][BG_WS_FLAG_ACTION_PICKEDUP]);
@@ -340,7 +343,7 @@ void BattleGroundWS::PickUpFlagFromBase(Player* player)
     m_FlagState[otherTeamIdx] = BG_WS_FLAG_STATE_ON_PLAYER;
 
     // update world state to show correct flag carrier
-    UpdateFlagState(player->GetTeam(), BG_WS_FLAG_STATE_ON_PLAYER);
+    UpdateFlagState(team, BG_WS_FLAG_STATE_ON_PLAYER);
     UpdateWorldState(wsStateUpdateId[otherTeamIdx], 1);
 
     player->CastSpell(player, wsSpellTypes[otherTeamIdx][BG_WS_FLAG_ACTION_PICKEDUP], TRIGGERED_OLD_TRIGGERED);
@@ -351,7 +354,8 @@ void BattleGroundWS::PickUpFlagFromBase(Player* player)
 
 uint32 BattleGroundWS::GroundFlagInteraction(Player* player, GameObject* target)
 {
-    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(player->GetTeam());
+    Team team = player->GetTeam();
+    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(team);
     PvpTeamIndex otherTeamIdx = GetOtherTeamIndex(teamIdx);
 
     int32 actionId = -1;
@@ -361,7 +365,6 @@ uint32 BattleGroundWS::GroundFlagInteraction(Player* player, GameObject* target)
     if (wsFlagIds[teamIdx] == displayId)
     {
         actionId = BG_WS_FLAG_ACTION_RETURNED;
-        Team team = player->GetTeam();
         UpdateFlagState(GetOtherTeam(team), BG_WS_FLAG_STATE_WAIT_RESPAWN);
         RespawnFlag(team, false);
         UpdatePlayerScore(player, SCORE_FLAG_RETURNS, 1);
@@ -374,9 +377,9 @@ uint32 BattleGroundWS::GroundFlagInteraction(Player* player, GameObject* target)
         actionId = BG_WS_FLAG_ACTION_PICKEDUP;
         SpawnEvent(otherTeamIdx, 0, false);
         SetFlagCarrier(otherTeamIdx, player->GetObjectGuid());
-        player->CastSpell(player, wsSpellTypes[otherTeamIdx][BG_WS_FLAG_ACTION_PICKEDUP], TRIGGERED_OLD_TRIGGERED);
+        player->CastSpell(player, wsSpellTypes[otherTeamIdx][actionId], TRIGGERED_OLD_TRIGGERED);
         m_FlagState[otherTeamIdx] = BG_WS_FLAG_STATE_ON_PLAYER;
-        UpdateFlagState(player->GetTeam(), BG_WS_FLAG_STATE_ON_PLAYER);
+        UpdateFlagState(team, BG_WS_FLAG_STATE_ON_PLAYER);
         UpdateWorldState(wsStateUpdateId[otherTeamIdx], 1);
         SendMessageToAll(wsMessageIds[otherTeamIdx][actionId], wsChatMessageTypes[teamIdx][actionId], player);
         PlaySoundToAll(wsSounds[otherTeamIdx][actionId]);

--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -358,7 +358,7 @@ uint32 BattleGroundWS::GroundFlagInteraction(Player* player, GameObject* target)
     PvpTeamIndex teamIdx = GetTeamIndexByTeamId(team);
     PvpTeamIndex otherTeamIdx = GetOtherTeamIndex(teamIdx);
 
-    int32 actionId = -1;
+    int32 actionId = BG_WS_FLAG_ACTION_NONE;
     uint32 displayId = target->GetDisplayId();
 
     // check if we are returning our flag
@@ -385,7 +385,7 @@ uint32 BattleGroundWS::GroundFlagInteraction(Player* player, GameObject* target)
         PlaySoundToAll(wsSounds[otherTeamIdx][actionId]);
     }
 
-    if (actionId > -1)
+    if (actionId != BG_WS_FLAG_ACTION_NONE)
         player->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
     return actionId;
 }
@@ -404,7 +404,7 @@ void BattleGroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
         PickUpFlagFromBase(player);
     }
     // Check if we are trying to pick up or return a flag from the ground
-    else if (player->IsWithinDistInMap(target, 10) && !GroundFlagInteraction(player, target))
+    else if (player->IsWithinDistInMap(target, 10) && GroundFlagInteraction(player, target) == BG_WS_FLAG_ACTION_NONE)
     {
         sLog.outError("Failed to action the WS flag from event '%d'.", event);
     }

--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -26,6 +26,94 @@
 #include "WorldPacket.h"
 #include "Tools/Language.h"
 
+static const uint32 wsFlagIds[PVP_TEAM_COUNT] = {
+    5912, // TEAM_INDEX_ALLIANCE
+    5913  // TEAM_INDEX_HORDE
+};
+
+static const uint32 wsMessageIds[PVP_TEAM_COUNT][WS_FLAG_ACTIONS_TOTAL] = {
+    // TEAM_INDEX_ALLIANCE
+    {
+        LANG_BG_WS_PICKEDUP_AF,            // BG_WS_FLAG_ACTION_PICKEDUP
+        LANG_BG_WS_RETURNED_AF,            // BG_WS_FLAG_ACTION_RETURNED
+        LANG_BG_WS_DROPPED_AF,             // BG_WS_FLAG_ACTION_DROPPED
+        LANG_BG_WS_CAPTURED_AF,            // BG_WS_FLAG_ACTION_CAPTURED
+        LANG_BG_WS_ALLIANCE_FLAG_RESPAWNED // BG_WS_FLAG_ACTION_RESPAWN
+    },
+    // TEAM_INDEX_HORDE
+    {
+        LANG_BG_WS_PICKEDUP_HF,            // BG_WS_FLAG_ACTION_PICKEDUP
+        LANG_BG_WS_RETURNED_HF,            // BG_WS_FLAG_ACTION_RETURNED
+        LANG_BG_WS_DROPPED_HF,             // BG_WS_FLAG_ACTION_DROPPED
+        LANG_BG_WS_CAPTURED_HF,            // BG_WS_FLAG_ACTION_CAPTURED
+        LANG_BG_WS_HORDE_FLAG_RESPAWNED    // BG_WS_FLAG_ACTION_RESPAWN
+    }
+};
+
+static const ChatMsg wsChatMessageTypes[PVP_TEAM_COUNT][WS_FLAG_ACTIONS_TOTAL] =
+{
+    // TEAM_INDEX_ALLIANCE
+    {
+        CHAT_MSG_BG_SYSTEM_ALLIANCE, // BG_WS_FLAG_ACTION_PICKEDUP
+        CHAT_MSG_BG_SYSTEM_ALLIANCE, // BG_WS_FLAG_ACTION_RETURNED
+        CHAT_MSG_BG_SYSTEM_ALLIANCE, // BG_WS_FLAG_ACTION_DROPPED
+        CHAT_MSG_BG_SYSTEM_ALLIANCE, // BG_WS_FLAG_ACTION_CAPTURED
+        CHAT_MSG_BG_SYSTEM_NEUTRAL   // BG_WS_FLAG_ACTION_RESPAWN
+    },
+    // TEAM_INDEX_HORDE
+    {
+        CHAT_MSG_BG_SYSTEM_HORDE,    // BG_WS_FLAG_ACTION_PICKEDUP
+        CHAT_MSG_BG_SYSTEM_HORDE,    // BG_WS_FLAG_ACTION_RETURNED
+        CHAT_MSG_BG_SYSTEM_HORDE,    // BG_WS_FLAG_ACTION_DROPPED
+        CHAT_MSG_BG_SYSTEM_HORDE,    // BG_WS_FLAG_ACTION_CAPTURED
+        CHAT_MSG_BG_SYSTEM_NEUTRAL   // BG_WS_FLAG_ACTION_RESPAWN
+    }
+};
+
+static const uint32 wsSounds[PVP_TEAM_COUNT][WS_FLAG_ACTIONS_TOTAL] =
+{
+    // TEAM_INDEX_ALLIANCE
+    {
+        BG_WS_SOUND_ALLIANCE_FLAG_PICKED_UP, // BG_WS_FLAG_ACTION_PICKEDUP
+        BG_WS_SOUND_FLAG_RETURNED,           // BG_WS_FLAG_ACTION_RETURNED
+        //BG_WS_SOUND_FLAG_RETURNED,         // BG_WS_FLAG_ACTION_DROPPED
+        BG_WS_SOUND_FLAG_CAPTURED_ALLIANCE,  // BG_WS_FLAG_ACTION_CAPTURED
+        BG_WS_SOUND_FLAGS_RESPAWNED          // BG_WS_FLAG_ACTION_RESPAWN
+    },
+    // TEAM_INDEX_HORDE
+    {
+        BG_WS_SOUND_HORDE_FLAG_PICKED_UP,    // BG_WS_FLAG_ACTION_PICKEDUP
+        BG_WS_SOUND_FLAG_RETURNED,           // BG_WS_FLAG_ACTION_RETURNED
+        //BG_WS_SOUND_FLAG_RETURNED,         // BG_WS_FLAG_ACTION_DROPPED
+        BG_WS_SOUND_FLAG_CAPTURED_HORDE,     // BG_WS_FLAG_ACTION_CAPTURED
+        BG_WS_SOUND_FLAGS_RESPAWNED          // BG_WS_FLAG_ACTION_RESPAWN
+    }
+};
+static const uint32 wsSpellTypes[PVP_TEAM_COUNT][WS_FLAG_ACTIONS_TOTAL] =
+{
+    // TEAM_INDEX_ALLIANCE
+    {
+        BG_WS_SPELL_SILVERWING_FLAG,         // BG_WS_FLAG_ACTION_PICKEDUP
+        BG_WS_SPELL_SILVERWING_FLAG,         // BG_WS_FLAG_ACTION_RETURNED
+        BG_WS_SPELL_SILVERWING_FLAG_DROPPED, // BG_WS_FLAG_ACTION_DROPPED
+        //BG_WS_SPELL_SILVERWING_FLAG,       // BG_WS_FLAG_ACTION_CAPTURED
+        //BG_WS_SPELL_SILVERWING_FLAG        // BG_WS_FLAG_ACTION_RESPAWN
+    },
+    // TEAM_INDEX_HORDE
+    {
+        BG_WS_SPELL_WARSONG_FLAG,            // BG_WS_FLAG_ACTION_PICKEDUP
+        BG_WS_SPELL_WARSONG_FLAG,            // BG_WS_FLAG_ACTION_RETURNED
+        BG_WS_SPELL_WARSONG_FLAG_DROPPED,    // BG_WS_FLAG_ACTION_DROPPED
+        //BG_WS_SPELL_WARSONG_FLAG,          // BG_WS_FLAG_ACTION_CAPTURED
+        //BG_WS_SPELL_WARSONG_FLAG           // BG_WS_FLAG_ACTION_RESPAWN
+    }
+};
+
+static const uint32 wsStateUpdateId[PVP_TEAM_COUNT] = {
+    BG_WS_FLAG_UNK_ALLIANCE,
+    BG_WS_FLAG_UNK_HORDE
+};
+
 BattleGroundWS::BattleGroundWS(): m_ReputationCapture(0), m_HonorWinKills(0), m_HonorEndKills(0)
 {
     m_StartMessageIds[BG_STARTING_EVENT_FIRST]  = 0;
@@ -50,7 +138,7 @@ void BattleGroundWS::Update(uint32 diff)
                 RespawnFlag(ALLIANCE, true);
             }
         }
-        if (m_FlagState[TEAM_INDEX_ALLIANCE] == BG_WS_FLAG_STATE_ON_GROUND)
+        else if (m_FlagState[TEAM_INDEX_ALLIANCE] == BG_WS_FLAG_STATE_ON_GROUND)
         {
             m_FlagsDropTimer[TEAM_INDEX_ALLIANCE] -= diff;
 
@@ -60,6 +148,7 @@ void BattleGroundWS::Update(uint32 diff)
                 RespawnDroppedFlag(ALLIANCE);
             }
         }
+        
         if (m_FlagState[TEAM_INDEX_HORDE] == BG_WS_FLAG_STATE_WAIT_RESPAWN)
         {
             m_FlagsTimer[TEAM_INDEX_HORDE] -= diff;
@@ -70,7 +159,7 @@ void BattleGroundWS::Update(uint32 diff)
                 RespawnFlag(HORDE, true);
             }
         }
-        if (m_FlagState[TEAM_INDEX_HORDE] == BG_WS_FLAG_STATE_ON_GROUND)
+        else if (m_FlagState[TEAM_INDEX_HORDE] == BG_WS_FLAG_STATE_ON_GROUND)
         {
             m_FlagsDropTimer[TEAM_INDEX_HORDE] -= diff;
 
@@ -97,6 +186,7 @@ void BattleGroundWS::StartingEventOpenDoors()
 void BattleGroundWS::AddPlayer(Player* plr)
 {
     BattleGround::AddPlayer(plr);
+
     // create score and add it to map, default values are set in constructor
     BattleGroundWGScore* sc = new BattleGroundWGScore;
 
@@ -106,17 +196,13 @@ void BattleGroundWS::AddPlayer(Player* plr)
 void BattleGroundWS::RespawnFlag(Team team, bool captured)
 {
     if (team == ALLIANCE)
-    {
         DEBUG_LOG("Respawn Alliance flag");
-        m_FlagState[TEAM_INDEX_ALLIANCE] = BG_WS_FLAG_STATE_ON_BASE;
-        SpawnEvent(WS_EVENT_FLAG_A, 0, true);
-    }
     else
-    {
         DEBUG_LOG("Respawn Horde flag");
-        m_FlagState[TEAM_INDEX_HORDE] = BG_WS_FLAG_STATE_ON_BASE;
-        SpawnEvent(WS_EVENT_FLAG_H, 0, true);
-    }
+
+    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(team);
+    m_FlagState[teamIdx] = BG_WS_FLAG_STATE_ON_BASE;
+    SpawnEvent(teamIdx, 0, true);
 
     if (captured)
     {
@@ -133,13 +219,13 @@ void BattleGroundWS::RespawnDroppedFlag(Team team)
     if (GetStatus() != STATUS_IN_PROGRESS)
         return;
 
+    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(team);
     RespawnFlag(team, false);
-    if (team == ALLIANCE)
-        SendMessageToAll(LANG_BG_WS_ALLIANCE_FLAG_RESPAWNED, CHAT_MSG_BG_SYSTEM_NEUTRAL);
-    else
-        SendMessageToAll(LANG_BG_WS_HORDE_FLAG_RESPAWNED, CHAT_MSG_BG_SYSTEM_NEUTRAL);
 
-    PlaySoundToAll(BG_WS_SOUND_FLAGS_RESPAWNED);
+    SendMessageToAll(wsMessageIds[teamIdx][BG_WS_FLAG_ACTION_CAPTURED],
+        wsChatMessageTypes[teamIdx][BG_WS_FLAG_ACTION_CAPTURED]);
+
+    PlaySoundToAll(wsSounds[teamIdx][BG_WS_FLAG_ACTION_CAPTURED]);
 
     GameObject* obj = GetBgMap()->GetGameObject(GetDroppedFlagGuid(team));
     if (obj)
@@ -150,56 +236,46 @@ void BattleGroundWS::RespawnDroppedFlag(Team team)
     ClearDroppedFlagGuid(team);
 }
 
-void BattleGroundWS::EventPlayerCapturedFlag(Player* source)
+void BattleGroundWS::EventPlayerCapturedFlag(Player* player)
 {
     if (GetStatus() != STATUS_IN_PROGRESS)
         return;
 
-    source->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
-    if (source->GetTeam() == ALLIANCE)
-    {
-        if (!IsHordeFlagPickedUp())
-            return;
-        ClearHordeFlagCarrier();                            // must be before aura remove to prevent 2 events (drop+capture) at the same time
-        // horde flag in base (but not respawned yet)
-        m_FlagState[TEAM_INDEX_HORDE] = BG_WS_FLAG_STATE_WAIT_RESPAWN;
-        // Drop Horde Flag from Player
-        source->RemoveAurasDueToSpell(BG_WS_SPELL_WARSONG_FLAG);
-        if (m_TeamScores[TEAM_INDEX_ALLIANCE] < BG_WS_MAX_TEAM_SCORE)
-            m_TeamScores[TEAM_INDEX_ALLIANCE] += 1;
-        PlaySoundToAll(BG_WS_SOUND_FLAG_CAPTURED_ALLIANCE);
-        RewardReputationToTeam(890, m_ReputationCapture, ALLIANCE);
-    }
-    else
-    {
-        if (!IsAllianceFlagPickedUp())
-            return;
-        ClearAllianceFlagCarrier();                         // must be before aura remove to prevent 2 events (drop+capture) at the same time
-        // alliance flag in base (but not respawned yet)
-        m_FlagState[TEAM_INDEX_ALLIANCE] = BG_WS_FLAG_STATE_WAIT_RESPAWN;
-        // Drop Alliance Flag from Player
-        source->RemoveAurasDueToSpell(BG_WS_SPELL_SILVERWING_FLAG);
-        if (m_TeamScores[TEAM_INDEX_HORDE] < BG_WS_MAX_TEAM_SCORE)
-            m_TeamScores[TEAM_INDEX_HORDE] += 1;
-        PlaySoundToAll(BG_WS_SOUND_FLAG_CAPTURED_HORDE);
-        RewardReputationToTeam(889, m_ReputationCapture, HORDE);
-    }
+    player->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
+
+    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(player->GetTeam());
+    uint8 otherTeamIdx = GetOtherTeamIndex(teamIdx);
+
+    if (!IsFlagPickedUp(otherTeamIdx))
+        return;
+
+    ClearFlagCarrier(otherTeamIdx); // must be before aura remove to prevent 2 events (drop+capture) at the same time
+
+    // Horde flag in base (but not respawned yet)
+    m_FlagState[otherTeamIdx] = BG_WS_FLAG_STATE_WAIT_RESPAWN;
+    // Drop Horde Flag from Player
+    player->RemoveAurasDueToSpell(wsSpellTypes[otherTeamIdx][BG_WS_FLAG_ACTION_PICKEDUP]);
+
+    if (m_TeamScores[teamIdx] < BG_WS_MAX_TEAM_SCORE)
+        m_TeamScores[teamIdx] += 1;
+    
+    PlaySoundToAll(wsSounds[teamIdx][BG_WS_FLAG_ACTION_CAPTURED]);
+    RewardReputationToTeam(890, m_ReputationCapture, player->GetTeam());
+
     // for flag capture is reward 2 honorable kills
-    RewardHonorToTeam(GetBonusHonorFromKill(2), source->GetTeam());
+    RewardHonorToTeam(GetBonusHonorFromKill(2), player->GetTeam());
 
     // despawn flags
     SpawnEvent(WS_EVENT_FLAG_A, 0, false);
     SpawnEvent(WS_EVENT_FLAG_H, 0, false);
 
-    if (source->GetTeam() == ALLIANCE)
-        SendMessageToAll(LANG_BG_WS_CAPTURED_HF, CHAT_MSG_BG_SYSTEM_ALLIANCE, source);
-    else
-        SendMessageToAll(LANG_BG_WS_CAPTURED_AF, CHAT_MSG_BG_SYSTEM_HORDE, source);
+    SendMessageToAll(wsMessageIds[otherTeamIdx][BG_WS_FLAG_ACTION_CAPTURED],
+                     wsChatMessageTypes[teamIdx][BG_WS_FLAG_ACTION_CAPTURED], player);
 
-    UpdateFlagState(source->GetTeam(), 1);                  // flag state none
-    UpdateTeamScore(source->GetTeam());
+    UpdateFlagState(player->GetTeam(), 1);                  // flag state none
+    UpdateTeamScore(player->GetTeam());
     // only flag capture should be updated
-    UpdatePlayerScore(source, SCORE_FLAG_CAPTURES, 1);      // +1 flag captures
+    UpdatePlayerScore(player, SCORE_FLAG_CAPTURES, 1);      // +1 flag captures
 
     Team winner = TEAM_NONE;
     if (m_TeamScores[TEAM_INDEX_ALLIANCE] == BG_WS_MAX_TEAM_SCORE)
@@ -217,218 +293,143 @@ void BattleGroundWS::EventPlayerCapturedFlag(Player* source)
         EndBattleGround(winner);
     }
     else
-    {
-        m_FlagsTimer[GetOtherTeamIndex(GetTeamIndexByTeamId(source->GetTeam()))] = BG_WS_FLAG_RESPAWN_TIME;
-    }
+        m_FlagsTimer[otherTeamIdx] = BG_WS_FLAG_RESPAWN_TIME;
 }
 
-void BattleGroundWS::EventPlayerDroppedFlag(Player* source)
+void BattleGroundWS::EventPlayerDroppedFlag(Player* player)
 {
+    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(player->GetTeam());
+    PvpTeamIndex otherTeamIdx = GetOtherTeamIndex(teamIdx);
+
     if (GetStatus() != STATUS_IN_PROGRESS)
     {
-        // if not running, do not cast things at the dropper player (prevent spawning the "dropped" flag), neither send unnecessary messages
-        // just take off the aura
-        if (source->GetTeam() == ALLIANCE)
+        if (IsFlagPickedUp(teamIdx) && GetFlagCarrierGuid(teamIdx) == player->GetObjectGuid())
         {
-            if (!IsHordeFlagPickedUp())
-                return;
-            if (GetHordeFlagCarrierGuid() == source->GetObjectGuid())
-            {
-                ClearHordeFlagCarrier();
-                source->RemoveAurasDueToSpell(BG_WS_SPELL_WARSONG_FLAG);
-            }
-        }
-        else
-        {
-            if (!IsAllianceFlagPickedUp())
-                return;
-            if (GetAllianceFlagCarrierGuid() == source->GetObjectGuid())
-            {
-                ClearAllianceFlagCarrier();
-                source->RemoveAurasDueToSpell(BG_WS_SPELL_SILVERWING_FLAG);
-            }
-        }
-        return;
-    }
-
-    bool set = false;
-
-    if (source->GetTeam() == ALLIANCE)
-    {
-        if (!IsHordeFlagPickedUp())
-            return;
-        if (GetHordeFlagCarrierGuid() == source->GetObjectGuid())
-        {
-            ClearHordeFlagCarrier();
-            source->RemoveAurasDueToSpell(BG_WS_SPELL_WARSONG_FLAG);
-            m_FlagState[TEAM_INDEX_HORDE] = BG_WS_FLAG_STATE_ON_GROUND;
-            source->CastSpell(source, BG_WS_SPELL_WARSONG_FLAG_DROPPED, TRIGGERED_OLD_TRIGGERED);
-            set = true;
+            ClearFlagCarrier(teamIdx);
+            player->RemoveAurasDueToSpell(wsSpellTypes[teamIdx][BG_WS_FLAG_ACTION_PICKEDUP]);
         }
     }
-    else
+    else if (IsFlagPickedUp(otherTeamIdx))
     {
-        if (!IsAllianceFlagPickedUp())
-            return;
-        if (GetAllianceFlagCarrierGuid() == source->GetObjectGuid())
+        if (GetFlagCarrierGuid(otherTeamIdx) == player->GetObjectGuid())
         {
-            ClearAllianceFlagCarrier();
-            source->RemoveAurasDueToSpell(BG_WS_SPELL_SILVERWING_FLAG);
-            m_FlagState[TEAM_INDEX_ALLIANCE] = BG_WS_FLAG_STATE_ON_GROUND;
-            source->CastSpell(source, BG_WS_SPELL_SILVERWING_FLAG_DROPPED, TRIGGERED_OLD_TRIGGERED);
-            set = true;
-        }
-    }
-
-    if (set)
-    {
-        source->CastSpell(source, SPELL_RECENTLY_DROPPED_FLAG, TRIGGERED_OLD_TRIGGERED);
-        UpdateFlagState(source->GetTeam(), 1);
-
-        if (source->GetTeam() == ALLIANCE)
-        {
-            SendMessageToAll(LANG_BG_WS_DROPPED_HF, CHAT_MSG_BG_SYSTEM_HORDE, source);
-            UpdateWorldState(BG_WS_FLAG_UNK_HORDE, uint32(-1));
-        }
-        else
-        {
-            SendMessageToAll(LANG_BG_WS_DROPPED_AF, CHAT_MSG_BG_SYSTEM_ALLIANCE, source);
-            UpdateWorldState(BG_WS_FLAG_UNK_ALLIANCE, uint32(-1));
+            ClearFlagCarrier(otherTeamIdx);
+            player->RemoveAurasDueToSpell(wsSpellTypes[otherTeamIdx][BG_WS_FLAG_ACTION_PICKEDUP]);
+            m_FlagState[otherTeamIdx] = BG_WS_FLAG_STATE_ON_GROUND;
+            player->CastSpell(player, wsSpellTypes[otherTeamIdx][BG_WS_FLAG_ACTION_DROPPED], TRIGGERED_OLD_TRIGGERED);
         }
 
-        m_FlagsDropTimer[GetOtherTeamIndex(GetTeamIndexByTeamId(source->GetTeam()))] = BG_WS_FLAG_DROP_TIME;
+        player->CastSpell(player, SPELL_RECENTLY_DROPPED_FLAG, TRIGGERED_OLD_TRIGGERED);
+        UpdateFlagState(player->GetTeam(), 1);
+
+        SendMessageToAll(wsMessageIds[otherTeamIdx][BG_WS_FLAG_ACTION_DROPPED],
+                         wsChatMessageTypes[TEAM_INDEX_HORDE][BG_WS_FLAG_ACTION_DROPPED], player);
+        UpdateWorldState(wsStateUpdateId[otherTeamIdx], uint32(-1));
+        m_FlagsDropTimer[otherTeamIdx] = BG_WS_FLAG_DROP_TIME;
     }
 }
 
-void BattleGroundWS::EventPlayerClickedOnFlag(Player* source, GameObject* target_obj)
+void BattleGroundWS::PickUpFlagFromBase(Player* player)
+{
+    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(player->GetTeam());
+    PvpTeamIndex otherTeamIdx = GetOtherTeamIndex(teamIdx);
+
+    PlaySoundToAll(wsSounds[otherTeamIdx][BG_WS_FLAG_ACTION_PICKEDUP]);
+    SpawnEvent(otherTeamIdx, 0, false);
+    SetFlagCarrier(otherTeamIdx, player->GetObjectGuid());
+    m_FlagState[otherTeamIdx] = BG_WS_FLAG_STATE_ON_PLAYER;
+
+    // update world state to show correct flag carrier
+    UpdateFlagState(player->GetTeam(), BG_WS_FLAG_STATE_ON_PLAYER);
+    UpdateWorldState(wsStateUpdateId[otherTeamIdx], 1);
+
+    player->CastSpell(player, wsSpellTypes[otherTeamIdx][BG_WS_FLAG_ACTION_PICKEDUP], TRIGGERED_OLD_TRIGGERED);
+    SendMessageToAll(wsMessageIds[otherTeamIdx][BG_WS_FLAG_ACTION_PICKEDUP],
+                     wsChatMessageTypes[teamIdx][BG_WS_FLAG_ACTION_PICKEDUP], player);
+    player->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
+}
+
+uint32 BattleGroundWS::GroundFlagInteraction(Player* player, GameObject* target)
+{
+    PvpTeamIndex teamIdx = GetTeamIndexByTeamId(player->GetTeam());
+    PvpTeamIndex otherTeamIdx = GetOtherTeamIndex(teamIdx);
+
+    int32 actionId = -1;
+    uint32 displayId = target->GetDisplayId();
+
+    // check if we are returning our flag
+    if (wsFlagIds[teamIdx] == displayId)
+    {
+        actionId = BG_WS_FLAG_ACTION_RETURNED;
+        Team team = player->GetTeam();
+        UpdateFlagState(GetOtherTeam(team), BG_WS_FLAG_STATE_WAIT_RESPAWN);
+        RespawnFlag(team, false);
+        UpdatePlayerScore(player, SCORE_FLAG_RETURNS, 1);
+        SendMessageToAll(wsMessageIds[teamIdx][actionId], wsChatMessageTypes[teamIdx][actionId], player);
+        PlaySoundToAll(wsSounds[teamIdx][actionId]);
+    }
+    // check if we are picking up enemy flag
+    else if (wsFlagIds[otherTeamIdx] == displayId)
+    {
+        actionId = BG_WS_FLAG_ACTION_PICKEDUP;
+        SpawnEvent(otherTeamIdx, 0, false);
+        SetFlagCarrier(otherTeamIdx, player->GetObjectGuid());
+        player->CastSpell(player, wsSpellTypes[otherTeamIdx][BG_WS_FLAG_ACTION_PICKEDUP], TRIGGERED_OLD_TRIGGERED);
+        m_FlagState[otherTeamIdx] = BG_WS_FLAG_STATE_ON_PLAYER;
+        UpdateFlagState(player->GetTeam(), BG_WS_FLAG_STATE_ON_PLAYER);
+        UpdateWorldState(wsStateUpdateId[otherTeamIdx], 1);
+        SendMessageToAll(wsMessageIds[otherTeamIdx][actionId], wsChatMessageTypes[teamIdx][actionId], player);
+        PlaySoundToAll(wsSounds[otherTeamIdx][actionId]);
+    }
+
+    if (actionId > -1)
+        player->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
+    return actionId;
+}
+
+void BattleGroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target)
 {
     if (GetStatus() != STATUS_IN_PROGRESS)
         return;
 
-    int32 message_id = 0;
-    ChatMsg type = CHAT_MSG_BG_SYSTEM_NEUTRAL;
+    uint8 event = sBattleGroundMgr.GetGameObjectEventIndex(target->GetGUIDLow()).event1;
 
-    uint8 event = (sBattleGroundMgr.GetGameObjectEventIndex(target_obj->GetGUIDLow())).event1;
-
-    // alliance flag picked up from base
-    if (source->GetTeam() == HORDE && GetFlagState(ALLIANCE) == BG_WS_FLAG_STATE_ON_BASE
-            && event == WS_EVENT_FLAG_A)
+    // Check if the flag is being picked up from base
+    if ((event == WS_EVENT_FLAG_A && GetFlagState(ALLIANCE) == BG_WS_FLAG_STATE_ON_BASE) ||
+        (event == WS_EVENT_FLAG_H && GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_BASE))
     {
-        message_id = LANG_BG_WS_PICKEDUP_AF;
-        type = CHAT_MSG_BG_SYSTEM_HORDE;
-        PlaySoundToAll(BG_WS_SOUND_ALLIANCE_FLAG_PICKED_UP);
-        SpawnEvent(WS_EVENT_FLAG_A, 0, false);
-        SetAllianceFlagCarrier(source->GetObjectGuid());
-        m_FlagState[TEAM_INDEX_ALLIANCE] = BG_WS_FLAG_STATE_ON_PLAYER;
-        // update world state to show correct flag carrier
-        UpdateFlagState(HORDE, BG_WS_FLAG_STATE_ON_PLAYER);
-        UpdateWorldState(BG_WS_FLAG_UNK_ALLIANCE, 1);
-        source->CastSpell(source, BG_WS_SPELL_SILVERWING_FLAG, TRIGGERED_OLD_TRIGGERED);
+        PickUpFlagFromBase(player);
     }
-
-    // horde flag picked up from base
-    if (source->GetTeam() == ALLIANCE && GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_BASE
-            && event == WS_EVENT_FLAG_H)
+    // Check if we are trying to pick up or return a flag from the ground
+    else if (player->IsWithinDistInMap(target, 10) && !GroundFlagInteraction(player, target))
     {
-        message_id = LANG_BG_WS_PICKEDUP_HF;
-        type = CHAT_MSG_BG_SYSTEM_ALLIANCE;
-        PlaySoundToAll(BG_WS_SOUND_HORDE_FLAG_PICKED_UP);
-        SpawnEvent(WS_EVENT_FLAG_H, 0, false);
-        SetHordeFlagCarrier(source->GetObjectGuid());
-        m_FlagState[TEAM_INDEX_HORDE] = BG_WS_FLAG_STATE_ON_PLAYER;
-        // update world state to show correct flag carrier
-        UpdateFlagState(ALLIANCE, BG_WS_FLAG_STATE_ON_PLAYER);
-        UpdateWorldState(BG_WS_FLAG_UNK_HORDE, 1);
-        source->CastSpell(source, BG_WS_SPELL_WARSONG_FLAG, TRIGGERED_OLD_TRIGGERED);
+        sLog.outError("Failed to action the WS flag from event '%d'.", event);
     }
-
-    // Alliance flag on ground(not in base) (returned or picked up again from ground!)
-    if (GetFlagState(ALLIANCE) == BG_WS_FLAG_STATE_ON_GROUND && source->IsWithinDistInMap(target_obj, 10))
-    {
-        if (source->GetTeam() == ALLIANCE)
-        {
-            message_id = LANG_BG_WS_RETURNED_AF;
-            type = CHAT_MSG_BG_SYSTEM_ALLIANCE;
-            UpdateFlagState(HORDE, BG_WS_FLAG_STATE_WAIT_RESPAWN);
-            RespawnFlag(ALLIANCE, false);
-            PlaySoundToAll(BG_WS_SOUND_FLAG_RETURNED);
-            UpdatePlayerScore(source, SCORE_FLAG_RETURNS, 1);
-        }
-        else
-        {
-            message_id = LANG_BG_WS_PICKEDUP_AF;
-            type = CHAT_MSG_BG_SYSTEM_HORDE;
-            PlaySoundToAll(BG_WS_SOUND_ALLIANCE_FLAG_PICKED_UP);
-            SpawnEvent(WS_EVENT_FLAG_A, 0, false);
-            SetAllianceFlagCarrier(source->GetObjectGuid());
-            source->CastSpell(source, BG_WS_SPELL_SILVERWING_FLAG, TRIGGERED_OLD_TRIGGERED);
-            m_FlagState[TEAM_INDEX_ALLIANCE] = BG_WS_FLAG_STATE_ON_PLAYER;
-            UpdateFlagState(HORDE, BG_WS_FLAG_STATE_ON_PLAYER);
-            UpdateWorldState(BG_WS_FLAG_UNK_ALLIANCE, 1);
-        }
-        // called in HandleGameObjectUseOpcode:
-        // target_obj->Delete();
-    }
-
-    // Horde flag on ground(not in base) (returned or picked up again)
-    if (GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_GROUND && source->IsWithinDistInMap(target_obj, 10))
-    {
-        if (source->GetTeam() == HORDE)
-        {
-            message_id = LANG_BG_WS_RETURNED_HF;
-            type = CHAT_MSG_BG_SYSTEM_HORDE;
-            UpdateFlagState(ALLIANCE, BG_WS_FLAG_STATE_WAIT_RESPAWN);
-            RespawnFlag(HORDE, false);
-            PlaySoundToAll(BG_WS_SOUND_FLAG_RETURNED);
-            UpdatePlayerScore(source, SCORE_FLAG_RETURNS, 1);
-        }
-        else
-        {
-            message_id = LANG_BG_WS_PICKEDUP_HF;
-            type = CHAT_MSG_BG_SYSTEM_ALLIANCE;
-            PlaySoundToAll(BG_WS_SOUND_HORDE_FLAG_PICKED_UP);
-            SpawnEvent(WS_EVENT_FLAG_H, 0, false);
-            SetHordeFlagCarrier(source->GetObjectGuid());
-            source->CastSpell(source, BG_WS_SPELL_WARSONG_FLAG, TRIGGERED_OLD_TRIGGERED);
-            m_FlagState[TEAM_INDEX_HORDE] = BG_WS_FLAG_STATE_ON_PLAYER;
-            UpdateFlagState(ALLIANCE, BG_WS_FLAG_STATE_ON_PLAYER);
-            UpdateWorldState(BG_WS_FLAG_UNK_HORDE, 1);
-        }
-        // called in HandleGameObjectUseOpcode:
-        // target_obj->Delete();
-    }
-
-    if (!message_id)
-        return;
-
-    SendMessageToAll(message_id, type, source);
-    source->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
 }
 
-void BattleGroundWS::RemovePlayer(Player* plr, ObjectGuid guid)
+void BattleGroundWS::RemovePlayer(Player* player, ObjectGuid guid)
 {
-    // sometimes flag aura not removed :(
-    if (IsAllianceFlagPickedUp() && m_flagCarrierAlliance == guid)
+    if (IsFlagPickedUp(TEAM_INDEX_ALLIANCE) && m_FlagCarrier[TEAM_INDEX_ALLIANCE] == guid)
     {
-        if (!plr)
+        if (!player)
         {
             sLog.outError("BattleGroundWS: Removing offline player who has the FLAG!!");
-            ClearAllianceFlagCarrier();
+            ClearFlagCarrier(TEAM_INDEX_ALLIANCE);
             RespawnFlag(ALLIANCE, false);
         }
         else
-            EventPlayerDroppedFlag(plr);
+            EventPlayerDroppedFlag(player);
     }
-    if (IsHordeFlagPickedUp() && m_flagCarrierHorde == guid)
+    if (IsFlagPickedUp(TEAM_INDEX_HORDE) && m_FlagCarrier[TEAM_INDEX_HORDE] == guid)
     {
-        if (!plr)
+        if (!player)
         {
             sLog.outError("BattleGroundWS: Removing offline player who has the FLAG!!");
-            ClearHordeFlagCarrier();
+            ClearFlagCarrier(TEAM_INDEX_HORDE);
             RespawnFlag(HORDE, false);
         }
         else
-            EventPlayerDroppedFlag(plr);
+            EventPlayerDroppedFlag(player);
     }
 }
 
@@ -448,7 +449,7 @@ void BattleGroundWS::UpdateTeamScore(Team team)
         UpdateWorldState(BG_WS_FLAG_CAPTURES_HORDE, m_TeamScores[TEAM_INDEX_HORDE]);
 }
 
-bool BattleGroundWS::HandleAreaTrigger(Player* source, uint32 trigger)
+bool BattleGroundWS::HandleAreaTrigger(Player* player, uint32 trigger)
 {
     // this is wrong way to implement these things. On official it done by gameobject spell cast.
     if (GetStatus() != STATUS_IN_PROGRESS)
@@ -458,13 +459,13 @@ bool BattleGroundWS::HandleAreaTrigger(Player* source, uint32 trigger)
     {
         case 3646:                                          // Alliance Flag spawn
             if (m_FlagState[TEAM_INDEX_HORDE] && !m_FlagState[TEAM_INDEX_ALLIANCE])
-                if (GetHordeFlagCarrierGuid() == source->GetObjectGuid())
-                    EventPlayerCapturedFlag(source);
+                if (GetFlagCarrierGuid(TEAM_INDEX_HORDE) == player->GetObjectGuid())
+                    EventPlayerCapturedFlag(player);
             break;
         case 3647:                                          // Horde Flag spawn
             if (m_FlagState[TEAM_INDEX_ALLIANCE] && !m_FlagState[TEAM_INDEX_HORDE])
-                if (GetAllianceFlagCarrierGuid() == source->GetObjectGuid())
-                    EventPlayerCapturedFlag(source);
+                if (GetFlagCarrierGuid(TEAM_INDEX_ALLIANCE) == player->GetObjectGuid())
+                    EventPlayerCapturedFlag(player);
             break;
         default:
             return false;
@@ -489,8 +490,8 @@ void BattleGroundWS::Reset()
         m_TeamScores[i]      = 0;
     }
 
-    m_flagCarrierAlliance.Clear();
-    m_flagCarrierHorde.Clear();
+    m_FlagCarrier[TEAM_INDEX_ALLIANCE].Clear();
+    m_FlagCarrier[TEAM_INDEX_HORDE].Clear();
 
     bool isBGWeekend = BattleGroundMgr::IsBGWeekend(GetTypeID());
     m_ReputationCapture = (isBGWeekend) ? WS_WEEKEND_FLAG_CAPTURE_REPUTATION : WS_NORMAL_FLAG_CAPTURE_REPUTATION;
@@ -501,10 +502,8 @@ void BattleGroundWS::Reset()
 void BattleGroundWS::EndBattleGround(Team winner)
 {
     // win reward
-    if (winner == ALLIANCE)
-        RewardHonorToTeam(GetBonusHonorFromKill(m_HonorWinKills), ALLIANCE);
-    if (winner == HORDE)
-        RewardHonorToTeam(GetBonusHonorFromKill(m_HonorWinKills), HORDE);
+    RewardHonorToTeam(GetBonusHonorFromKill(m_HonorWinKills), winner);
+
     // complete map_end rewards (even if no team wins)
     RewardHonorToTeam(GetBonusHonorFromKill(m_HonorEndKills), ALLIANCE);
     RewardHonorToTeam(GetBonusHonorFromKill(m_HonorEndKills), HORDE);
@@ -522,9 +521,9 @@ void BattleGroundWS::HandleKillPlayer(Player* player, Player* killer)
     BattleGround::HandleKillPlayer(player, killer);
 }
 
-void BattleGroundWS::UpdatePlayerScore(Player* source, uint32 type, uint32 value)
+void BattleGroundWS::UpdatePlayerScore(Player* player, uint32 type, uint32 value)
 {
-    BattleGroundScoreMap::iterator itr = m_PlayerScores.find(source->GetObjectGuid());
+    BattleGroundScoreMap::iterator itr = m_PlayerScores.find(player->GetObjectGuid());
     if (itr == m_PlayerScores.end())                        // player not found
         return;
 
@@ -537,7 +536,7 @@ void BattleGroundWS::UpdatePlayerScore(Player* source, uint32 type, uint32 value
             ((BattleGroundWGScore*)itr->second)->FlagReturns += value;
             break;
         default:
-            BattleGround::UpdatePlayerScore(source, type, value);
+            BattleGround::UpdatePlayerScore(player, type, value);
             break;
     }
 }
@@ -553,10 +552,12 @@ WorldSafeLocsEntry const* BattleGroundWS::GetClosestGraveYard(Player* player)
     {
         if (GetStatus() == STATUS_IN_PROGRESS)
             return sWorldSafeLocsStore.LookupEntry(WS_GRAVEYARD_MAIN_ALLIANCE);
+
         return sWorldSafeLocsStore.LookupEntry(WS_GRAVEYARD_FLAGROOM_ALLIANCE);
     }
     if (GetStatus() == STATUS_IN_PROGRESS)
         return sWorldSafeLocsStore.LookupEntry(WS_GRAVEYARD_MAIN_HORDE);
+
     return sWorldSafeLocsStore.LookupEntry(WS_GRAVEYARD_FLAGROOM_HORDE);
 }
 
@@ -581,12 +582,12 @@ void BattleGroundWS::FillInitialWorldStates(WorldPacket& data, uint32& count)
 
     FillInitialWorldState(data, count, BG_WS_FLAG_CAPTURES_MAX, BG_WS_MAX_TEAM_SCORE);
 
-    if (m_FlagState[TEAM_INDEX_HORDE] == BG_WS_FLAG_STATE_ON_PLAYER)
+    if (m_FlagState[TEAM_INDEX_ALLIANCE] == BG_WS_FLAG_STATE_ON_PLAYER)
         FillInitialWorldState(data, count, BG_WS_FLAG_STATE_HORDE, 2);
     else
         FillInitialWorldState(data, count, BG_WS_FLAG_STATE_HORDE, 1);
 
-    if (m_FlagState[TEAM_INDEX_ALLIANCE] == BG_WS_FLAG_STATE_ON_PLAYER)
+    if (m_FlagState[TEAM_INDEX_HORDE] == BG_WS_FLAG_STATE_ON_PLAYER)
         FillInitialWorldState(data, count, BG_WS_FLAG_STATE_ALLIANCE, 2);
     else
         FillInitialWorldState(data, count, BG_WS_FLAG_STATE_ALLIANCE, 1);

--- a/src/game/BattleGround/BattleGroundWS.h
+++ b/src/game/BattleGround/BattleGroundWS.h
@@ -65,13 +65,14 @@ enum BG_WS_WorldStates
 
 enum BG_WS_FlagActions
 {
+    BG_WS_FLAG_ACTION_NONE     = -1,
     BG_WS_FLAG_ACTION_PICKEDUP = 0,
     BG_WS_FLAG_ACTION_RETURNED = 1,
     BG_WS_FLAG_ACTION_DROPPED  = 2,
     BG_WS_FLAG_ACTION_CAPTURED = 3,
     BG_WS_FLAG_ACTION_RESPAWN  = 4
 };
-#define WS_FLAG_ACTIONS_TOTAL                       5
+#define WS_FLAG_ACTIONS_TOTAL 5
 
 enum BG_WS_FlagState
 {

--- a/src/game/BattleGround/BattleGroundWS.h
+++ b/src/game/BattleGround/BattleGroundWS.h
@@ -25,6 +25,13 @@
 #define BG_WS_FLAG_RESPAWN_TIME   (23*IN_MILLISECONDS)
 #define BG_WS_FLAG_DROP_TIME      (10*IN_MILLISECONDS)
 
+#define WS_NORMAL_FLAG_CAPTURE_REPUTATION           35
+#define WS_WEEKEND_FLAG_CAPTURE_REPUTATION          45
+#define WS_NORMAL_WIN_KILLS                         1
+#define WS_WEEKEND_WIN_KILLS                        3
+#define WS_NORMAL_MAP_COMPLETE_KILLS                2
+#define WS_WEEKEND_MAP_COMPLETE_KILLS               4
+
 enum BG_WS_Sound
 {
     BG_WS_SOUND_FLAG_CAPTURED_ALLIANCE  = 8173,
@@ -48,7 +55,7 @@ enum BG_WS_WorldStates
 {
     BG_WS_FLAG_UNK_ALLIANCE       = 1545,
     BG_WS_FLAG_UNK_HORDE          = 1546,
-//    FLAG_UNK                      = 1547,
+//  FLAG_UNK                      = 1547,
     BG_WS_FLAG_CAPTURES_ALLIANCE  = 1581,
     BG_WS_FLAG_CAPTURES_HORDE     = 1582,
     BG_WS_FLAG_CAPTURES_MAX       = 1601,
@@ -56,12 +63,15 @@ enum BG_WS_WorldStates
     BG_WS_FLAG_STATE_ALLIANCE     = 2339
 };
 
-#define WS_NORMAL_FLAG_CAPTURE_REPUTATION           35
-#define WS_WEEKEND_FLAG_CAPTURE_REPUTATION          45
-#define WS_NORMAL_WIN_KILLS                         1
-#define WS_WEEKEND_WIN_KILLS                        3
-#define WS_NORMAL_MAP_COMPLETE_KILLS                2
-#define WS_WEEKEND_MAP_COMPLETE_KILLS               4
+enum BG_WS_FlagActions
+{
+    BG_WS_FLAG_ACTION_PICKEDUP = 0,
+    BG_WS_FLAG_ACTION_RETURNED = 1,
+    BG_WS_FLAG_ACTION_DROPPED  = 2,
+    BG_WS_FLAG_ACTION_CAPTURED = 3,
+    BG_WS_FLAG_ACTION_RESPAWN  = 4
+};
+#define WS_FLAG_ACTIONS_TOTAL                       5
 
 enum BG_WS_FlagState
 {
@@ -92,7 +102,6 @@ class BattleGroundWGScore : public BattleGroundScore
         uint32 FlagReturns;
 };
 
-
 enum BG_WS_Events
 {
     WS_EVENT_FLAG_A               = 0,
@@ -103,7 +112,7 @@ enum BG_WS_Events
 
 class BattleGroundWS : public BattleGround
 {
-        friend class BattleGroundMgr;
+    friend class BattleGroundMgr;
 
     public:
         /* Construction */
@@ -115,17 +124,10 @@ class BattleGroundWS : public BattleGround
         virtual void StartingEventOpenDoors() override;
 
         /* BG Flags */
-        ObjectGuid GetAllianceFlagCarrierGuid() const { return m_flagCarrierAlliance; }
-        ObjectGuid GetHordeFlagCarrierGuid() const { return m_flagCarrierHorde; }
-
-        void SetAllianceFlagCarrier(ObjectGuid guid) { m_flagCarrierAlliance = guid; }
-        void SetHordeFlagCarrier(ObjectGuid guid) { m_flagCarrierHorde = guid; }
-
-        void ClearAllianceFlagCarrier() { m_flagCarrierAlliance.Clear(); }
-        void ClearHordeFlagCarrier() { m_flagCarrierHorde.Clear(); }
-
-        bool IsAllianceFlagPickedUp() const { return !m_flagCarrierAlliance.IsEmpty(); }
-        bool IsHordeFlagPickedUp() const { return !m_flagCarrierHorde.IsEmpty(); }
+        ObjectGuid GetFlagCarrierGuid(uint8 teamIdx) const { return m_FlagCarrier[teamIdx]; }
+        void SetFlagCarrier(uint8 teamIdx, ObjectGuid guid) { m_FlagCarrier[teamIdx] = guid; }
+        void ClearFlagCarrier(uint8 teamIdx) { m_FlagCarrier[teamIdx].Clear(); }
+        bool IsFlagPickedUp(uint8 teamIdx) const { return !m_FlagCarrier[teamIdx].IsEmpty(); }
 
         void RespawnFlag(Team team, bool captured);
         void RespawnDroppedFlag(Team team);
@@ -143,6 +145,10 @@ class BattleGroundWS : public BattleGround
         void EndBattleGround(Team winner) override;
         virtual WorldSafeLocsEntry const* GetClosestGraveYard(Player* player) override;
 
+        // Flag interactions
+        void PickUpFlagFromBase(Player* source);
+        uint32 GroundFlagInteraction(Player* source, GameObject* target);
+
         void UpdateFlagState(Team team, uint32 value);
         void UpdateTeamScore(Team team);
         void UpdatePlayerScore(Player* source, uint32 type, uint32 value) override;
@@ -153,10 +159,9 @@ class BattleGroundWS : public BattleGround
         virtual Team GetPrematureWinner() override;
 
     private:
-        ObjectGuid m_flagCarrierAlliance;
-        ObjectGuid m_flagCarrierHorde;
-
         ObjectGuid m_DroppedFlagGuid[PVP_TEAM_COUNT];
+        ObjectGuid m_FlagCarrier[PVP_TEAM_COUNT];
+
         uint8 m_FlagState[PVP_TEAM_COUNT];
         int32 m_FlagsTimer[PVP_TEAM_COUNT];
         int32 m_FlagsDropTimer[PVP_TEAM_COUNT];


### PR DESCRIPTION
## 🍰 Pullrequest
Reworked Warsong Gulch to be more efficient and resolve the strange sync issues.

Thanks to @Yatzii93 for testing and also providing the fix for the FillInitialWorldStates issue.

Deals with:
* The huge amount of code duplication
* Uses team index for all common data configs (FlagIds, MessageIds, MessageTypes, Sounds)
* Centralize flag actions to `PickUpFlagFromBase` & `GroundFlagInteraction`
* Properly checks the flags display id for the ground pick up actions

### Proof
Will compile a video of all the results, but it seems to be working flawlessly form all my testing.

### Issues
https://github.com/cmangos/issues/issues/1872
also addresses https://github.com/cmangos/mangos-tbc/pull/296

### How2Test
.debug bg
enter warsong

### Todo / Checklist
- [X] Internal Tests
- [x] Production Tests
