### PR TITLE
Implement new command to make easier to debug single object.

### DIFF
--- a/src/game/AI/BaseAI/PetAI.cpp
+++ b/src/game/AI/BaseAI/PetAI.cpp
@@ -301,7 +301,7 @@ void PetAI::UpdateAI(const uint32 diff)
         // This is needed for charmed creatures, as once their target was reset other effects can trigger threat
         if (!m_unit->CanAttack(victim))
         {
-            DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "PetAI (guid = %u) is stopping attack.", m_unit->GetGUIDLow());
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_unit->GetObjectGuid().GetCounter(), m_unit->GetTypeId(), "PetAI (guid = %u) is stopping attack.", m_unit->GetGUIDLow());
             m_unit->CombatStop();
             inCombat = false;
 

--- a/src/game/AI/CreatureAISelector.cpp
+++ b/src/game/AI/CreatureAISelector.cpp
@@ -85,7 +85,7 @@ namespace FactorySelector
         // select NullCreatureAI if not another cases
         ainame = (ai_factory == nullptr) ? "NullCreatureAI" : ai_factory->key();
 
-        DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "Creature %u used AI is %s.", creature->GetGUIDLow(), ainame.c_str());
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, creature->GetObjectGuid().GetCounter(), creature->GetTypeId(), "Creature %u used AI is %s.", creature->GetGUIDLow(), ainame.c_str());
         return (ai_factory == nullptr ? new NullCreatureAI(creature) : ai_factory->Create(creature));
     }
 

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -307,7 +307,7 @@ bool CreatureEventAI::CheckEvent(CreatureEventAIHolder& holder, Unit* actionInvo
     if (holder.event.event_inverse_phase_mask & (1 << m_Phase))
     {
         if (!IsTimerExecutedEvent(holder.event.event_type))
-            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "%s: Event %u skipped because of phasemask %u. Current phase %u", GetAIName().data(), holder.event.event_id, holder.event.event_inverse_phase_mask, m_Phase);
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_EVENT_AI_DEV, m_unit->GetObjectGuid().GetCounter(), m_unit->GetTypeId(), "%s: Event %u skipped because of phasemask %u. Current phase %u", GetAIName().data(), holder.event.event_id, holder.event.event_inverse_phase_mask, m_Phase);
         return false;
     }
 
@@ -676,7 +676,7 @@ bool CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
     if (action.type == ACTION_T_NONE)
         return false;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "%s: Process action %u (script %u) triggered for %s (invoked by %s)", GetAIName().data(),
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_EVENT_AI_DEV, m_unit->GetObjectGuid().GetCounter(), m_unit->GetTypeId(), "%s: Process action %u (script %u) triggered for %s (invoked by %s)", GetAIName().data(),
                      action.type, eventId, m_creature->GetGuidStr().c_str(), actionInvoker ? actionInvoker->GetGuidStr().c_str() : "<no invoker>");
 
     bool failedTargetSelection = false;
@@ -1004,7 +1004,7 @@ bool CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
         }
         case ACTION_T_SET_PHASE:
             m_Phase = action.set_phase.phase;
-            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "%s: ACTION_T_SET_PHASE - script %u for %s, phase is now %u", GetAIName().data(), eventId, m_creature->GetGuidStr().c_str(), m_Phase);
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_EVENT_AI_DEV, m_unit->GetObjectGuid().GetCounter(), m_unit->GetTypeId(), "%s: ACTION_T_SET_PHASE - script %u for %s, phase is now %u", GetAIName().data(), eventId, m_creature->GetGuidStr().c_str(), m_Phase);
             break;
         case ACTION_T_INC_PHASE:
         {
@@ -1022,7 +1022,7 @@ bool CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             else
                 m_Phase = new_phase;
 
-            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "%s: ACTION_T_INC_PHASE - script %u for %s, phase is now %u", GetAIName().data(), eventId, m_creature->GetGuidStr().c_str(), m_Phase);
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_EVENT_AI_DEV, m_unit->GetObjectGuid().GetCounter(), m_unit->GetTypeId(), "%s: ACTION_T_INC_PHASE - script %u for %s, phase is now %u", GetAIName().data(), eventId, m_creature->GetGuidStr().c_str(), m_Phase);
             break;
         }
         case ACTION_T_EVADE:
@@ -1072,7 +1072,7 @@ bool CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             break;
         case ACTION_T_RANDOM_PHASE:
             m_Phase = GetRandActionParam(rnd, action.random_phase.phase1, action.random_phase.phase2, action.random_phase.phase3);
-            DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "%s: ACTION_T_RANDOM_PHASE - script %u for %s, phase is now %u", GetAIName().data(), eventId, m_creature->GetGuidStr().c_str(), m_Phase);
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_EVENT_AI_DEV, m_unit->GetObjectGuid().GetCounter(), m_unit->GetTypeId(), "%s: ACTION_T_RANDOM_PHASE - script %u for %s, phase is now %u", GetAIName().data(), eventId, m_creature->GetGuidStr().c_str(), m_Phase);
             break;
         case ACTION_T_RANDOM_PHASE_RANGE:
             if (action.random_phase_range.phaseMax > action.random_phase_range.phaseMin)

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -33,7 +33,7 @@ class WorldObject;
 #define MAX_PHASE                       32
 
 #define LOG_PROCESS_EVENT                                                                                                       \
-    DEBUG_FILTER_LOG(LOG_FILTER_EVENT_AI_DEV, "CreatureEventAI: Event type %u (script %u) triggered for %s (invoked by %s)",    \
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_EVENT_AI_DEV, m_unit->GetObjectGuid().GetCounter(), m_unit->GetTypeId(), "CreatureEventAI: Event type %u (script %u) triggered for %s (invoked by %s)",    \
                      holder.event.event_type, holder.event.event_id, m_creature->GetGuidStr().c_str(), actionInvoker ? actionInvoker->GetGuidStr().c_str() : "<no invoker>")
 
 enum EventAI_Type

--- a/src/game/AI/ScriptDevAI/base/pet_ai.cpp
+++ b/src/game/AI/ScriptDevAI/base/pet_ai.cpp
@@ -46,7 +46,7 @@ void ScriptedPetAI::ResetPetCombat()
 
     m_creature->AttackStop();
 
-    debug_log("SD2: ScriptedPetAI reset pet combat and stop attack.");
+    DETAIL_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "SD2: ScriptedPetAI reset pet combat and stop attack.");
     Reset();
 }
 

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -190,8 +190,9 @@ ChatCommand* ChatHandler::getCommandTable()
     {
         { "list",           SEC_ADMINISTRATOR,  false, &ChatHandler::HandleCooldownListCommand,             "", nullptr },
         { "clear",          SEC_ADMINISTRATOR,  false, &ChatHandler::HandleCooldownClearCommand,            "", nullptr },
-        { "clearclientside", SEC_ADMINISTRATOR,  false, &ChatHandler::HandleCooldownClearClientSideCommand,  "", nullptr },
+        { "clearclientside", SEC_ADMINISTRATOR, false, &ChatHandler::HandleCooldownClearClientSideCommand,  "", nullptr },
         { "cleararena",     SEC_ADMINISTRATOR,  false, &ChatHandler::HandleCooldownClearArenaCommand,       "", nullptr },
+        { "",               SEC_ADMINISTRATOR,  false, &ChatHandler::HandleCooldownListCommand,             "", nullptr },
         { nullptr,             0,                  false, nullptr,                                          "", nullptr }
     };
 
@@ -705,8 +706,10 @@ ChatCommand* ChatHandler::getCommandTable()
 
     static ChatCommand serverLogCommandTable[] =
     {
-        { "filter",         SEC_CONSOLE,        true,  &ChatHandler::HandleServerLogFilterCommand,     "", nullptr },
-        { "level",          SEC_CONSOLE,        true,  &ChatHandler::HandleServerLogLevelCommand,      "", nullptr },
+        { "filter",         SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleServerLogFilterCommand,     "", nullptr },
+        { "level",          SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleServerLogLevelCommand,      "", nullptr },
+        { "guidfilter",     SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleServerLogGuidFilterCommand, "", nullptr },
+        { "typefilter",     SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleServerLogTypeFilterCommand, "", nullptr },
         { nullptr,          0,                  false, nullptr,                                        "", nullptr }
     };
 
@@ -723,7 +726,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "idlerestart",    SEC_ADMINISTRATOR,  true,  nullptr,                                        "", serverIdleRestartCommandTable },
         { "idleshutdown",   SEC_ADMINISTRATOR,  true,  nullptr,                                        "", serverIdleShutdownCommandTable },
         { "info",           SEC_PLAYER,         true,  &ChatHandler::HandleServerInfoCommand,          "", nullptr },
-        { "log",            SEC_CONSOLE,        true,  nullptr,                                        "", serverLogCommandTable },
+        { "log",            SEC_ADMINISTRATOR,  true,  nullptr,                                        "", serverLogCommandTable },
         { "motd",           SEC_PLAYER,         true,  &ChatHandler::HandleServerMotdCommand,          "", nullptr },
         { "plimit",         SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleServerPLimitCommand,        "", nullptr },
         { "resetallraid",   SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleServerResetAllRaidCommand,  "", nullptr },
@@ -871,6 +874,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "waterwalk",      SEC_GAMEMASTER,     false, &ChatHandler::HandleWaterwalkCommand,           "", nullptr },
         { "quit",           SEC_CONSOLE,        true,  &ChatHandler::HandleQuitCommand,                "", nullptr },
         { "mmap",           SEC_GAMEMASTER,     false, nullptr,                                        "", mmapCommandTable },
+        { "logtarget",      SEC_ADMINISTRATOR,  false, &ChatHandler::HandleLogTargetCommand,           "", nullptr },
 #ifdef BUILD_PLAYERBOT
         { "bot",            SEC_PLAYER,         false, &ChatHandler::HandlePlayerbotCommand,           "", nullptr },
 #endif

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -562,6 +562,8 @@ class ChatHandler
         bool HandleServerInfoCommand(char* args);
         bool HandleServerLogFilterCommand(char* args);
         bool HandleServerLogLevelCommand(char* args);
+        bool HandleServerLogGuidFilterCommand(char* args);
+        bool HandleServerLogTypeFilterCommand(char* args);
         bool HandleServerMotdCommand(char* args);
         bool HandleServerPLimitCommand(char* args);
         bool HandleServerResetAllRaidCommand(char* args);
@@ -662,6 +664,8 @@ class ChatHandler
         bool HandleStableCommand(char* args);
         bool HandleWaterwalkCommand(char* args);
         bool HandleQuitCommand(char* args);
+        bool HandleLogTargetCommand(char* args);
+
 #ifdef BUILD_PLAYERBOT
         bool HandlePlayerbotCommand(char* args);
 #endif

