### PR TITLE
Fix ATTUMEN_MOUNTED not registering in JustSummon

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/boss_midnight.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/boss_midnight.cpp
@@ -169,19 +169,7 @@ struct boss_midnightAI : public ScriptedAI, public CombatActions
                 case 1: DoScriptText(SAY_APPEAR_2, pSummoned); break;
                 case 2: DoScriptText(SAY_APPEAR_3, pSummoned); break;
             }
-        }
-        else if (pSummoned->GetEntry() == NPC_ATTUMEN_MOUNTED)
-        {
-            if (!m_pInstance)
-                return;
-
-            // Smoke effect
-            pSummoned->CastSpell(pSummoned, SPELL_SPAWN_SMOKE_1, TRIGGERED_NONE);
-
-            // The summoned has the health equal to the one which has the higher HP percentage of both
-            if (Creature* pAttumen = m_pInstance->GetSingleCreatureFromStorage(NPC_ATTUMEN))
-                pSummoned->SetHealth(pAttumen->GetHealth() > m_creature->GetHealth() ? pAttumen->GetHealth() : m_creature->GetHealth());
-        }
+        }  
     }
 
     void MovementInform(uint32 uiMoveType, uint32 uiPointId) override
@@ -401,7 +389,24 @@ struct boss_attumenAI : public ScriptedAI, public CombatActions
         // Despawn Attumen on fail
         m_creature->ForcedDespawn();
     }
+    
+    void JustSummoned(Creature* pSummoned) override
+    {
+        if (pSummoned->GetEntry() == NPC_ATTUMEN_MOUNTED)
+        {
+            if (!m_pInstance)
+                return;
+            pSummoned->SetCorpseDelay(180 * MINUTE * IN_MILLISECONDS);
 
+            // Smoke effect
+            pSummoned->CastSpell(pSummoned, SPELL_SPAWN_SMOKE_1, TRIGGERED_NONE);
+
+            // The summoned has the health equal to the one which has the higher HP percentage of both
+            if (Creature* pMidnight = m_pInstance->GetSingleCreatureFromStorage(NPC_MIDNIGHT))
+                pSummoned->SetHealth(pMidnight->GetHealth() > m_creature->GetHealth() ? pMidnight->GetHealth() : m_creature->GetHealth());
+        }
+    }
+    
     void UpdateAI(const uint32 uiDiff) override
     {
         if (!m_creature->SelectHostileTarget() || !m_creature->getVictim())


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
In the current script it's trying to pick up Attun mounted in Midnights JustSummon function, however it's actually Attun that summons the mounted version of himself. Moving the code to the proper npc script resolves the issue of the code not triggering. Fixing this also leave the oppurtunity to resolve the quick corse delay. Going by the code in Creature.cpp right now boss npcs are 3 hours corpse decay, thus the reason for the three hours set in this corretion. 

### Proof
<!-- Link resources as proof -->
- https://github.com/cmangos/mangos-tbc/blob/22d87fc513e2aec47c41a3a3e19f57718c818a84/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/boss_midnight.cpp#L183
pAttun is the one casting the summon spell not Midnight

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fast corspe decay
- JustSummon code not triggering

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
-->
- .tele kara
- Fight midnight until the mounted version is summoned
- Notice how the Justsummon function for the summon npc entry isnt triggered

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
