### PR TITLE
Move Gong activation to stop script break

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/zulaman/zulamanScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/zulaman/zulamanScripts.cpp
@@ -414,9 +414,7 @@ struct npc_harrison_jones_zaAI : public npc_escortAI
         {
             case 1:
                 DoScriptText(SAY_AT_GONG, m_creature);
-
-                m_pInstance->DoToggleGameObjectFlags(GO_STRANGE_GONG, GO_FLAG_NO_INTERACT, false);
-
+                
                 if (GameObject* pGong = GetClosestGameObjectWithEntry(m_creature, GO_STRANGE_GONG, INTERACTION_DISTANCE))
                     m_creature->SetFacingToObject(pGong);
 
@@ -425,6 +423,7 @@ struct npc_harrison_jones_zaAI : public npc_escortAI
             case 2:
                 // Start bang gong for 2min
                 DoCastSpellIfCan(m_creature, SPELL_BANGING_THE_GONG);
+                m_pInstance->DoToggleGameObjectFlags(GO_STRANGE_GONG, GO_FLAG_NO_INTERACT, false);
                 SetEscortPaused(true);
                 break;
             case 6:


### PR DESCRIPTION
-Gong object activation is a little big to quick atm. Right now if a player clicks on it to quickly harrisons script will lockup.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Change gong object activation to part 2.

### Proof
<!-- Link resources as proof -->
- No offical proof of when the gong should or shouldn't activate aside from word of mouth.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX Harrison's script locking up if the gong is clicked on to quickly by a player
- relates #XXX
-->
- Harrison's script locking up if the gong is clicked on to quickly by a player

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Go into ZA
- Talk to Harrison, wait for him to activate the gong.
-Spam click it
-See whether he continues his script to open the gate or if he continues banging the now deactive gong.
-->
- Go into ZA
- Talk to Harrison, wait for him to activate the gong.
-Spam click it
-See whether he continues his script to open the gate or if he continues banging the now deactive gong.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