--- a/src/game/Combat/CombatHandler.cpp
+++ b/src/game/Combat/CombatHandler.cpp
@@ -28,7 +28,7 @@ void WorldSession::HandleAttackSwingOpcode(WorldPacket& recv_data)
     ObjectGuid guid;
     recv_data >> guid;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "WORLD: Received opcode CMSG_ATTACKSWING %s", guid.GetString().c_str());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, _player->GetObjectGuid().GetCounter(), _player->GetTypeId(), "WORLD: Received opcode CMSG_ATTACKSWING %s", guid.GetString().c_str());
 
     if (!guid.IsUnit())
     {

--- a/src/game/Combat/DuelHandler.cpp
+++ b/src/game/Combat/DuelHandler.cpp
@@ -50,9 +50,9 @@ void WorldSession::HandleDuelAcceptedOpcode(WorldPacket& recvPacket)
     if (self->duel->startTime != 0 || opponent->duel->startTime != 0)
         return;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "WORLD: received CMSG_DUEL_ACCEPTED");
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "Player 1 is: %u (%s)", self->GetGUIDLow(), self->GetName());
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "Player 2 is: %u (%s)", opponent->GetGUIDLow(), opponent->GetName());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, self->GetObjectGuid().GetCounter(), self->GetTypeId(), "WORLD: received CMSG_DUEL_ACCEPTED");
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, self->GetObjectGuid().GetCounter(), self->GetTypeId(), "Player 1 is: %u (%s)", self->GetGUIDLow(), self->GetName());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, self->GetObjectGuid().GetCounter(), self->GetTypeId(), "Player 2 is: %u (%s)", opponent->GetGUIDLow(), opponent->GetName());
 
     time_t now = time(nullptr);
     self->duel->startTimer = now;

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -202,7 +202,7 @@ void Creature::RemoveCorpse(bool inPlace)
     if ((getDeathState() != CORPSE && !m_isDeadByDefault) || (getDeathState() != ALIVE && m_isDeadByDefault))
         return;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "Removing corpse of %s ", GetGuidStr().c_str());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, GetObjectGuid().GetCounter(), GetTypeId(), "Removing corpse of %s ", GetGuidStr().c_str());
 
     m_corpseExpirationTime = TimePoint();
     SetDeathState(DEAD);
@@ -588,7 +588,7 @@ void Creature::Update(const uint32 diff)
         {
             if (m_respawnTime <= time(nullptr) && (!m_isSpawningLinked || GetMap()->GetCreatureLinkingHolder()->CanSpawn(this)))
             {
-                DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "Respawning...");
+                DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, GetObjectGuid().GetCounter(), GetTypeId(), "Respawning...");
                 m_respawnTime = 0;
                 SetCanAggro(false);
                 delete loot;

--- a/src/game/Entities/GameObject.cpp
+++ b/src/game/Entities/GameObject.cpp
@@ -1409,7 +1409,7 @@ void GameObject::Use(Unit* user)
 
                 if (info->goober.eventId)
                 {
-                    DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "Goober ScriptStart id %u for %s (Used by %s).", info->goober.eventId, GetGuidStr().c_str(), player->GetGuidStr().c_str());
+                    DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, GetObjectGuid().GetCounter(), GetTypeId(), "Goober ScriptStart id %u for %s (Used by %s).", info->goober.eventId, GetGuidStr().c_str(), player->GetGuidStr().c_str());
 
                     // for battleground events we need to allow the event id to be forwarded
                     // Note: this exception is required in order not to change the legacy even handling in DB scripts

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -17915,7 +17915,7 @@ void Player::HandleStealthedUnitsDetection()
                 (*i)->SendCreateUpdateToPlayer(this);
                 m_clientGUIDs.insert(i_guid);
 
-                DEBUG_FILTER_LOG(LOG_FILTER_VISIBILITY_CHANGES, "%s is detected in stealth by player %u. Distance = %f", i_guid.GetString().c_str(), GetGUIDLow(), GetDistance(*i));
+                DEBUG_FILTER_LOG_GUID(LOG_FILTER_VISIBILITY_CHANGES, GetObjectGuid().GetCounter(), GetTypeId(), "%s is detected in stealth by player %u. Distance = %f", i_guid.GetString().c_str(), GetGUIDLow(), GetDistance(*i));
 
                 // target aura duration for caster show only if target exist at caster client
                 // send data at target visibility change (adding to client)
@@ -18314,7 +18314,7 @@ void Player::OnTaxiFlightRouteProgress(const TaxiPathNodeEntry* node, const Taxi
         if (uint32 eventid = (arrival ? node->arrivalEventID : node->departureEventID))
         {
             const char* desc = (arrival ? "arrival" : "departure");
-            DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "Taxi %s event %u of node %u of path %u for player %s", desc, eventid, node->index, node->path, GetName());
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, GetObjectGuid().GetCounter(), GetTypeId(), "Taxi %s event %u of node %u of path %u for player %s", desc, eventid, node->index, node->path, GetName());
             StartEvents_Event(GetMap(), eventid, this, this, !arrival);
         }
     }
@@ -19069,7 +19069,7 @@ void Player::UpdateVisibilityOf(WorldObject const* viewPoint, WorldObject* targe
             target->DestroyForPlayer(this);
             m_clientGUIDs.erase(t_guid);
 
-            DEBUG_FILTER_LOG(LOG_FILTER_VISIBILITY_CHANGES, "UpdateVisibilityOf: %s out of range for player %u. Distance = %f", t_guid.GetString().c_str(), GetGUIDLow(), GetDistance(target));
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_VISIBILITY_CHANGES, GetObjectGuid().GetCounter(), GetTypeId(), "UpdateVisibilityOf: %s out of range for player %u. Distance = %f", t_guid.GetString().c_str(), GetGUIDLow(), GetDistance(target));
         }
     }
     else
@@ -19080,7 +19080,7 @@ void Player::UpdateVisibilityOf(WorldObject const* viewPoint, WorldObject* targe
             if (target->GetTypeId() != TYPEID_GAMEOBJECT || !((GameObject*)target)->IsTransport())
                 m_clientGUIDs.insert(target->GetObjectGuid());
 
-            DEBUG_FILTER_LOG(LOG_FILTER_VISIBILITY_CHANGES, "UpdateVisibilityOf: %s is visible now for player %u. Distance = %f", target->GetGuidStr().c_str(), GetGUIDLow(), GetDistance(target));
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_VISIBILITY_CHANGES, GetObjectGuid().GetCounter(), GetTypeId(), "UpdateVisibilityOf: %s is visible now for player %u. Distance = %f", target->GetGuidStr().c_str(), GetGUIDLow(), GetDistance(target));
 
             // target aura duration for caster show only if target exist at caster client
             // send data at target visibility change (adding to client)
@@ -19117,7 +19117,7 @@ void Player::UpdateVisibilityOf(WorldObject const* viewPoint, T* target, UpdateD
             target->BuildOutOfRangeUpdateBlock(&data);
             m_clientGUIDs.erase(t_guid);
 
-            DEBUG_FILTER_LOG(LOG_FILTER_VISIBILITY_CHANGES, "UpdateVisibilityOf(TemplateV): %s is out of range for %s. Distance = %f", t_guid.GetString().c_str(), GetGuidStr().c_str(), GetDistance(target));
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_VISIBILITY_CHANGES, GetObjectGuid().GetCounter(), GetTypeId(), "UpdateVisibilityOf(TemplateV): %s is out of range for %s. Distance = %f", t_guid.GetString().c_str(), GetGuidStr().c_str(), GetDistance(target));
         }
     }
     else
@@ -19128,7 +19128,7 @@ void Player::UpdateVisibilityOf(WorldObject const* viewPoint, T* target, UpdateD
             target->BuildCreateUpdateBlockForPlayer(&data, this);
             UpdateVisibilityOf_helper(m_clientGUIDs, target);
 
-            DEBUG_FILTER_LOG(LOG_FILTER_VISIBILITY_CHANGES, "UpdateVisibilityOf(TemplateV): %s is visible now for %s. Distance = %f", target->GetGuidStr().c_str(), GetGuidStr().c_str(), GetDistance(target));
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_VISIBILITY_CHANGES, GetObjectGuid().GetCounter(), GetTypeId(), "UpdateVisibilityOf(TemplateV): %s is visible now for %s. Distance = %f", target->GetGuidStr().c_str(), GetGuidStr().c_str(), GetDistance(target));
         }
     }
 }

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -799,10 +799,10 @@ uint32 Unit::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDa
         return 0;
     }
 
-    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamageStart");
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_DAMAGE, GetObjectGuid().GetCounter(), GetTypeId(), "DealDamageStart");
 
     uint32 health = pVictim->GetHealth();
-    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "deal dmg:%d to health:%d ", damage, health);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_DAMAGE, GetObjectGuid().GetCounter(), GetTypeId(), "deal dmg:%d to health:%d ", damage, health);
 
     // Rage from Damage made (only from direct weapon damage)
     if (cleanDamage && damagetype == DIRECT_DAMAGE && this != pVictim && GetTypeId() == TYPEID_PLAYER && (GetPowerType() == POWER_RAGE))
@@ -845,7 +845,7 @@ uint32 Unit::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDa
         // Critter may not die of damage taken, instead expect it to run away (no fighting back)
         // If (this) is TYPEID_PLAYER, (this) will enter combat w/victim, but after some time, automatically leave combat.
         // It is unclear how it should work for other cases.
-        DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamage critter, critter dies");
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_DAMAGE, GetObjectGuid().GetCounter(), GetTypeId(), "DealDamage critter, critter dies");
 
         ((Creature*)pVictim)->SetLootRecipient(this);
 
@@ -890,14 +890,14 @@ uint32 Unit::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDa
     else                                                    // if (health <= damage)
         HandleDamageDealt(pVictim, damage, cleanDamage, damagetype, damageSchoolMask, spellProto, duel_hasEnded);
 
-    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamageEnd returned %d damage", damage);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_DAMAGE, GetObjectGuid().GetCounter(), GetTypeId(), "DealDamageEnd returned %d damage", damage);
 
     return damage;
 }
 
 void Unit::Kill(Unit* victim, DamageEffectType damagetype, SpellEntry const* spellProto, bool durabilityLoss, bool duel_hasEnded)
 {
-    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamage %s Killed %s", GetGuidStr().c_str(), victim->GetGuidStr().c_str());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_DAMAGE, GetObjectGuid().GetCounter(), GetTypeId(), "DealDamage %s Killed %s", GetGuidStr().c_str(), victim->GetGuidStr().c_str());
 
     /*
     *                      Preparation: Who gets credit for killing whom, invoke SpiritOfRedemtion?
@@ -980,7 +980,7 @@ void Unit::Kill(Unit* victim, DamageEffectType damagetype, SpellEntry const* spe
     */
     if (spiritOfRedemtionTalentReady)
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamage: Spirit of Redemtion ready");
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_DAMAGE, GetObjectGuid().GetCounter(), GetTypeId(), "DealDamage: Spirit of Redemtion ready");
 
         // save value before aura remove
         uint32 ressSpellId = victim->GetUInt32Value(PLAYER_SELF_RES_SPELL);
@@ -1031,7 +1031,7 @@ void Unit::Kill(Unit* victim, DamageEffectType damagetype, SpellEntry const* spe
 
         if (!spiritOfRedemtionTalentReady)              // Before informing Battleground
         {
-            DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "SET JUST_DIED");
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_DAMAGE, GetObjectGuid().GetCounter(), GetTypeId(), "SET JUST_DIED");
             victim->SetDeathState(JUST_DIED);
         }
 
@@ -1063,13 +1063,13 @@ void Unit::Kill(Unit* victim, DamageEffectType damagetype, SpellEntry const* spe
         JustKilledCreature((Creature*)victim, killer);
 
     // stop combat
-    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamageAttackStop");
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_DAMAGE, GetObjectGuid().GetCounter(), GetTypeId(), "DealDamageAttackStop");
     victim->CombatStop();
 }
 
 void Unit::HandleDamageDealt(Unit* victim, uint32& damage, CleanDamage const* cleanDamage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask, SpellEntry const* spellProto, bool duel_hasEnded)
 {
-    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "DealDamageAlive");
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_DAMAGE, GetObjectGuid().GetCounter(), GetTypeId(), "DealDamageAlive");
 
     victim->ModifyHealth(-(int32)damage);
 
@@ -1302,7 +1302,7 @@ void Unit::JustKilledCreature(Creature* victim, Player* responsiblePlayer)
     bool isPet = victim->IsPet();
 
     /* ********************************* Set Death finally ************************************* */
-    DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "SET JUST_DIED");
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_DAMAGE, GetObjectGuid().GetCounter(), GetTypeId(), "SET JUST_DIED");
     victim->SetDeathState(JUST_DIED);                       // if !spiritOfRedemtionTalentReady always true for unit
 
     if (isPet)
