### PR TITLE
Hunter 3:2 Macro Support!

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -588,6 +588,7 @@ Player::Player(WorldSession* session): Unit(), m_taxiTracker(*this), m_mover(thi
     m_ammoDPS = 0.0f;
 
     m_temporaryUnsummonedPetNumber = 0;
+    m_pendingSteadyShot = false;
 
     //////////////////// Rest System/////////////////////
     time_inn_enter = 0;

--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -1184,6 +1184,8 @@ class Player : public Unit
         void RemoveAmmo();
         float GetAmmoDPS() const { return m_ammoDPS; }
         bool CheckAmmoCompatibility(const ItemPrototype* ammo_proto) const;
+        void SetPendingSteadyShot(bool pendingSteadyShot) { m_pendingSteadyShot = pendingSteadyShot; }
+        float IsPendingSteadyShot() const { return m_pendingSteadyShot; }
         void QuickEquipItem(uint16 pos, Item* pItem);
         void VisualizeItem(uint8 slot, Item* pItem);
         void SetVisibleItemSlot(uint8 slot, Item* pItem);
@@ -2444,6 +2446,8 @@ class Player : public Unit
         uint32 m_ArmorProficiency;
         uint8 m_swingErrorMsg;
         float m_ammoDPS;
+
+        bool m_pendingSteadyShot;
 
         //////////////////// Rest System/////////////////////
         time_t time_inn_enter;

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -4274,7 +4274,7 @@ void Unit::InterruptSpell(CurrentSpellTypes spellType, bool withDelayed)
         // send autorepeat cancel message for autorepeat spells
         if (spellType == CURRENT_AUTOREPEAT_SPELL)
         {
-            if (GetTypeId() == TYPEID_PLAYER)
+            if (IsPlayer())
                 ((Player*)this)->SendAutoRepeatCancel();
         }
 

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -334,6 +334,7 @@ enum TriggerCastFlags : uint32
     TRIGGERED_DO_NOT_PROC                       = 0x00000040,   // Spells from scripts should not proc - DBScripts for example
     TRIGGERED_PET_CAST                          = 0x00000080,   // Spell that should report error through pet opcode
     TRIGGERED_NORMAL_COMBAT_CAST                = 0x00000100,   // AI needs to be notified about change of target
+    TRIGGERED_IGNORE_GCD                        = 0x00000200,   // Ignores the GCD checks and do not apply GCD
     TRIGGERED_FULL_MASK                         = 0xFFFFFFFF
 };
 
@@ -2437,6 +2438,7 @@ class Unit : public WorldObject
         void AddDelayedHolderDueToProc(SpellAuraHolder* holder) { m_delayedSpellAuraHolders.push_back(holder); }
 
         void ResetAutoRepeatSpells() { m_AutoRepeatFirstCast = true; }
+        bool IsAutoRepeatFirstCast() { return m_AutoRepeatFirstCast; }
 
         const uint64& GetAuraUpdateMask() const { return m_auraUpdateMask; }
         void SetAuraUpdateMask(uint8 slot) { m_auraUpdateMask |= (uint64(1) << slot); }

--- a/src/game/Spells/Spell.h
+++ b/src/game/Spells/Spell.h
@@ -480,6 +480,7 @@ class Spell
         bool m_doNotProc;
         bool m_petCast;
         bool m_notifyAI;
+        bool m_ignoreGCD;
 
         int32 GetCastTime() const { return m_casttime; }
         uint32 GetCastedTime() const { return m_timer; }

--- a/src/game/Spells/SpellHandler.cpp
+++ b/src/game/Spells/SpellHandler.cpp
@@ -355,6 +355,9 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
         }
     }
 
+    if (spellId == 75 && mover->FindCurrentSpellBySpellId(spellId))
+        return;
+
     // client provided targets
     SpellCastTargets targets;
 


### PR DESCRIPTION
## 🍰 Pullrequest
All hunters can sleep in peace? Support for the Hunter 3:2 Macro.

Long shot that this will make it into `master` but at least provides a solution and also gets the ball rolling on the Hunter macro issues.

Give tips to improve this, it is somewhat hacky? But its not too bad overall given the nuance of this mechanic is very complicated in the current spell system.

### Proof
https://www.youtube.com/watch?v=cObqUH-zKwg
https://www.youtube.com/watch?v=lnoOnmW-0Bs

### Issues
- None

### How2Test
Add macro:
```
#showtooltip Steady Shot
/cast !Auto shot
/cast [target=pettarget, exists] Kill command
/cast Steady shot
/script UIErrorsFrame:Clear() 
```
Use it as demonstrated in the video.

### Todo / Checklist