### PR TITLE
Add Battleground config Raid Warning announcements 

### DIFF
--- a/src/game/BattleGround/BattleGround.h
+++ b/src/game/BattleGround/BattleGround.h
@@ -540,6 +540,8 @@ class BattleGround
         void EndNow();
         void PlayerAddedToBGCheckIfBGIsRunning(Player* plr);
 
+        ChatMsg GetAnnouncerMessageType();
+
         /* Scorekeeping */
 
         BattleGroundScoreMap m_PlayerScores;                // Player scores

--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -669,6 +669,7 @@ void World::LoadConfigSettings(bool reload)
     setConfig(CONFIG_BOOL_BATTLEGROUND_CAST_DESERTER,                  "Battleground.CastDeserter", true);
     setConfigMinMax(CONFIG_UINT32_BATTLEGROUND_QUEUE_ANNOUNCER_JOIN,   "Battleground.QueueAnnouncer.Join", 0, 0, 2);
     setConfig(CONFIG_BOOL_BATTLEGROUND_QUEUE_ANNOUNCER_START,          "Battleground.QueueAnnouncer.Start", false);
+    setConfig(CONFIG_BOOL_BATTLEGROUND_RAIDWARNING_ANNOUNCE,           "Battleground.RaidWarningAnnouncer", false);
     setConfig(CONFIG_BOOL_BATTLEGROUND_SCORE_STATISTICS,               "Battleground.ScoreStatistics", false);
     setConfig(CONFIG_UINT32_BATTLEGROUND_INVITATION_TYPE,              "Battleground.InvitationType", 0);
     setConfig(CONFIG_UINT32_BATTLEGROUND_PREMATURE_FINISH_TIMER,       "BattleGround.PrematureFinishTimer", 5 * MINUTE * IN_MILLISECONDS);

--- a/src/game/World/World.h
+++ b/src/game/World/World.h
@@ -324,6 +324,7 @@ enum eConfigBoolValues
     CONFIG_BOOL_BATTLEGROUND_CAST_DESERTER,
     CONFIG_BOOL_BATTLEGROUND_QUEUE_ANNOUNCER_START,
     CONFIG_BOOL_BATTLEGROUND_SCORE_STATISTICS,
+    CONFIG_BOOL_BATTLEGROUND_RAIDWARNING_ANNOUNCE,
     CONFIG_BOOL_ARENA_AUTO_DISTRIBUTE_POINTS,
     CONFIG_BOOL_ARENA_QUEUE_ANNOUNCER_JOIN,
     CONFIG_BOOL_ARENA_QUEUE_ANNOUNCER_EXIT,
@@ -369,7 +370,7 @@ enum RealmType
     REALM_TYPE_RP       = 6,
     REALM_TYPE_RPPVP    = 8,
     REALM_TYPE_FFA_PVP  = 16                                // custom, free for all pvp mode like arena PvP in all zones except rest activated places and sanctuaries
-                          // replaced by REALM_PVP in realm list
+    // replaced by REALM_PVP in realm list
 };
 
 /// This is values from first column of Cfg_Categories.dbc (1.12.1 have another numeration)

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -1480,6 +1480,11 @@ Death.Ghost.RunSpeed.Battleground = 1.0
 #        Default: 0 (disable)
 #                 1 (enable)
 #
+#    Battleground.RaidWarningAnnouncer
+#        Enable the use of raid warning message type for announcements (i.e starting messages)
+#        Default: 0 (disable)
+#                 1 (enable)
+#
 #    Battleground.ScoreStatistics
 #        Enable Battleground scores storage in database.
 #        Default: 0 - (Disabled)
@@ -1505,6 +1510,7 @@ Death.Ghost.RunSpeed.Battleground = 1.0
 Battleground.CastDeserter = 1
 Battleground.QueueAnnouncer.Join = 0
 Battleground.QueueAnnouncer.Start = 0
+Battleground.RaidWarningAnnouncer = 0
 Battleground.ScoreStatistics = 0
 Battleground.InvitationType = 0
 BattleGround.PrematureFinishTimer = 300000


### PR DESCRIPTION
## 🍰 Pullrequest
Adds the config Battleground.RaidWarningAnnouncer (default: 0)
Enable the use of raid warning message type for announcements (i.e starting messages)

Not sure if customization like this are acceptable with configurations, but this one seemed nice to have as an option.

### Proof
![image](https://user-images.githubusercontent.com/1935706/58803176-eba6b980-8662-11e9-87eb-29911a4fd04b.png)

### How2Test
Start a Battleground