@@ -1357,7 +1357,7 @@ SpellCastResult Unit::CastSpell(Unit* Victim, SpellEntry const* spellInfo, uint3
     }
 
     if (castItem)
-        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: cast Item spellId - %i", spellInfo->Id);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, GetObjectGuid().GetCounter(), GetTypeId(), "WORLD: cast Item spellId - %i", spellInfo->Id);
 
     if (triggeredByAura)
     {
@@ -1410,7 +1410,7 @@ SpellCastResult Unit::CastCustomSpell(Unit* Victim, SpellEntry const* spellInfo,
     }
 
     if (castItem)
-        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: cast Item spellId - %i", spellInfo->Id);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, GetObjectGuid().GetCounter(), GetTypeId(), "WORLD: cast Item spellId - %i", spellInfo->Id);
 
     if (triggeredByAura)
     {
@@ -1474,7 +1474,7 @@ SpellCastResult Unit::CastSpell(float x, float y, float z, SpellEntry const* spe
     }
 
     if (castItem)
-        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: cast Item spellId - %i", spellInfo->Id);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, GetObjectGuid().GetCounter(), GetTypeId(), "WORLD: cast Item spellId - %i", spellInfo->Id);
 
     if (triggeredByAura)
     {
@@ -1513,7 +1513,7 @@ SpellCastResult Unit::CastSpell(SpellCastTargets& targets, SpellEntry const* spe
     }
 
     if (castItem)
-        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: cast Item spellId - %i", spellInfo->Id);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, GetObjectGuid().GetCounter(), GetTypeId(), "WORLD: cast Item spellId - %i", spellInfo->Id);
 
     if (triggeredByAura)
     {
@@ -2558,10 +2558,10 @@ void Unit::AttackerStateUpdate(Unit* pVictim, WeaponAttackType attType, bool ext
     }
 
     if (GetTypeId() == TYPEID_PLAYER)
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "AttackerStateUpdate: (Player) %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "AttackerStateUpdate: (Player) %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",
                          GetGUIDLow(), pVictim->GetGUIDLow(), pVictim->GetTypeId(), meleeDamageInfo.totalDamage, totalAbsorb, meleeDamageInfo.blocked_amount, totalResist);
     else
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "AttackerStateUpdate: (NPC)    %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "AttackerStateUpdate: (NPC)    %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",
                          GetGUIDLow(), pVictim->GetGUIDLow(), pVictim->GetTypeId(), meleeDamageInfo.totalDamage, totalAbsorb, meleeDamageInfo.blocked_amount, totalResist);
 
     if (CanEnterCombat() && pVictim->CanEnterCombat())
@@ -2609,7 +2609,7 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackT
     if (pVictim->GetTypeId() == TYPEID_PLAYER && !pVictim->IsStandState() && CanCrit(attType))
     {
         die.chance[UNIT_COMBAT_DIE_CRIT] = 10000;
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: New attack die: [MISS:%u, CRIT:%u] (target is sitting)",
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "RollMeleeOutcomeAgainst: New attack die: [MISS:%u, CRIT:%u] (target is sitting)",
                          die.chance[UNIT_COMBAT_DIE_MISS], die.chance[UNIT_COMBAT_DIE_CRIT]);
     }
     else
@@ -2628,7 +2628,7 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackT
         die.set(UNIT_COMBAT_DIE_CRIT, CalculateEffectiveCritChance(pVictim, attType));
         if (CanCrushInCombat(pVictim))
             die.set(UNIT_COMBAT_DIE_CRUSH, CalculateEffectiveCrushChance(pVictim, attType));
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: New attack die: [MISS:%u, DODGE:%u, PARRY:%u, BLOCK:%u, GLANCE:%u, CRIT:%u, CRUSH:%u]",
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "RollMeleeOutcomeAgainst: New attack die: [MISS:%u, DODGE:%u, PARRY:%u, BLOCK:%u, GLANCE:%u, CRIT:%u, CRUSH:%u]",
                          die.chance[UNIT_COMBAT_DIE_MISS], die.chance[UNIT_COMBAT_DIE_DODGE], die.chance[UNIT_COMBAT_DIE_PARRY], die.chance[UNIT_COMBAT_DIE_BLOCK],
                          die.chance[UNIT_COMBAT_DIE_GLANCE], die.chance[UNIT_COMBAT_DIE_CRIT], die.chance[UNIT_COMBAT_DIE_CRUSH]);
     }
@@ -2636,7 +2636,7 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackT
     const uint32 random = urand(1, 10000);
     const UnitCombatDieSide side = die.roll(random);
     if (side != UNIT_COMBAT_DIE_HIT)
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: Rolled %u, result: %s (chance %u)", random, UnitCombatDieSideText(side), die.chance[side]);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "RollMeleeOutcomeAgainst: Rolled %u, result: %s (chance %u)", random, UnitCombatDieSideText(side), die.chance[side]);
     switch (uint32(side))
     {
         case UNIT_COMBAT_DIE_MISS:   return MELEE_HIT_MISS;
@@ -2647,7 +2647,7 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackT
         case UNIT_COMBAT_DIE_CRIT:   return MELEE_HIT_CRIT;
         case UNIT_COMBAT_DIE_CRUSH:  return MELEE_HIT_CRUSHING;
     }
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: Rolled %u, result: HIT", random);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "RollMeleeOutcomeAgainst: Rolled %u, result: HIT", random);
     return MELEE_HIT_NORMAL;
 }
 
@@ -2720,7 +2720,7 @@ void Unit::SendMeleeAttackStart(Unit* pVictim) const
     data << pVictim->GetObjectGuid();
 
     SendMessageToSet(data, true);
-    DEBUG_LOG("WORLD: Sent SMSG_ATTACKSTART");
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "WORLD: Sent SMSG_ATTACKSTART");
 }
 
 void Unit::SendMeleeAttackStop(Unit* victim) const
@@ -2733,7 +2733,7 @@ void Unit::SendMeleeAttackStop(Unit* victim) const
     data << victim->GetPackGUID();                          // can be 0x00...
     data << uint32(0);                                      // can be 0x1
     SendMessageToSet(data, true);
-    DETAIL_FILTER_LOG(LOG_FILTER_COMBAT, "%s stopped attacking %s", GetGuidStr().c_str(), victim->GetGuidStr().c_str());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "%s stopped attacking %s", GetGuidStr().c_str(), victim->GetGuidStr().c_str());
 
     /*if(victim->GetTypeId() == TYPEID_UNIT)
     ((Creature*)victim)->AI().EnterEvadeMode(this);*/
@@ -2756,13 +2756,13 @@ SpellMissInfo Unit::MeleeSpellHitResult(Unit* pVictim, SpellEntry const* spell)
         if (pVictim->CanBlockAbility(this, spell, true))
             die.set(UNIT_COMBAT_DIE_BLOCK, pVictim->CalculateEffectiveBlockChance(this, attackType, spell));
     }
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MeleeSpellHitResult: New ability hit die: %u [MISS:%u, RESIST:%u, DODGE:%u, PARRY:%u, DEFLECT:%u, BLOCK:%u]", spell->Id,
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "MeleeSpellHitResult: New ability hit die: %u [MISS:%u, RESIST:%u, DODGE:%u, PARRY:%u, DEFLECT:%u, BLOCK:%u]", spell->Id,
                      die.chance[UNIT_COMBAT_DIE_MISS], die.chance[UNIT_COMBAT_DIE_RESIST], die.chance[UNIT_COMBAT_DIE_DODGE],
                      die.chance[UNIT_COMBAT_DIE_PARRY], die.chance[UNIT_COMBAT_DIE_DEFLECT], die.chance[UNIT_COMBAT_DIE_BLOCK]);
     const uint32 random = urand(1, 10000);
     const UnitCombatDieSide side = die.roll(random);
     if (side != UNIT_COMBAT_DIE_HIT)
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MeleeSpellHitResult: Rolled %u, result: %s (chance %u)", random, UnitCombatDieSideText(side), die.chance[side]);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "MeleeSpellHitResult: Rolled %u, result: %s (chance %u)", random, UnitCombatDieSideText(side), die.chance[side]);
     switch (uint32(side))
     {
         case UNIT_COMBAT_DIE_MISS:      return SPELL_MISS_MISS;
@@ -2772,7 +2772,7 @@ SpellMissInfo Unit::MeleeSpellHitResult(Unit* pVictim, SpellEntry const* spell)
         case UNIT_COMBAT_DIE_DEFLECT:   return SPELL_MISS_DEFLECT;
         case UNIT_COMBAT_DIE_BLOCK:     return SPELL_MISS_BLOCK;
     }
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MeleeSpellHitResult: Rolled %u, result: HIT", random);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "MeleeSpellHitResult: Rolled %u, result: HIT", random);
     return SPELL_MISS_NONE;
 }
 
@@ -2784,18 +2784,18 @@ SpellMissInfo Unit::MagicSpellHitResult(Unit* pVictim, SpellEntry const* spell, 
     if (pVictim->CanDeflectAbility(this, spell))
        die.set(UNIT_COMBAT_DIE_DEFLECT, pVictim->CalculateAbilityDeflectChance(this, spell));
     */
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MagicSpellHitResult: New spell hit die: %u [RESIST:%u, DEFLECT:%u]", spell->Id,
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "MagicSpellHitResult: New spell hit die: %u [RESIST:%u, DEFLECT:%u]", spell->Id,
                      die.chance[UNIT_COMBAT_DIE_RESIST], die.chance[UNIT_COMBAT_DIE_DEFLECT]);
     const uint32 random = urand(1, 10000);
     const UnitCombatDieSide side = die.roll(random);
     if (side != UNIT_COMBAT_DIE_HIT)
-        DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MagicSpellHitResult: Rolled %u, result: %s (chance %u)", random, UnitCombatDieSideText(side), die.chance[side]);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "MagicSpellHitResult: Rolled %u, result: %s (chance %u)", random, UnitCombatDieSideText(side), die.chance[side]);
     switch (uint32(side))
     {
         case UNIT_COMBAT_DIE_RESIST:    return SPELL_MISS_RESIST;   // Pre-WotLK: magic resist and miss/hit are on the same die side
         case UNIT_COMBAT_DIE_DEFLECT:   return SPELL_MISS_DEFLECT;
     }
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "MagicSpellHitResult: Rolled %u, result: HIT", random);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "MagicSpellHitResult: Rolled %u, result: HIT", random);
     return SPELL_MISS_NONE;
 }
 
@@ -4760,7 +4760,7 @@ bool Unit::AddSpellAuraHolder(SpellAuraHolder* holder)
             AddAuraToModList(aur);
 
     holder->ApplyAuraModifiers(true, true);                 // This is the place where auras are actually applied onto the target
-    DETAIL_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Holder of spell %u now is in use", holder->GetId());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, GetObjectGuid().GetCounter(), GetTypeId(), "Holder of spell %u now is in use", holder->GetId());
 
     // if aura deleted before boosts apply ignore
     // this can be possible it it removed indirectly by triggered spell effect at ApplyModifier
@@ -5353,7 +5353,7 @@ void Unit::RemoveAura(Aura* Aur, AuraRemoveMode mode)
     // remove aura from list before to prevent deleting it before
     /// m_Auras.erase(i);
 
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Aura %u now is remove mode %d", Aur->GetModifier()->m_auraname, mode);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, GetObjectGuid().GetCounter(), GetTypeId(), "Aura %u now is remove mode %d", Aur->GetModifier()->m_auraname, mode);
 
     // aura _MUST_ be remove from holder before unapply.
     // un-apply code expected that aura not find by diff searches
