### PR TITLE
eliminate warning about comparison of signed and unsigned types

### DIFF
--- a/src/game/PlayerBot/Base/PlayerbotClassAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotClassAI.cpp
@@ -342,7 +342,7 @@ Player* PlayerbotClassAI::GetHealTarget(JOB_TYPE type, bool onlyPickFromSameGrou
     // Try to find a tank in need of healing (if multiple, the lowest health one)
     while (true)
     {
-        if ((uCount + i) >= uint32(targets.size()) || !(targets.at(uCount).type & JOB_TANK)) break;
+        if (uint32(uCount + i) >= uint32(targets.size()) || !(targets.at(uCount).type & JOB_TANK)) break;
         uCount++;
     }
 
@@ -359,7 +359,7 @@ Player* PlayerbotClassAI::GetHealTarget(JOB_TYPE type, bool onlyPickFromSameGrou
     {
         while (true)
         {
-            if ((uCount + i) >= uint32(targets.size()) || !(targets.at(uCount).type & JOB_MASTER)) break;
+            if (uint32(uCount + i) >= uint32(targets.size()) || !(targets.at(uCount).type & JOB_MASTER)) break;
             uCount++;
         }
 
@@ -375,7 +375,7 @@ Player* PlayerbotClassAI::GetHealTarget(JOB_TYPE type, bool onlyPickFromSameGrou
     // Try to find anyone else in need of healing (lowest health one first)
     while (true)
     {
-        if ((uCount + i) >= uint32(targets.size())) break;
+        if (uint32(uCount + i) >= uint32(targets.size())) break;
         uCount++;
     }
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This little change removes 3 warnings I had while compiling cmangos core.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->

1. Checkout this PR and compile
2. There should be no more warnings about type conflicts with comparisons

### TODO
- Do this for wotlk and classic if needed

@cala This uint32() casting was used a few lines before for similar comparisons, I wasnt sure why It wasnt done for the 3 places changed in this PR. 