### PR TITLE
Resolves players running on the spot

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -4277,20 +4277,10 @@ void Player::SetLevitate(bool enable)
 
 void Player::SetCanFly(bool enable)
 {
-    WorldPacket data;
-    if (enable)
-        data.Initialize(SMSG_MOVE_SET_CAN_FLY, 12);
-    else
-        data.Initialize(SMSG_MOVE_UNSET_CAN_FLY, 12);
-
+    WorldPacket data(enable ? SMSG_MOVE_SET_CAN_FLY : SMSG_MOVE_UNSET_CAN_FLY, GetPackGUID().size() + 4);
     data << GetPackGUID();
-    data << uint32(0);                                      // unk
-    SendMessageToSet(data, true);
-
-    data.Initialize(MSG_MOVE_UPDATE_CAN_FLY, 64);
-    data << GetPackGUID();
-    m_movementInfo.Write(data);
-    SendMessageToSet(data, false);
+    data << uint32(0);
+    GetSession()->SendPacket(data);
 }
 
 void Player::SetFeatherFall(bool enable)


### PR DESCRIPTION
## 🍰 Pullrequest

-It seemed the old code was applying data packets from the source to other players in close proximity. This was causing a lot of visual issues like players suddenly running on the spot.
-This fix also improves the de-flying/re-flying animation client side. Much reduce delay to update other flying player states.

Fixes - https://github.com/cmangos/issues/issues/1933

(FYI: I may be describing whats happening here wrong, this area of the software isn't something I'm well versed in)

### Proof
https://github.com/cmangos/issues/issues/1933
https://youtu.be/KIDYfksq5W4
This is a custom anti-cheat, but it exposed the data packet problem this PR fixes + also resolves the issue with the anti-cheat processing these unintended duplicate data packets. 

Just so theres no confusion, without the anti-cheat the player wouldn't be teleporting around, this is just the anti-cheat responding to fact that it's receiving the druids movement information from the non-druid. The anti-cheat thinks the non-druid is hacking and ultimlaty is trying to send the non-druid back to a previously stored waypoint.


### Issues
<!-- Which Issues does this fix, which are related? -->
-players running on the spot
-unintended duplicate data packets being applied to players in close proximity 

### How2Test

-leave druid flight form and re-enter in close proximity with another player
(I needed a custom anti-cheat to fully expose the issue)

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