@@ -5465,7 +5465,7 @@ void Unit::DelaySpellAuraHolder(uint32 spellId, int32 delaytime, ObjectGuid cast
 
         holder->UpdateAuraDuration();
 
-        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell %u partially interrupted on %s, new duration: %u ms", spellId, GetGuidStr().c_str(), holder->GetAuraDuration());
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, GetObjectGuid().GetCounter(), GetTypeId(), "Spell %u partially interrupted on %s, new duration: %u ms", spellId, GetGuidStr().c_str(), holder->GetAuraDuration());
     }
 }
 
@@ -5932,7 +5932,7 @@ void Unit::SendAIReaction(AiReaction reactionType)
 
     SendMessageToSet(data, true);
 
-    DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "WORLD: Sent SMSG_AI_REACTION, type %u.", reactionType);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, GetObjectGuid().GetCounter(), GetTypeId(), "WORLD: Sent SMSG_AI_REACTION, type %u.", reactionType);
 }
 
 bool Unit::CanInitiateAttack() const
@@ -5952,7 +5952,7 @@ bool Unit::CanInitiateAttack() const
 
 void Unit::SendAttackStateUpdate(CalcDamageInfo* calcDamageInfo) const
 {
-    DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "WORLD: Sending SMSG_ATTACKERSTATEUPDATE");
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_COMBAT, GetObjectGuid().GetCounter(), GetTypeId(), "WORLD: Sending SMSG_ATTACKERSTATEUPDATE");
 
     // Subdamage count:
     uint32 lines = m_weaponDamageInfo.weapon[calcDamageInfo->attackType].lines;
@@ -6450,7 +6450,7 @@ Unit* Unit::GetCharm(WorldObject const* pov /*= nullptr*/) const
                     return ObjectAccessor::FindPlayer(guid);
             }
             // Bugcheck
-            sLog.outDebug("Unit::GetCharm: Guid field management continuity violation for %s, can't look up %s while accessor is outside of the world",
+            DEBUG_LOG("Unit::GetCharm: Guid field management continuity violation for %s, can't look up %s while accessor is outside of the world",
                           GetGuidStr().c_str(), guid.GetString().c_str());
             return nullptr;
         }
@@ -6458,7 +6458,7 @@ Unit* Unit::GetCharm(WorldObject const* pov /*= nullptr*/) const
         if (Unit* unit = accessor->GetMap()->GetUnit(guid))
             return unit;
         // Bugcheck
-        sLog.outDebug("Unit::GetCharm: Guid field management continuity violation for %s in map '%s', %s does not exist in this instance",
+        DEBUG_LOG("Unit::GetCharm: Guid field management continuity violation for %s in map '%s', %s does not exist in this instance",
                       GetGuidStr().c_str(), accessor->GetMap()->GetMapName(), guid.GetString().c_str());
         // const_cast<Unit*>(this)->SetCharm(nullptr);
     }
@@ -6479,7 +6479,7 @@ Unit* Unit::GetCharmer(WorldObject const* pov /*= nullptr*/) const
                     return ObjectAccessor::FindPlayer(guid);
             }
             // Bugcheck
-            sLog.outDebug("Unit::GetCharmer: Guid field management continuity violation for %s, can't look up %s while accessor is outside of the world",
+            DEBUG_LOG("Unit::GetCharmer: Guid field management continuity violation for %s, can't look up %s while accessor is outside of the world",
                           GetGuidStr().c_str(), guid.GetString().c_str());
             return nullptr;
         }
@@ -6487,7 +6487,7 @@ Unit* Unit::GetCharmer(WorldObject const* pov /*= nullptr*/) const
         if (Unit* unit = accessor->GetMap()->GetUnit(guid))
             return unit;
         // Bugcheck
-        sLog.outDebug("Unit::GetCharmer: Guid field management continuity violation for %s in map '%s', %s does not exist in this instance",
+        DEBUG_LOG("Unit::GetCharmer: Guid field management continuity violation for %s in map '%s', %s does not exist in this instance",
                       GetGuidStr().c_str(), accessor->GetMap()->GetMapName(), guid.GetString().c_str());
         // const_cast<Unit*>(this)->SetCharmer(nullptr);
     }
@@ -6508,7 +6508,7 @@ Unit* Unit::GetCreator(WorldObject const* pov /*= nullptr*/) const
                     return ObjectAccessor::FindPlayer(guid);
             }
             // Bugcheck
-            sLog.outDebug("Unit::GetCreator: Guid field management continuity violation for %s, can't look up %s while accessor is outside of the world",
+            DEBUG_LOG("Unit::GetCreator: Guid field management continuity violation for %s, can't look up %s while accessor is outside of the world",
                           GetGuidStr().c_str(), guid.GetString().c_str());
             return nullptr;
         }
@@ -6516,7 +6516,7 @@ Unit* Unit::GetCreator(WorldObject const* pov /*= nullptr*/) const
         if (Unit* unit = accessor->GetMap()->GetUnit(guid))
             return unit;
         // Bugcheck
-        sLog.outDebug("Unit::GetCreator: Guid field management continuity violation for %s in map '%s', %s does not exist in this instance",
+        DEBUG_LOG("Unit::GetCreator: Guid field management continuity violation for %s in map '%s', %s does not exist in this instance",
                       GetGuidStr().c_str(), accessor->GetMap()->GetMapName(), guid.GetString().c_str());
         // const_cast<Unit*>(this)->SetCreator(nullptr);
     }
@@ -6537,7 +6537,7 @@ Unit* Unit::GetTarget(WorldObject const* pov /*= nullptr*/) const
                     return ObjectAccessor::FindPlayer(guid);
             }
             // Bugcheck
-            sLog.outDebug("Unit::GetTarget: Guid field management continuity violation for %s, can't look up %s while accessor is outside of the world",
+            DEBUG_LOG("Unit::GetTarget: Guid field management continuity violation for %s, can't look up %s while accessor is outside of the world",
                           GetGuidStr().c_str(), guid.GetString().c_str());
             return nullptr;
         }
@@ -6545,7 +6545,7 @@ Unit* Unit::GetTarget(WorldObject const* pov /*= nullptr*/) const
         if (Unit* unit = accessor->GetMap()->GetUnit(guid))
             return unit;
         // Bugcheck
-        sLog.outDebug("Unit::GetTarget: Guid field management continuity violation for %s in map '%s', %s does not exist in this instance",
+        DEBUG_LOG("Unit::GetTarget: Guid field management continuity violation for %s in map '%s', %s does not exist in this instance",
                       GetGuidStr().c_str(), accessor->GetMap()->GetMapName(), guid.GetString().c_str());
         // const_cast<Unit*>(this)->SetTarget(nullptr);
     }
@@ -6566,7 +6566,7 @@ Unit* Unit::GetChannelObject(WorldObject const* pov /*= nullptr*/) const
                     return ObjectAccessor::FindPlayer(guid);
             }
             // Bugcheck
-            sLog.outDebug("Unit::GetChannelObject: Guid field management continuity violation for %s, can't look up %s while accessor is outside of the world",
+            DEBUG_LOG("Unit::GetChannelObject: Guid field management continuity violation for %s, can't look up %s while accessor is outside of the world",
                           GetGuidStr().c_str(), guid.GetString().c_str());
             return nullptr;
         }
@@ -6574,7 +6574,7 @@ Unit* Unit::GetChannelObject(WorldObject const* pov /*= nullptr*/) const
         if (Unit* unit = accessor->GetMap()->GetUnit(guid))
             return unit;
         // Bugcheck
-        sLog.outDebug("Unit::GetChannelObject: Guid field management continuity violation for %s in map '%s', %s does not exist in this instance",
+        DEBUG_LOG("Unit::GetChannelObject: Guid field management continuity violation for %s in map '%s', %s does not exist in this instance",
                       GetGuidStr().c_str(), accessor->GetMap()->GetMapName(), guid.GetString().c_str());
         // const_cast<Unit*>(this)->SetChannelObject(nullptr);
     }
@@ -6614,7 +6614,7 @@ Unit* Unit::GetSpawner(WorldObject const* pov /*= nullptr*/) const
                     return ObjectAccessor::FindPlayer(guid);
             }
             // Bugcheck
-            sLog.outDebug("Unit::GetSpawner: Guid field management continuity violation for %s, can't look up %s while accessor is outside of the world",
+            DEBUG_LOG("Unit::GetSpawner: Guid field management continuity violation for %s, can't look up %s while accessor is outside of the world",
                           GetGuidStr().c_str(), guid.GetString().c_str());
             return nullptr;
         }
@@ -6622,7 +6622,7 @@ Unit* Unit::GetSpawner(WorldObject const* pov /*= nullptr*/) const
         if (Unit* unit = accessor->GetMap()->GetUnit(guid))
             return unit;
         // Bugcheck
-        sLog.outDebug("Unit::GetSpawner: Guid field management continuity violation for %s in map '%s', %s does not exist in this instance",
+        DEBUG_LOG("Unit::GetSpawner: Guid field management continuity violation for %s in map '%s', %s does not exist in this instance",
                       GetGuidStr().c_str(), accessor->GetMap()->GetMapName(), guid.GetString().c_str());
     }
     return nullptr;

--- a/src/game/Grids/GridNotifiers.cpp
+++ b/src/game/Grids/GridNotifiers.cpp
@@ -61,7 +61,7 @@ void VisibleNotifier::Notify()
     {
         player.m_clientGUIDs.erase(*itr);
 
-        DEBUG_FILTER_LOG(LOG_FILTER_VISIBILITY_CHANGES, "%s is out of range (no in active cells set) now for %s",
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_VISIBILITY_CHANGES, player.GetObjectGuid().GetCounter(), player.GetTypeId(), "%s is out of range (no in active cells set) now for %s",
                          itr->GetString().c_str(), player.GetGuidStr().c_str());
     }
 

--- a/src/game/Grids/GridStates.cpp
+++ b/src/game/Grids/GridStates.cpp
@@ -50,7 +50,7 @@ IdleState::Update(Map& m, NGridType& grid, GridInfo&, const uint32& x, const uin
 {
     m.ResetGridExpiry(grid);
     grid.SetGridState(GRID_STATE_REMOVAL);
-    DEBUG_LOG("Grid[%u,%u] on map %u moved to IDLE state", x, y, m.GetId());
+    DETAIL_FILTER_LOG(LOG_FILTER_MAP_LOADING, "Grid[%u,%u] on map %u moved to IDLE state", x, y, m.GetId());
 }
 
 void

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -260,7 +260,7 @@ Map::EnsureGridLoadedAtEnter(const Cell& cell, Player* player)
 
         if (player)
         {
-            DEBUG_FILTER_LOG(LOG_FILTER_PLAYER_MOVES, "Player %s enter cell[%u,%u] triggers of loading grid[%u,%u] on map %u", player->GetName(), cell.CellX(), cell.CellY(), cell.GridX(), cell.GridY(), i_id);
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_PLAYER_MOVES, player->GetObjectGuid().GetCounter(), player->GetTypeId(), "Player %s enter cell[%u,%u] triggers of loading grid[%u,%u] on map %u", player->GetName(), cell.CellX(), cell.CellY(), cell.GridX(), cell.GridY(), i_id);
         }
         else
         {
@@ -381,7 +381,7 @@ Map::Add(T* obj)
     if (obj->isActiveObject())
         AddToActive(obj);
 
-    DEBUG_FILTER_LOG(LOG_FILTER_CREATURE_MOVES, "%s enters grid[%u,%u]", obj->GetGuidStr().c_str(), cell.GridX(), cell.GridY());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_CREATURE_MOVES, obj->GetObjectGuid().GetCounter(), obj->GetTypeId(), "%s enters grid[%u,%u]", obj->GetGuidStr().c_str(), cell.GridX(), cell.GridY());
 
     obj->GetViewPoint().Event_AddedToWorld(&(*grid)(cell.CellX(), cell.CellY()));
     obj->SetItsNewObject(true);
@@ -736,7 +736,7 @@ void Map::Remove(Player* player, bool remove)
         return;
     }
 
