### PR TITLE
Resolve looting issues when using Group Loot

### DIFF
--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -1235,9 +1235,7 @@ void Loot::Release(Player* player)
                     // The fishing hole used once more
                     go->AddUse();                           // if the max usage is reached, will be despawned at next tick
                     if (go->GetUseCount() >= urand(go->GetGOInfo()->fishinghole.minSuccessOpens, go->GetGOInfo()->fishinghole.maxSuccessOpens))
-                    {
                         go->SetLootState(GO_JUST_DEACTIVATED);
-                    }
                     else
                         go->SetLootState(GO_READY);
                     break;
@@ -1357,14 +1355,19 @@ void Loot::Release(Player* player)
                         SendReleaseForAll();
                         creature->SetLootStatus(CREATURE_LOOT_STATUS_LOOTED);
                         m_lootTarget->ForceValuesUpdateAtIndex(UNIT_DYNAMIC_FLAGS);
-                        break;
                     }
-
-                    if (IsLootedForAll())
+                    else if (IsLootedForAll())
                     {
                         SendReleaseForAll();
                         creature->SetLootStatus(CREATURE_LOOT_STATUS_LOOTED);
                     }
+                    else
+                    {
+                        // nothing was released, we need to ensure
+                        // the client has been updated.
+                        updateClients = true;
+                    }
+
                     break;
                 }
                 default:
@@ -2090,7 +2093,6 @@ void Loot::ForceLootAnimationClientUpdate() const
             m_lootTarget->ForceValuesUpdateAtIndex(UNIT_DYNAMIC_FLAGS);
             break;
         case TYPEID_GAMEOBJECT:
-            return;
             // we have to update sparkles/loot for this object
             if (m_isChest)
                 m_lootTarget->ForceValuesUpdateAtIndex(GAMEOBJECT_DYN_FLAGS);


### PR DESCRIPTION
## 🍰 Pullrequest
Was resulting in seeing loot sparkles that wasn't yours in some cases.

### Proof
Addresses the dicussion here: https://github.com/cmangos/mangos-tbc/commit/e87cf36ecfd1b964a96e98b632fd2ff93a9b1172

### How2Test
1. Party with someone using Group Loot
2. Kills a mob, until you see sparkles but aren't able to loot it.

With this PR the above won't happen anymore.

### Todo / Checklist