### PR TITLE
Fix CreateAccount function error

### DIFF
--- a/src/game/Accounts/AccountMgr.cpp
+++ b/src/game/Accounts/AccountMgr.cpp
@@ -83,7 +83,20 @@ AccountOpResult AccountMgr::CreateAccount(std::string username, std::string pass
         return AOR_NAME_ALREADY_EXIST;                       // username does already exist
     }
 
-    if (!LoginDatabase.PExecute("INSERT INTO account(username,sha_pass_hash,joindate,expansion) VALUES('%s','%s',NOW(),'%u')", username.c_str(), CalculateShaPassHash(username, password).c_str(), expansion))
+    SRP6 srp;
+
+    srp.CalculateVerifier(CalculateShaPassHash(username, password));
+    const char* s_hex = srp.GetSalt().AsHexStr();
+    const char* v_hex = srp.GetVerifier().AsHexStr();
+
+    bool update_sv = LoginDatabase.PExecute(
+        "INSERT INTO account(username,v,s,joindate,expansion) VALUES('%s','%s','%s',NOW(), %u)",
+        username.c_str(), v_hex, s_hex, expansion);
+
+    OPENSSL_free((void*)s_hex);
+    OPENSSL_free((void*)v_hex);
+
+    if (!update_sv)
         return AOR_DB_INTERNAL_ERROR;                       // unexpected error
     LoginDatabase.Execute("INSERT INTO realmcharacters (realmid, acctid, numchars) SELECT realmlist.id, account.id, 0 FROM realmlist,account LEFT JOIN realmcharacters ON acctid=account.id WHERE acctid IS NULL");
 


### PR DESCRIPTION
## 🍰 Pullrequest
required commit: 44b395cee8ed8db172da32e72ae7974bc4eeb355

### Issues
Using .account create $account $password [$expansion] will cause the console to throw a SQL error.

### How2Test
Execute .account create command with specified expansion.

I think you guys forget this override function.