-    DEBUG_FILTER_LOG(LOG_FILTER_PLAYER_MOVES, "Remove player %s from grid[%u,%u]", player->GetName(), cell.GridX(), cell.GridY());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_PLAYER_MOVES, player->GetObjectGuid().GetCounter(), player->GetTypeId(), "Remove player %s from grid[%u,%u]", player->GetName(), cell.GridX(), cell.GridY());
     NGridType* grid = getNGrid(cell.GridX(), cell.GridY());
     MANGOS_ASSERT(grid != nullptr);
 
@@ -765,7 +765,7 @@ Map::Remove(T* obj, bool remove)
     if (!loaded(GridPair(cell.data.Part.grid_x, cell.data.Part.grid_y)))
         return;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_CREATURE_MOVES, "Remove %s from grid[%u,%u]", obj->GetGuidStr().c_str(), cell.data.Part.grid_x, cell.data.Part.grid_y);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_CREATURE_MOVES, obj->GetObjectGuid().GetCounter(), obj->GetTypeId(), "Remove %s from grid[%u,%u]", obj->GetGuidStr().c_str(), cell.data.Part.grid_x, cell.data.Part.grid_y);
     NGridType* grid = getNGrid(cell.GridX(), cell.GridY());
     MANGOS_ASSERT(grid != nullptr);
 
@@ -808,7 +808,7 @@ Map::PlayerRelocation(Player* player, float x, float y, float z, float orientati
 
     if (old_cell.DiffGrid(new_cell) || old_cell.DiffCell(new_cell))
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_PLAYER_MOVES, "Player %s relocation grid[%u,%u]cell[%u,%u]->grid[%u,%u]cell[%u,%u]", player->GetName(), old_cell.GridX(), old_cell.GridY(), old_cell.CellX(), old_cell.CellY(), new_cell.GridX(), new_cell.GridY(), new_cell.CellX(), new_cell.CellY());
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_PLAYER_MOVES, player->GetObjectGuid().GetCounter(), player->GetTypeId(), "Player %s relocation grid[%u,%u]cell[%u,%u]->grid[%u,%u]cell[%u,%u]", player->GetName(), old_cell.GridX(), old_cell.GridY(), old_cell.CellX(), old_cell.CellY(), new_cell.GridX(), new_cell.GridY(), new_cell.CellX(), new_cell.CellY());
 
         NGridType* oldGrid = getNGrid(old_cell.GridX(), old_cell.GridY());
         RemoveFromGrid(player, oldGrid, old_cell);
@@ -847,7 +847,7 @@ void Map::CreatureRelocation(Creature* creature, float x, float y, float z, floa
     else if (!CreatureRespawnRelocation(creature))
     {
         // ... or unload (if respawn grid also not loaded)
-        DEBUG_FILTER_LOG(LOG_FILTER_CREATURE_MOVES, "Creature (GUID: %u Entry: %u ) can't be move to unloaded respawn grid.", creature->GetGUIDLow(), creature->GetEntry());
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_CREATURE_MOVES, creature->GetObjectGuid().GetCounter(), creature->GetTypeId(), "Creature (GUID: %u Entry: %u ) can't be move to unloaded respawn grid.", creature->GetGUIDLow(), creature->GetEntry());
     }
 }
 
@@ -858,7 +858,7 @@ bool Map::CreatureCellRelocation(Creature* c, const Cell& new_cell)
     {
         if (!c->isActiveObject() && !loaded(new_cell.gridPair()))
         {
-            DEBUG_FILTER_LOG(LOG_FILTER_CREATURE_MOVES, "Creature (GUID: %u Entry: %u) attempt move from grid[%u,%u]cell[%u,%u] to unloaded grid[%u,%u]cell[%u,%u].", c->GetGUIDLow(), c->GetEntry(), old_cell.GridX(), old_cell.GridY(), old_cell.CellX(), old_cell.CellY(), new_cell.GridX(), new_cell.GridY(), new_cell.CellX(), new_cell.CellY());
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_CREATURE_MOVES, c->GetObjectGuid().GetCounter(), c->GetTypeId(), "Creature (GUID: %u Entry: %u) attempt move from grid[%u,%u]cell[%u,%u] to unloaded grid[%u,%u]cell[%u,%u].", c->GetGUIDLow(), c->GetEntry(), old_cell.GridX(), old_cell.GridY(), old_cell.CellX(), old_cell.CellY(), new_cell.GridX(), new_cell.GridY(), new_cell.CellX(), new_cell.CellY());
             return false;
         }
         EnsureGridLoadedAtEnter(new_cell);
@@ -866,7 +866,7 @@ bool Map::CreatureCellRelocation(Creature* c, const Cell& new_cell)
 
     if (old_cell != new_cell)
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_CREATURE_MOVES, "Creature (GUID: %u Entry: %u) moved in grid[%u,%u] from cell[%u,%u] to cell[%u,%u].", c->GetGUIDLow(), c->GetEntry(), old_cell.GridX(), old_cell.GridY(), old_cell.CellX(), old_cell.CellY(), new_cell.CellX(), new_cell.CellY());
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_CREATURE_MOVES, c->GetObjectGuid().GetCounter(), c->GetTypeId(), "Creature (GUID: %u Entry: %u) moved in grid[%u,%u] from cell[%u,%u] to cell[%u,%u].", c->GetGUIDLow(), c->GetEntry(), old_cell.GridX(), old_cell.GridY(), old_cell.CellX(), old_cell.CellY(), new_cell.CellX(), new_cell.CellY());
         NGridType* oldGrid = getNGrid(old_cell.GridX(), old_cell.GridY());
         NGridType* newGrid = getNGrid(new_cell.GridX(), new_cell.GridY());
         RemoveFromGrid(c, oldGrid, old_cell);
@@ -887,7 +887,7 @@ bool Map::CreatureRespawnRelocation(Creature* c)
     c->CombatStopWithPets();
     c->GetMotionMaster()->Clear();
 
-    DEBUG_FILTER_LOG(LOG_FILTER_CREATURE_MOVES, "Creature (GUID: %u Entry: %u) will moved from grid[%u,%u]cell[%u,%u] to respawn grid[%u,%u]cell[%u,%u].", c->GetGUIDLow(), c->GetEntry(), c->GetCurrentCell().GridX(), c->GetCurrentCell().GridY(), c->GetCurrentCell().CellX(), c->GetCurrentCell().CellY(), resp_cell.GridX(), resp_cell.GridY(), resp_cell.CellX(), resp_cell.CellY());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_CREATURE_MOVES, c->GetObjectGuid().GetCounter(), c->GetTypeId(), "Creature (GUID: %u Entry: %u) will moved from grid[%u,%u]cell[%u,%u] to respawn grid[%u,%u]cell[%u,%u].", c->GetGUIDLow(), c->GetEntry(), c->GetCurrentCell().GridX(), c->GetCurrentCell().GridY(), c->GetCurrentCell().CellX(), c->GetCurrentCell().CellY(), resp_cell.GridX(), resp_cell.GridY(), resp_cell.CellX(), resp_cell.CellY());
 
     // teleport it to respawn point (like normal respawn if player see)
     if (CreatureCellRelocation(c, resp_cell))

--- a/src/game/MotionGenerators/MotionMaster.cpp
+++ b/src/game/MotionGenerators/MotionMaster.cpp
@@ -236,7 +236,7 @@ void MotionMaster::MoveRandomAroundPoint(float x, float y, float z, float radius
     }
     else
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s move random.", m_owner->GetGuidStr().c_str());
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s move random.", m_owner->GetGuidStr().c_str());
         Mutate(new RandomMovementGenerator<Creature>(x, y, z, radius, verticalZ));
     }
 }
@@ -252,15 +252,15 @@ void MotionMaster::MoveTargetedHome(bool runHome)
     {
         if (Unit* target = m_owner->GetMaster())
         {
-            DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s follow to %s", m_owner->GetGuidStr().c_str(), target->GetGuidStr().c_str());
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s follow to %s", m_owner->GetGuidStr().c_str(), target->GetGuidStr().c_str());
             Mutate(new FollowMovementGenerator<Creature>(*target, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE));
         }
         // Manual exception for linked mobs
         else if (m_owner->IsLinkingEventTrigger() && m_owner->GetMap()->GetCreatureLinkingHolder()->TryFollowMaster((Creature*)m_owner))
-            DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s refollowed linked master", m_owner->GetGuidStr().c_str());
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s refollowed linked master", m_owner->GetGuidStr().c_str());
         else
         {
-            DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s targeted home", m_owner->GetGuidStr().c_str());
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s targeted home", m_owner->GetGuidStr().c_str());
             Mutate(new HomeMovementGenerator<Creature>(runHome));
         }
     }
@@ -270,7 +270,7 @@ void MotionMaster::MoveTargetedHome(bool runHome)
 
 void MotionMaster::MoveConfused()
 {
-    DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s move confused", m_owner->GetGuidStr().c_str());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s move confused", m_owner->GetGuidStr().c_str());
 
     if (m_owner->GetTypeId() == TYPEID_PLAYER)
         Mutate(new ConfusedMovementGenerator<Player>());
@@ -292,7 +292,7 @@ void MotionMaster::MoveChase(Unit* target, float dist, float angle, bool moveFur
         return;
     }
 
-    DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s chase to %s", m_owner->GetGuidStr().c_str(), target->GetGuidStr().c_str());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s chase to %s", m_owner->GetGuidStr().c_str(), target->GetGuidStr().c_str());
 
     Mutate(new ChaseMovementGenerator(*target, dist, angle, moveFurther, walk, combat));
 }
@@ -321,7 +321,7 @@ void MotionMaster::MoveFollow(Unit* target, float dist, float angle, bool asMain
     if (!target)
         return;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s follow to %s", m_owner->GetGuidStr().c_str(), target->GetGuidStr().c_str());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s follow to %s", m_owner->GetGuidStr().c_str(), target->GetGuidStr().c_str());
 
     if (m_owner->GetTypeId() == TYPEID_PLAYER)
         Mutate(new FollowMovementGenerator<Player>(*target, dist, angle));
@@ -331,7 +331,7 @@ void MotionMaster::MoveFollow(Unit* target, float dist, float angle, bool asMain
 
 void MotionMaster::MovePoint(uint32 id, float x, float y, float z, bool generatePath)
 {
-    DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s targeted point (Id: %u X: %f Y: %f Z: %f)", m_owner->GetGuidStr().c_str(), id, x, y, z);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s targeted point (Id: %u X: %f Y: %f Z: %f)", m_owner->GetGuidStr().c_str(), id, x, y, z);
 
     if (m_owner->GetTypeId() == TYPEID_PLAYER)
         Mutate(new PointMovementGenerator<Player>(id, x, y, z, generatePath));
@@ -347,7 +347,7 @@ void MotionMaster::MoveSeekAssistance(float x, float y, float z)
     }
     else
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s seek assistance (X: %f Y: %f Z: %f)",
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s seek assistance (X: %f Y: %f Z: %f)",
                          m_owner->GetGuidStr().c_str(), x, y, z);
         Mutate(new AssistanceMovementGenerator(x, y, z));
     }
@@ -361,7 +361,7 @@ void MotionMaster::MoveSeekAssistanceDistract(uint32 time)
     }
     else
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s is distracted after assistance call (Time: %u)",
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s is distracted after assistance call (Time: %u)",
                          m_owner->GetGuidStr().c_str(), time);
         Mutate(new AssistanceDistractMovementGenerator(time));
     }
@@ -372,7 +372,7 @@ void MotionMaster::MoveFleeing(Unit* enemy, uint32 time)
     if (!enemy)
         return;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s flee from %s", m_owner->GetGuidStr().c_str(), enemy->GetGuidStr().c_str());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s flee from %s", m_owner->GetGuidStr().c_str(), enemy->GetGuidStr().c_str());
 
     if (m_owner->GetTypeId() == TYPEID_PLAYER)
         Mutate(new FleeingMovementGenerator<Player>(enemy->GetObjectGuid()));
