### PR TITLE
Fix attacking LivingFlare

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_peninsula.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_peninsula.cpp
@@ -1326,6 +1326,7 @@ struct npc_living_flareAI : public ScriptedPetAI
         m_bCheckComplete    = false;
 
         DoCastSpellIfCan(m_creature, SPELL_LIVING_COSMETIC);
+        SetReactState(REACT_PASSIVE);
     }
 
     void ReceiveAIEvent(AIEventType eventType, Unit* /*pSender*/, Unit* /*pInvoker*/, uint32 /*uiMiscValue*/) override


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
LivingFlare pet for the quest https://www.wowhead.com/quest=11516/blast-the-gateway currently tries to attack mobs due to the petai scripts. This can result in the bug where it will stay targeting dead npcs and a host of just werid behaviour.  This change makes sure the pet is set to passive on spawn.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Makes the pet not interactive with enerny npcs, which resolves bugs to do with it trying to attack creatures aggroed on it's owner and it makes it blizzlike.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .tele throne
- .quest add 11516
- Use Sizzling Ember
- Attack a mob

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
