### PR TITLE
Fix to SPELL_AURA_ADD_TARGET_TRIGGER auras

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -7310,8 +7310,9 @@ void Spell::ProcSpellAuraTriggers()
                     SpellEntry const* auraSpellInfo = targetTrigger->GetSpellProto();
                     SpellEffectIndex auraSpellIdx = targetTrigger->GetEffIndex();
                     const uint32 procid = auraSpellInfo->EffectTriggerSpell[auraSpellIdx];
+                    const uint32 proctarget = auraSpellInfo->EffectImplicitTargetA[0];
                     // Quick target mode check for procs and triggers (do not cast at friendly targets stuff against hostiles only)
-                    if (IsPositiveSpellTargetModeForSpecificTarget(m_spellInfo, ihit->effectMask, m_caster, unit) != IsPositiveSpellTargetModeForSpecificTarget(procid, ihit->effectMask, m_caster, unit))
+                    if (IsPositiveSpellTargetModeForSpecificTarget(m_spellInfo, ihit->effectMask, m_caster, unit) != IsPositiveSpellTargetModeForSpecificTarget(procid, ihit->effectMask, m_caster, unit) && proctarget != 1)
                         continue;
                     // Calculate chance at that moment (can be depend for example from combo points)
                     int32 auraBasePoints = targetTrigger->GetBasePoints();


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Fix to multiple relics/librams/idols which have proc spells that are cast on self but are triggered by spells that hit the players target.

Currently unsure whether this will have a negative affect elsewhere. Requires someone more knowledgable to chime in.

### Proof
<!-- Link resources as proof -->
- Tome of the Lightbringer, Merciless Gladiator's Idol of Steadfastness, Brutal Gladiator's Totem of Indomitability & Idol of the Claw are three example items that don't work due to the core handling them here https://github.com/cmangos/mangos-tbc/blob/master/src/game/Spells/Spell.cpp#L7315.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
-As stated in the description it fixes the handling of a specific proc trigger instance. This change checks the whether the triggered spell has the target self flag and if so, allows for it to be cast.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
-->
- .additem 33943 Merciless Gladiator's Idol of Steadfastness
- Use Moonfire (.learn 8921)

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