@@ -398,7 +398,7 @@ void MotionMaster::MoveWaypoint(uint32 pathId /*=0*/, uint32 source /*=0==PATH_N
         Creature* creature = (Creature*)m_owner;
         m_currentPathId = pathId;
 
-        DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s start MoveWaypoint()", m_owner->GetGuidStr().c_str());
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s start MoveWaypoint()", m_owner->GetGuidStr().c_str());
         WaypointMovementGenerator<Creature>* newWPMMgen = new WaypointMovementGenerator<Creature>(*creature);
         Mutate(newWPMMgen);
         newWPMMgen->InitializeWaypointPath(*creature, pathId, (WaypointPathOrigin)source, initialDelay, overwriteEntry);
@@ -433,7 +433,7 @@ void MotionMaster::MoveTaxiFlight()
 
     if (m_owner->GetTypeId() == TYPEID_PLAYER)
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s is now in taxi flight", m_owner->GetGuidStr().c_str());
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s is now in taxi flight", m_owner->GetGuidStr().c_str());
         Mutate(new FlightPathMovementGenerator());
     }
     else
@@ -442,7 +442,7 @@ void MotionMaster::MoveTaxiFlight()
 
 void MotionMaster::MoveDistract(uint32 timer)
 {
-    DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s distracted (timer: %u)", m_owner->GetGuidStr().c_str(), timer);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s distracted (timer: %u)", m_owner->GetGuidStr().c_str(), timer);
     DistractMovementGenerator* mgen = new DistractMovementGenerator(timer);
     Mutate(mgen);
 }
@@ -452,7 +452,7 @@ void MotionMaster::MoveFlyOrLand(uint32 id, float x, float y, float z, bool lift
     if (m_owner->GetTypeId() != TYPEID_UNIT)
         return;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s targeted point for %s (Id: %u X: %f Y: %f Z: %f)", m_owner->GetGuidStr().c_str(), liftOff ? "liftoff" : "landing", id, x, y, z);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, m_owner->GetObjectGuid().GetCounter(), m_owner->GetTypeId(), "%s targeted point for %s (Id: %u X: %f Y: %f Z: %f)", m_owner->GetGuidStr().c_str(), liftOff ? "liftoff" : "landing", id, x, y, z);
     Mutate(new FlyOrLandMovementGenerator(id, x, y, z, liftOff));
 }
 

--- a/src/game/MotionGenerators/MovementHandler.cpp
+++ b/src/game/MotionGenerators/MovementHandler.cpp
@@ -239,11 +239,7 @@ void WorldSession::HandleMoveTeleportAckOpcode(WorldPacket& recv_data)
 void WorldSession::HandleMovementOpcodes(WorldPacket& recv_data)
 {
     Opcodes opcode = recv_data.GetOpcode();
-    if (!sLog.HasLogFilter(LOG_FILTER_PLAYER_MOVES))
-    {
-        DEBUG_LOG("WORLD: Received opcode %s (%u, 0x%X)", LookupOpcodeName(opcode), opcode, opcode);
-        recv_data.hexlike();
-    }
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_PLAYER_MOVES, _player->GetObjectGuid().GetCounter(), _player->GetTypeId(), "WORLD: Received opcode %s (%u, 0x%X)", LookupOpcodeName(opcode), opcode, opcode);
 
     Unit* mover = _player->GetMover();
     Player* plMover = mover->GetTypeId() == TYPEID_PLAYER ? (Player*)mover : nullptr;

--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -32,7 +32,7 @@ PathFinder::PathFinder(const Unit* owner) :
     m_useStraightPath(false), m_forceDestination(false), m_pointPathLimit(MAX_POINT_PATH_LENGTH),
     m_sourceUnit(owner), m_navMesh(nullptr), m_navMeshQuery(nullptr)
 {
-    DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::PathInfo for %u \n", m_sourceUnit->GetGUIDLow());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ PathFinder::PathInfo for %u \n", m_sourceUnit->GetGUIDLow());
 
     uint32 mapId = m_sourceUnit->GetMapId();
     if (MMAP::MMapFactory::IsPathfindingEnabled(mapId, owner))
@@ -47,7 +47,7 @@ PathFinder::PathFinder(const Unit* owner) :
 
 PathFinder::~PathFinder()
 {
-    DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::~PathInfo() for %u \n", m_sourceUnit->GetGUIDLow());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ PathFinder::~PathInfo() for %u \n", m_sourceUnit->GetGUIDLow());
 }
 
 bool PathFinder::calculate(float destX, float destY, float destZ, bool forceDest)
@@ -68,7 +68,7 @@ bool PathFinder::calculate(float destX, float destY, float destZ, bool forceDest
 
     m_forceDestination = forceDest;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::calculate() for %u \n", m_sourceUnit->GetGUIDLow());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ PathFinder::calculate() for %u \n", m_sourceUnit->GetGUIDLow());
 
     // make sure navMesh works - we can run on map w/o mmap
     // check if the start and end point have a .mmtile loaded (can we pass via not loaded tile on the way?)
@@ -171,7 +171,7 @@ void PathFinder::BuildPolyPath(const Vector3& startPos, const Vector3& endPos)
     // its up to caller how he will use this info
     if (startPoly == INVALID_POLYREF || endPoly == INVALID_POLYREF)
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: (startPoly == 0 || endPoly == 0)\n");
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ BuildPolyPath :: (startPoly == 0 || endPoly == 0)\n");
         BuildShortcut();
 
         // Check for swimming or flying shortcut
@@ -193,7 +193,7 @@ void PathFinder::BuildPolyPath(const Vector3& startPos, const Vector3& endPos)
     bool farFromPoly = (distToStartPoly > 7.0f || distToEndPoly > 7.0f);
     if (farFromPoly)
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: farFromPoly distToStartPoly=%.3f distToEndPoly=%.3f\n", distToStartPoly, distToEndPoly);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ BuildPolyPath :: farFromPoly distToStartPoly=%.3f distToEndPoly=%.3f\n", distToStartPoly, distToEndPoly);
 
         bool buildShotrcut = false;
         if (m_sourceUnit->GetTypeId() == TYPEID_UNIT)
@@ -203,13 +203,13 @@ void PathFinder::BuildPolyPath(const Vector3& startPos, const Vector3& endPos)
             Vector3 p = (distToStartPoly > 7.0f) ? startPos : endPos;
             if (m_sourceUnit->GetTerrain()->IsUnderWater(p.x, p.y, p.z))
             {
-                DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: underWater case\n");
+                DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ BuildPolyPath :: underWater case\n");
                 if (owner->CanSwim())
                     buildShotrcut = true;
             }
             else
             {
-                DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: flying case\n");
+                DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ BuildPolyPath :: flying case\n");
                 if (owner->CanFly())
                     buildShotrcut = true;
             }
@@ -238,7 +238,7 @@ void PathFinder::BuildPolyPath(const Vector3& startPos, const Vector3& endPos)
     // just need to move in straight line
     if (startPoly == endPoly)
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: (startPoly == endPoly)\n");
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ BuildPolyPath :: (startPoly == endPoly)\n");
 
         BuildShortcut();
 
@@ -246,7 +246,7 @@ void PathFinder::BuildPolyPath(const Vector3& startPos, const Vector3& endPos)
         m_polyLength = 1;
 
         m_type = farFromPoly ? PATHFIND_INCOMPLETE : PATHFIND_NORMAL;
-        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: path type %d\n", m_type);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ BuildPolyPath :: path type %d\n", m_type);
         return;
     }
 
@@ -290,7 +290,7 @@ void PathFinder::BuildPolyPath(const Vector3& startPos, const Vector3& endPos)
 
     if (startPolyFound && endPolyFound)
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: (startPolyFound && endPolyFound)\n");
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ BuildPolyPath :: (startPolyFound && endPolyFound)\n");
 
         // we moved along the path and the target did not move out of our old poly-path
         // our path is a simple subpath case, we have all the data we need
@@ -301,7 +301,7 @@ void PathFinder::BuildPolyPath(const Vector3& startPos, const Vector3& endPos)
     }
     else if (startPolyFound && !endPolyFound)
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: (startPolyFound && !endPolyFound)\n");
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ BuildPolyPath :: (startPolyFound && !endPolyFound)\n");
 
         // we are moving on the old path but target moved out
         // so we have atleast part of poly-path ready
@@ -357,14 +357,14 @@ void PathFinder::BuildPolyPath(const Vector3& startPos, const Vector3& endPos)
             sLog.outError("%u's Path Build failed: 0 length path", m_sourceUnit->GetGUIDLow());
         }
 
-        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++  m_polyLength=%u prefixPolyLength=%u suffixPolyLength=%u \n", m_polyLength, prefixPolyLength, suffixPolyLength);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++  m_polyLength=%u prefixPolyLength=%u suffixPolyLength=%u \n", m_polyLength, prefixPolyLength, suffixPolyLength);
 
         // new path = prefix + suffix - overlap
         m_polyLength = prefixPolyLength + suffixPolyLength - 1;
     }
     else
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: (!startPolyFound && !endPolyFound)\n");
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ BuildPolyPath :: (!startPolyFound && !endPolyFound)\n");
 
         // either we have no path at all -> first run
         // or something went really wrong -> we aren't moving along the path to the target
@@ -439,7 +439,7 @@ void PathFinder::BuildPointPath(const float* startPoint, const float* endPoint)
         // only happens if pass bad data to findStraightPath or navmesh is broken
         // single point paths can be generated here
         // TODO : check the exact cases
-        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::BuildPointPath FAILED! path sized %d returned\n", pointCount);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ PathFinder::BuildPointPath FAILED! path sized %d returned\n", pointCount);
         BuildShortcut();
         m_type = PATHFIND_NOPATH;
         return;
@@ -447,7 +447,7 @@ void PathFinder::BuildPointPath(const float* startPoint, const float* endPoint)
 
     if (pointCount == m_pointPathLimit)
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::BuildPointPath FAILED! path sized %d returned, lower than limit set to %d\n", pointCount, m_pointPathLimit);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ PathFinder::BuildPointPath FAILED! path sized %d returned, lower than limit set to %d\n", pointCount, m_pointPathLimit);
         BuildShortcut();
         m_type = PATHFIND_SHORT;
         return;
@@ -538,7 +538,7 @@ void PathFinder::BuildPointPath(const float* startPoint, const float* endPoint)
 
     NormalizePath();
 
-    DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::BuildPointPath path type %d size %d poly-size %d\n", m_type, pointCount, m_polyLength);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ PathFinder::BuildPointPath path type %d size %d poly-size %d\n", m_type, pointCount, m_polyLength);
 }
 
 void PathFinder::NormalizePath()
@@ -552,7 +552,7 @@ void PathFinder::NormalizePath()
 
 void PathFinder::BuildShortcut()
 {
-    DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::BuildShortcut :: making shortcut\n");
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_PATHFINDING, m_sourceUnit->GetObjectGuid().GetCounter(), m_sourceUnit->GetTypeId(), "++ PathFinder::BuildShortcut :: making shortcut\n");
 
     clear();
 

--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -114,7 +114,7 @@ void WaypointMovementGenerator<Creature>::OnArrived(Creature& creature)
 
     if (node.script_id)
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "Creature movement start script %u at point %u for %s.", node.script_id, i_currentNode, creature.GetGuidStr().c_str());
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_AI_AND_MOVEGENSS, creature.GetObjectGuid().GetCounter(), creature.GetTypeId(), "Creature movement start script %u at point %u for %s.", node.script_id, i_currentNode, creature.GetGuidStr().c_str());
         creature.GetMap()->ScriptsStart(sCreatureMovementScripts, node.script_id, &creature, &creature);
     }
 

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -3946,7 +3946,7 @@ void Spell::SendSpellStart() const
     if (!IsNeedSendToClient())
         return;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Sending SMSG_SPELL_START id=%u", m_spellInfo->Id);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Sending SMSG_SPELL_START id=%u", m_spellInfo->Id);
 
     uint32 castFlags = CAST_FLAG_UNKNOWN2;
     if ((m_IsTriggeredSpell && !IsAutoRepeatRangedSpell(m_spellInfo)) || m_triggeredByAuraSpell)
@@ -3981,7 +3981,7 @@ void Spell::SendSpellGo()
     if (!IsNeedSendToClient())
         return;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Sending SMSG_SPELL_GO id=%u", m_spellInfo->Id);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Sending SMSG_SPELL_GO id=%u", m_spellInfo->Id);
 
     uint32 castFlags = CAST_FLAG_UNKNOWN9;
     if ((m_IsTriggeredSpell && !IsAutoRepeatRangedSpell(m_spellInfo)) || m_triggeredByAuraSpell)
@@ -4480,7 +4480,7 @@ void Spell::HandleThreatSpells()
         // so abort when only some effects are negative.
         if ((m_negativeEffectMask & effectMask) != effectMask)
         {
-            DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell %u, rank %u, is not clearly positive or negative, ignoring bonus threat", m_spellInfo->Id, sSpellMgr.GetSpellRank(m_spellInfo->Id));
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Spell %u, rank %u, is not clearly positive or negative, ignoring bonus threat", m_spellInfo->Id, sSpellMgr.GetSpellRank(m_spellInfo->Id));
             return;
         }
         positive = false;
@@ -4513,7 +4513,7 @@ void Spell::HandleThreatSpells()
         }
     }
 
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell %u added an additional %f threat for %s " SIZEFMTD " target(s)", m_spellInfo->Id, threat, positive ? "assisting" : "harming", m_UniqueTargetInfo.size());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Spell %u added an additional %f threat for %s " SIZEFMTD " target(s)", m_spellInfo->Id, threat, positive ? "assisting" : "harming", m_UniqueTargetInfo.size());
 }
 
 void Spell::HandleEffects(Unit* pUnitTarget, Item* pItemTarget, GameObject* pGOTarget, SpellEffectIndex i, float DamageMultiplier)
@@ -4533,7 +4533,7 @@ void Spell::HandleEffects(Unit* pUnitTarget, Item* pItemTarget, GameObject* pGOT
     else
         damage = int32(CalculateDamage(i, unitTarget) * DamageMultiplier);
 
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell %u Effect%d : %u Targets: %s, %s, %s",
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Spell %u Effect%d : %u Targets: %s, %s, %s",
                      m_spellInfo->Id, i, eff,
                      unitTarget ? unitTarget->GetGuidStr().c_str() : "-",
                      itemTarget ? itemTarget->GetGuidStr().c_str() : "-",
@@ -6814,7 +6814,7 @@ void Spell::Delayed()
     else
         m_timer += delaytime;
 
-    DETAIL_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell %u partially interrupted for (%d) ms at damage", m_spellInfo->Id, delaytime);
+    DETAIL_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Spell %u partially interrupted for (%d) ms at damage", m_spellInfo->Id, delaytime);
 
     WorldPacket data(SMSG_SPELL_DELAYED, 8 + 4);
     data << m_caster->GetPackGUID();
@@ -6845,7 +6845,7 @@ void Spell::DelayedChannel()
     else
         m_timer -= delaytime;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell %u partially interrupted for %i ms, new duration: %u ms", m_spellInfo->Id, delaytime, m_timer);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Spell %u partially interrupted for %i ms, new duration: %u ms", m_spellInfo->Id, delaytime, m_timer);
 
     for (TargetList::const_iterator ihit = m_UniqueTargetInfo.begin(); ihit != m_UniqueTargetInfo.end(); ++ihit)
     {

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -379,7 +379,7 @@ Aura::Aura(SpellEntry const* spellproto, SpellEffectIndex eff, int32* currentBas
         }
     }
 
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Aura: construct Spellid : %u, Aura : %u Target : %d Damage : %d", spellproto->Id, spellproto->EffectApplyAuraName[eff], spellproto->EffectImplicitTargetA[eff], damage);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, GetTarget()->GetObjectGuid().GetCounter(), GetTarget()->GetTypeId(), "Aura: construct Spellid : %u, Aura : %u Target : %d Damage : %d", spellproto->Id, spellproto->EffectApplyAuraName[eff], spellproto->EffectImplicitTargetA[eff], damage);
 
     SetModifier(AuraType(spellproto->EffectApplyAuraName[eff]), damage, spellproto->EffectAmplitude[eff], spellproto->EffectMiscValue[eff]);
 
@@ -6027,7 +6027,7 @@ void Aura::HandleModDamageDone(bool apply, bool Real)
 
 void Aura::HandleModDamagePercentDone(bool apply, bool Real)
 {
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "AURA MOD DAMAGE type:%u negative:%u", m_modifier.m_miscvalue, m_positive ? 0 : 1);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, GetTarget()->GetObjectGuid().GetCounter(), GetTarget()->GetTypeId(), "AURA MOD DAMAGE type:%u negative:%u", m_modifier.m_miscvalue, m_positive ? 0 : 1);
     Unit* target = GetTarget();
 
     // apply item specific bonuses for already equipped weapon
@@ -6095,7 +6095,7 @@ void Aura::HandleModOffhandDamagePercent(bool apply, bool Real)
     if (!Real)
         return;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "AURA MOD OFFHAND DAMAGE");
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, GetTarget()->GetObjectGuid().GetCounter(), GetTarget()->GetTypeId(), "AURA MOD OFFHAND DAMAGE");
 
     GetTarget()->HandleStatModifier(UNIT_MOD_DAMAGE_OFFHAND, TOTAL_PCT, float(m_modifier.m_amount), apply);
 }
@@ -6625,7 +6625,7 @@ void Aura::PeriodicTick()
 
             target->CalculateDamageAbsorbAndResist(pCaster, GetSpellSchoolMask(spellProto), DOT, pdamage, &absorb, &resist, IsReflectableSpell(spellProto), IsResistableSpell(spellProto));
 
-            DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s attacked %s for %u dmg inflicted by %u",
+            DETAIL_FILTER_LOG_GUID(LOG_FILTER_PERIODIC_AFFECTS, GetCasterGuid().GetCounter(), GetCasterGuid().GetTypeId(), "PeriodicTick: %s attacked %s for %u dmg inflicted by %u",
                               GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, GetId());
 
             pCaster->DealDamageMods(target, pdamage, &absorb, DOT, spellProto);
@@ -6690,7 +6690,7 @@ void Aura::PeriodicTick()
 
             target->CalculateDamageAbsorbAndResist(pCaster, GetSpellSchoolMask(spellProto), DOT, pdamage, &absorb, &resist, IsReflectableSpell(spellProto), IsResistableSpell(spellProto));
 
-            DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s health leech of %s for %u dmg inflicted by %u abs is %u",
+            DETAIL_FILTER_LOG_GUID(LOG_FILTER_PERIODIC_AFFECTS, GetCasterGuid().GetCounter(), GetCasterGuid().GetTypeId(), "PeriodicTick: %s health leech of %s for %u dmg inflicted by %u abs is %u",
                               GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, GetId(), absorb);
 
             pCaster->DealDamageMods(target, pdamage, &absorb, DOT, spellProto);
@@ -6770,7 +6770,7 @@ void Aura::PeriodicTick()
 
             pdamage = target->SpellHealingBonusTaken(pCaster, spellProto, pdamage, DOT, GetStackAmount());
 
-            DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s heal of %s for %u health inflicted by %u",
+            DETAIL_FILTER_LOG_GUID(LOG_FILTER_PERIODIC_AFFECTS, GetCasterGuid().GetCounter(), GetCasterGuid().GetTypeId(), "PeriodicTick: %s heal of %s for %u health inflicted by %u",
                 GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, GetId());
 
             int32 gain = target->ModifyHealth(pdamage);
@@ -6856,7 +6856,7 @@ void Aura::PeriodicTick()
             // ignore non positive values (can be result apply spellmods to aura damage
             uint32 pdamage = m_modifier.m_amount > 0 ? m_modifier.m_amount : 0;
 
-            DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s power leech of %s for %u dmg inflicted by %u",
+            DETAIL_FILTER_LOG_GUID(LOG_FILTER_PERIODIC_AFFECTS, GetCasterGuid().GetCounter(), GetCasterGuid().GetTypeId(), "PeriodicTick: %s power leech of %s for %u dmg inflicted by %u",
                               GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, GetId());
 
             int32 drain_amount = target->GetPower(power) > pdamage ? pdamage : target->GetPower(power);
@@ -6947,7 +6947,7 @@ void Aura::PeriodicTick()
             // ignore non positive values (can be result apply spellmods to aura damage
             uint32 pdamage = m_modifier.m_amount > 0 ? m_modifier.m_amount : 0;
 
-            DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s energize %s for %u dmg inflicted by %u",
+            DETAIL_FILTER_LOG_GUID(LOG_FILTER_PERIODIC_AFFECTS, GetCasterGuid().GetCounter(), GetCasterGuid().GetTypeId(), "PeriodicTick: %s energize %s for %u dmg inflicted by %u",
                               GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, GetId());
 
             if (m_modifier.m_miscvalue < 0 || m_modifier.m_miscvalue >= MAX_POWERS)
@@ -6989,7 +6989,7 @@ void Aura::PeriodicTick()
 
             uint32 pdamage = uint32(target->GetMaxPower(POWER_MANA) * amount / 100);
 
-            DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s energize %s for %u mana inflicted by %u",
+            DETAIL_FILTER_LOG_GUID(LOG_FILTER_PERIODIC_AFFECTS, GetCasterGuid().GetCounter(), GetCasterGuid().GetTypeId(), "PeriodicTick: %s energize %s for %u mana inflicted by %u",
                               GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, GetId());
 
             if (target->GetMaxPower(POWER_MANA) == 0)

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -3102,7 +3102,7 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
         // Previous effect might have started script
         if (ScriptMgr::CanSpellEffectStartDBScript(m_spellInfo, eff_idx))
         {
-            DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell ScriptStart spellid %u in EffectDummy", m_spellInfo->Id);
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Spell ScriptStart spellid %u in EffectDummy", m_spellInfo->Id);
             m_caster->GetMap()->ScriptsStart(sSpellScripts, m_spellInfo->Id, m_caster, unitTarget);
         }
     }
@@ -3121,7 +3121,7 @@ void Spell::EffectTriggerSpellWithValue(SpellEffectIndex eff_idx)
         bool startDBScript = unitTarget && ScriptMgr::CanSpellEffectStartDBScript(m_spellInfo, eff_idx);
         if (startDBScript)
         {
-            DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell ScriptStart spellid %u in EffectTriggerSpell", m_spellInfo->Id);
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Spell ScriptStart spellid %u in EffectTriggerSpell", m_spellInfo->Id);
             startDBScript = m_caster->GetMap()->ScriptsStart(sSpellScripts, m_spellInfo->Id, m_caster, unitTarget);
         }
 
@@ -3278,7 +3278,7 @@ void Spell::EffectTriggerMissileSpell(SpellEffectIndex effect_idx)
     {
         if (unitTarget)
         {
-            DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell ScriptStart spellid %u in EffectTriggerMissileSpell", m_spellInfo->Id);
+            DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Spell ScriptStart spellid %u in EffectTriggerMissileSpell", m_spellInfo->Id);
             m_caster->GetMap()->ScriptsStart(sSpellScripts, m_spellInfo->Id, m_caster, unitTarget);
         }
         else
@@ -3288,7 +3288,7 @@ void Spell::EffectTriggerMissileSpell(SpellEffectIndex effect_idx)
     }
 
     if (m_CastItem)
-        DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: cast Item spellId - %i", spellInfo->Id);
+        DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "WORLD: cast Item spellId - %i", spellInfo->Id);
 
     m_caster->CastSpell(m_targets.m_destX, m_targets.m_destY, m_targets.m_destZ, spellInfo, TRIGGERED_OLD_TRIGGERED, m_CastItem, nullptr, m_originalCasterGUID, m_spellInfo);
 }
@@ -3501,7 +3501,7 @@ void Spell::EffectApplyAura(SpellEffectIndex eff_idx)
             return;
     }
 
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell: Aura is: %u", m_spellInfo->EffectApplyAuraName[eff_idx]);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Spell: Aura is: %u", m_spellInfo->EffectApplyAuraName[eff_idx]);
 
     Aura* aur = CreateAura(m_spellInfo, eff_idx, &m_currentBasePoints[eff_idx], m_spellAuraHolder, unitTarget, caster, m_CastItem);
     m_spellAuraHolder->AddAura(aur, eff_idx);
@@ -3578,7 +3578,7 @@ void Spell::EffectSendEvent(SpellEffectIndex effectIndex)
     we do not handle a flag dropping or clicking on flag in battleground by sendevent system
     TODO: Actually, why not...
     */
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell ScriptStart %u for spellid %u in EffectSendEvent ", m_spellInfo->EffectMiscValue[effectIndex], m_spellInfo->Id);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Spell ScriptStart %u for spellid %u in EffectSendEvent ", m_spellInfo->EffectMiscValue[effectIndex], m_spellInfo->Id);
 
     StartEvents_Event(m_caster->GetMap(), m_spellInfo->EffectMiscValue[effectIndex], m_caster, focusObject, true, m_caster);
 }
