### PR TITLE
Fixes auto shot wind up time issues

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -4128,8 +4128,8 @@ void Unit::_UpdateAutoRepeatSpell()
         // cancel wand shoot
         if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Category == 351)
             InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
-        else if (getAttackTimer(RANGED_ATTACK) < 500)
-            setAttackTimer(RANGED_ATTACK, 500);
+        // set 0.5 second wind-up time.
+        m_AutoRepeatFirstCast = true;
         return;
     }
 

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -4128,6 +4128,8 @@ void Unit::_UpdateAutoRepeatSpell()
         // cancel wand shoot
         if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Category == 351)
             InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+        else if (getAttackTimer(RANGED_ATTACK) < 500)
+			setAttackTimer(RANGED_ATTACK, 500);
         return;
     }
 

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -4129,7 +4129,7 @@ void Unit::_UpdateAutoRepeatSpell()
         if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Category == 351)
             InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
         else if (getAttackTimer(RANGED_ATTACK) < 500)
-			setAttackTimer(RANGED_ATTACK, 500);
+            setAttackTimer(RANGED_ATTACK, 500);
         return;
     }
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Currently, auto shot has no wind up time, 
This pull request makes the auto shot wind up time reset whenever you are not able to fire an auto shot.

### Proof
<!-- Link resources as proof -->
If you pay close attention to the auto shot timer, you can see that auto shot has a 0.5 wind up time 
https://www.youtube.com/watch?v=FAz6E6W4T-I

This old wowwiki page also references the 0.5s wind up time: 
https://wowwiki.fandom.com/wiki/Auto_Shot?oldid=1153137

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Shoot something, move around long enough so the auto shot timer is fully reset and stop, you should only fire your next auto 0.5s later.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
