### PR TITLE
Despawn Wrath-Scryer's Felfire npcs to avoid being stuck in combat

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/arcatraz/arcatraz.h
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/arcatraz/arcatraz.h
@@ -111,6 +111,7 @@ class instance_arcatraz : public ScriptedInstance, private DialogueHelper
         uint8 m_uiKilledDefenders;
 
         GuidList m_lSkyrissEventMobsGuidList;
+        GuidList m_ChargeFelfireMobsGuidList;
 };
 
 #endif

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/arcatraz/instance_arcatraz.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/arcatraz/instance_arcatraz.cpp
@@ -159,6 +159,7 @@ void instance_arcatraz::OnCreatureCreate(Creature* pCreature)
             break;
         case NPC_WRATH_SCRYER_FELFIRE:
             m_npcEntryGuidCollection[pCreature->GetEntry()].push_back(pCreature->GetObjectGuid());
+            m_ChargetargetMobsGuidList.push_back(pCreature->GetObjectGuid());
             break;
         case NPC_BLAZING_TRICKSTER:
         case NPC_PHASE_HUNTER:
@@ -200,7 +201,18 @@ void instance_arcatraz::SetData(uint32 uiType, uint32 uiData)
 
         case TYPE_SOCCOTHRATES:
             if (uiData == DONE)
+            { 
                 DoUseDoorOrButton(GO_CORE_SECURITY_FIELD_ALPHA);
+                for (ObjectGuid& guid : m_ChargetargetMobsGuidList)
+                    if (Creature* creature = instance->GetCreature(guid))
+                        creature->ForcedDespawn();
+            }
+            if(uiData == FAIL)
+            { 
+                for (ObjectGuid& guid : m_ChargetargetMobsGuidList)
+                    if (Creature* creature = instance->GetCreature(guid))
+                        creature->ForcedDespawn();
+            }
             m_auiEncounter[uiType] = uiData;
             break;
 

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/arcatraz/instance_arcatraz.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/arcatraz/instance_arcatraz.cpp
@@ -159,7 +159,7 @@ void instance_arcatraz::OnCreatureCreate(Creature* pCreature)
             break;
         case NPC_WRATH_SCRYER_FELFIRE:
             m_npcEntryGuidCollection[pCreature->GetEntry()].push_back(pCreature->GetObjectGuid());
-            m_ChargetargetMobsGuidList.push_back(pCreature->GetObjectGuid());
+            m_ChargeFelfireMobsGuidList.push_back(pCreature->GetObjectGuid());
             break;
         case NPC_BLAZING_TRICKSTER:
         case NPC_PHASE_HUNTER:

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/arcatraz/instance_arcatraz.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/arcatraz/instance_arcatraz.cpp
@@ -203,13 +203,13 @@ void instance_arcatraz::SetData(uint32 uiType, uint32 uiData)
             if (uiData == DONE)
             { 
                 DoUseDoorOrButton(GO_CORE_SECURITY_FIELD_ALPHA);
-                for (ObjectGuid& guid : m_ChargetargetMobsGuidList)
+                for (ObjectGuid& guid : m_ChargeFelfireMobsGuidList)
                     if (Creature* creature = instance->GetCreature(guid))
                         creature->ForcedDespawn();
             }
             if(uiData == FAIL)
             { 
-                for (ObjectGuid& guid : m_ChargetargetMobsGuidList)
+                for (ObjectGuid& guid : m_ChargeFelfireMobsGuidList)
                     if (Creature* creature = instance->GetCreature(guid))
                         creature->ForcedDespawn();
             }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Wrath-Scryer's Felfire npcs do not despawn on fail or completion of the boss. This results in players staying in combat with these invisible creatures.
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Stop players getting stuck in combat with invisible spell trigger npcs

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Go into The Arcatraz and engage Wrath-Scryer Soccothrates.
- Let him do his charge spell then proceed to kill the boss.
- You are now stuck in combat.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