@@ -3770,7 +3770,7 @@ void Spell::EffectHealthLeech(SpellEffectIndex eff_idx)
     if (damage < 0)
         return;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "HealthLeech :%i", damage);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "HealthLeech :%i", damage);
 
     uint32 curHealth = unitTarget->GetHealth();
     damage = m_caster->SpellNonMeleeDamageLog(unitTarget, m_spellInfo->Id, damage);
@@ -5151,7 +5151,7 @@ void Spell::EffectAddHonor(SpellEffectIndex /*eff_idx*/)
     // 2.4.3 honor-spells don't scale with level and won't be casted by an item
     // also we must use damage+1 (spelldescription says +25 honor but damage is only 24)
     ((Player*)unitTarget)->RewardHonor(nullptr, 1, float(damage + 1));
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "SpellEffect::AddHonor (spell_id %u) rewards %u honor points (non scale) for player: %u", m_spellInfo->Id, damage, ((Player*)unitTarget)->GetGUIDLow());
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "SpellEffect::AddHonor (spell_id %u) rewards %u honor points (non scale) for player: %u", m_spellInfo->Id, damage, ((Player*)unitTarget)->GetGUIDLow());
 }
 
 void Spell::EffectSpawn(SpellEffectIndex /*eff_idx*/)
@@ -7344,7 +7344,7 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
     if (!ScriptMgr::CanSpellEffectStartDBScript(m_spellInfo, eff_idx))
         return;
 
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell ScriptStart spellid %u in EffectScriptEffect", m_spellInfo->Id);
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, m_caster->GetObjectGuid().GetCounter(), m_caster->GetTypeId(), "Spell ScriptStart spellid %u in EffectScriptEffect", m_spellInfo->Id);
     m_caster->GetMap()->ScriptsStart(sSpellScripts, m_spellInfo->Id, m_caster, unitTarget);
 }
 

--- a/src/game/Spells/SpellHandler.cpp
+++ b/src/game/Spells/SpellHandler.cpp
@@ -546,7 +546,7 @@ void WorldSession::HandleTotemDestroyed(WorldPacket& recvPacket)
 
 void WorldSession::HandleSelfResOpcode(WorldPacket& /*recv_data*/)
 {
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: CMSG_SELF_RES");                  // empty opcode
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, _player->GetObjectGuid().GetCounter(), _player->GetTypeId(), "WORLD: CMSG_SELF_RES");                  // empty opcode
 
     if (_player->GetUInt32Value(PLAYER_SELF_RES_SPELL))
     {
@@ -560,7 +560,7 @@ void WorldSession::HandleSelfResOpcode(WorldPacket& /*recv_data*/)
 
 void WorldSession::HandleGetMirrorimageData(WorldPacket& recv_data)
 {
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "WORLD: CMSG_GET_MIRRORIMAGE_DATA");
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, _player->GetObjectGuid().GetCounter(), _player->GetTypeId(), "WORLD: CMSG_GET_MIRRORIMAGE_DATA");
 
     ObjectGuid guid;
     recv_data >> guid;

--- a/src/game/Spells/SpellMgr.h
+++ b/src/game/Spells/SpellMgr.h
@@ -916,7 +916,7 @@ inline bool IsPositiveEffectTargetMode(const SpellEntry* entry, SpellEffectIndex
 
     // If we ever get to this point, we have unhandled target. Gotta say something about it.
     if (entry->Effect[effIndex])
-        DETAIL_LOG("IsPositiveEffectTargetMode: Spell %u's effect %u has unhandled targets (A:%u B:%u)", entry->Id, effIndex,
+        DETAIL_LOG("IsPositiveEffectTargetMode: Spell %u's effect %u has unhandled targets (A:%u B:%u)", entry->Id, uint32(effIndex),
                    entry->EffectImplicitTargetA[effIndex], entry->EffectImplicitTargetB[effIndex]);
     return true;
 }

--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -2618,7 +2618,7 @@ SpellAuraProcResult Unit::HandleProcTriggerDamageAuraProc(ProcExecutionData& dat
 {
     Unit* pVictim = data.victim; Aura* triggeredByAura = data.triggeredByAura;
     SpellEntry const* spellInfo = triggeredByAura->GetSpellProto();
-    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "ProcDamageAndSpell: doing %u damage from spell id %u (triggered by auratype %u of spell %u)",
+    DEBUG_FILTER_LOG_GUID(LOG_FILTER_SPELL_CAST, GetObjectGuid().GetCounter(), GetTypeId(), "ProcDamageAndSpell: doing %u damage from spell id %u (triggered by auratype %u of spell %u)",
                      triggeredByAura->GetModifier()->m_amount, spellInfo->Id, triggeredByAura->GetModifier()->m_auraname, triggeredByAura->GetId());
     SpellNonMeleeDamage damageInfo(this, pVictim, spellInfo->Id, SpellSchoolMask(spellInfo->SchoolMask));
     CalculateSpellDamage(&damageInfo, triggeredByAura->GetModifier()->m_amount, spellInfo);

--- a/src/game/VoiceChat/VoiceChatHandler.cpp
+++ b/src/game/VoiceChat/VoiceChatHandler.cpp
@@ -27,14 +27,14 @@ void WorldSession::HandleVoiceSessionEnableOpcode(WorldPacket& recv_data)
     // uint8 isVoiceEnabled, uint8 isMicrophoneEnabled
     recv_data.read_skip<uint8>();
     recv_data.read_skip<uint8>();
-    recv_data.hexlike();
+    //recv_data.hexlike();
 }
 
 void WorldSession::HandleChannelVoiceOnOpcode(WorldPacket& recv_data)
 {
     DEBUG_LOG("WORLD: CMSG_CHANNEL_VOICE_ON");
     // Enable Voice button in channel context menu
-    recv_data.hexlike();
+    //recv_data.hexlike();
 }
 
 void WorldSession::HandleSetActiveVoiceChannel(WorldPacket& recv_data)
@@ -42,5 +42,5 @@ void WorldSession::HandleSetActiveVoiceChannel(WorldPacket& recv_data)
     DEBUG_LOG("WORLD: CMSG_SET_ACTIVE_VOICE_CHANNEL");
     recv_data.read_skip<uint32>();
     recv_data.read_skip<char*>();
-    recv_data.hexlike();
+    //recv_data.hexlike();
 }

--- a/src/mangosd/CliRunnable.cpp
+++ b/src/mangosd/CliRunnable.cpp
@@ -599,23 +599,27 @@ bool ChatHandler::HandleServerLogGuidFilterCommand(char* args)
         return true;
     }
 
-    uint32 gFilter = 0;
-
-    ExtractUInt32(&args, gFilter);
-
-    if (gFilter)
+    do
     {
-        if (sLog.IsGuidFiltered(gFilter))
+        uint32 gFilter = 0;
+
+        if (!ExtractUInt32(&args, gFilter))
+            break;
+
+        if (gFilter)
         {
-            sLog.RemoveGuidFilter(gFilter);
-            PSendSysMessage("Guid(%u) removed from filter list!", gFilter);
+            if (sLog.IsGuidFiltered(gFilter))
+            {
+                sLog.RemoveGuidFilter(gFilter);
+                PSendSysMessage("Guid(%u) removed from filter list!", gFilter);
+            }
+            else
+            {
+                sLog.AddGuidFilter(gFilter);
+                PSendSysMessage("Guid(%u) added to filter list!", gFilter);
+            }
         }
-        else
-        {
-            sLog.AddGuidFilter(gFilter);
-            PSendSysMessage("Guid(%u) added to filter list!", gFilter);
-        }
-    }
+    } while (1);
     return true;
 }
 

--- a/src/mangosd/CliRunnable.cpp
+++ b/src/mangosd/CliRunnable.cpp
@@ -641,7 +641,11 @@ bool ChatHandler::HandleServerLogTypeFilterCommand(char* args)
     std::vector<std::string> validName = { "object", "item", "container", "creature", "player", "gobject", "dgobject", "corpse" };
     do
     {
-        std::string tName = ExtractLiteralArg(&args);
+        char* pName = ExtractLiteralArg(&args);
+        if (!pName)
+            break;
+
+        std::string tName(pName);
         if (tName.empty())
             break;
 
@@ -665,15 +669,15 @@ bool ChatHandler::HandleServerLogTypeFilterCommand(char* args)
             if (sLog.IsTypeFiltered(tFilter))
             {
                 sLog.RemoveTypedIdFilter(tFilter);
-                PSendSysMessage("Type %s(%u) removed from filter list!", validName.at(tFilter), tFilter);
+                PSendSysMessage("Type %s(%u) removed from filter list!", validName.at(tFilter).c_str(), tFilter);
             }
             else
             {
                 sLog.AddTypeIdFilter(tFilter);
-                PSendSysMessage("Type %s(%u) added to filter list!", validName.at(tFilter), tFilter);
+                PSendSysMessage("Type %s(%u) added to filter list!", validName.at(tFilter).c_str(), tFilter);
             }
         }
-    } while (1);
+     } while (1);
     return true;
 }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Console log might be a nightmare to read when debuging specific creature. You have to do with all loaded creature that move, melee, cast...

With this patch you are now able to select one or more object to make everything quiet but the chossen unit.

You can also filter all object type so event related to let say players will only be logged.

As some instruction are added for log and there are many call to log i also added a compilation directive so we can disable all log at once by undefining NDEBUG.
That way Release will not be impacted and can even be a little bit faster than before.

Commands added

> server log guidfilter #guid
> server log typefilter #player, creature, item, gob...
> logtarget (add selected unit to the log list)

These commands should be used with filter commands
> server log filter #filtername off

So filter filename is disabled and you are able to see log.
filtername can be "all" so in one command you can enable/disable all filters.

I think this can help alot db dev and even core dev for debugging.

### Issues
- too logs in debug mode in the console

### How2Test

You have to use ```server log filter off``` command in the console.
If you want to use following command in the game chat you have to do
```sql
UPDATE `command` SET `security`='3' WHERE `name` LIKE "server log%";
```

- Merge this code
- .server log filter all off
- .go c hogger
- select hogger as a target
- .logtarget
