### PR TITLE
Implement CanLoot for creature lootable flag changes

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/magisters_terrace/boss_priestess_delrissa.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/magisters_terrace/boss_priestess_delrissa.cpp
@@ -173,11 +173,10 @@ struct boss_priestess_delrissaAI : public ScriptedAI
         if (!m_pInstance)
             return;
 
-        // Remove lootable flag if the lackeys are not killed
         if (m_pInstance->GetData(TYPE_DELRISSA) == SPECIAL)
             m_pInstance->SetData(TYPE_DELRISSA, DONE);
         else
-            m_creature->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
+            m_creature->SetCanLoot(false);
     }
 
     void UpdateAI(const uint32 uiDiff) override

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/magisters_terrace/boss_priestess_delrissa.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/magisters_terrace/boss_priestess_delrissa.cpp
@@ -173,6 +173,7 @@ struct boss_priestess_delrissaAI : public ScriptedAI
         if (!m_pInstance)
             return;
 
+        // Remove lootable flag if the lackeys are not killed
         if (m_pInstance->GetData(TYPE_DELRISSA) == SPECIAL)
             m_pInstance->SetData(TYPE_DELRISSA, DONE);
         else

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/magisters_terrace/instance_magisters_terrace.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/magisters_terrace/instance_magisters_terrace.cpp
@@ -117,7 +117,7 @@ void instance_magisters_terrace::OnCreatureDeath(Creature* pCreature)
                 else if (GetData(TYPE_DELRISSA) == SPECIAL)
                 {
                     SetData(TYPE_DELRISSA, DONE);
-                    pDelrissa->SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
+                    pDelrissa->SetCanLoot(true);
                 }
             }
             break;

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/sunwell_plateau/boss_eredar_twins.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/sunwell_plateau/boss_eredar_twins.cpp
@@ -184,7 +184,7 @@ struct boss_alythessAI : public ScriptedAI
                 else
                 {
                     // Remove loot flag and cast empower
-                    m_creature->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
+                    m_creature->SetCanLoot(false);
                     DoScriptText(SAY_SACROLASH_EMPOWER, pSacrolash);
                     pSacrolash->InterruptNonMeleeSpells(true);
                     pSacrolash->CastSpell(pSacrolash, DARK_FLAME_AURA_ALYTHESS, TRIGGERED_NONE);
@@ -339,7 +339,7 @@ struct boss_sacrolashAI : public ScriptedAI
                 else
                 {
                     // Remove loot flag and cast empower
-                    m_creature->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
+                    m_creature->SetCanLoot(false);
                     DoScriptText(SAY_ALYTHESS_EMPOWER, pAlythess);
                     pAlythess->InterruptNonMeleeSpells(true);
                     pAlythess->CastSpell(pAlythess, DARK_FLAME_AURA_SCAROLASH, TRIGGERED_NONE);

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -1761,6 +1761,18 @@ void Creature::SetDeathState(DeathState s)
     }
 }
 
+void Creature::SetCanLoot(bool enable)
+{
+    if (enable)
+    {
+        m_canloot = true;
+        SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
+        ForceValuesUpdateAtIndex(UNIT_DYNAMIC_FLAGS);
+    }
+    else
+        m_canloot = false;
+}
+
 void Creature::Respawn()
 {
     RemoveCorpse();

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -711,6 +711,8 @@ class Creature : public Unit
         const char* GetNameForLocaleIdx(int32 loc_idx) const override;
 
         void SetDeathState(DeathState s) override;          // overwrite virtual Unit::SetDeathState
+        
+        void SetCanLoot(bool enable);
 
         bool LoadFromDB(uint32 guidlow, Map* map);
         virtual void SaveToDB();
@@ -858,6 +860,7 @@ class Creature : public Unit
         void SetNoLoot(bool state) { m_noLoot = state; }
         bool IsNoReputation() { return m_noReputation; }
         void SetNoReputation(bool state) { m_noReputation = state; }
+        bool GetCanLoot() const { return m_canloot; }
 
     protected:
         bool MeetsSelectAttackingRequirement(Unit* pTarget, SpellEntry const* pSpellInfo, uint32 selectFlags, SelectAttackingTargetParams params) const;
@@ -914,6 +917,7 @@ class Creature : public Unit
         bool m_noXP;
         bool m_noLoot;
         bool m_noReputation;
+        bool m_canloot;
 
         // Script logic
         bool m_ignoreRangedTargets;                         // Ignores ranged targets when picking someone to attack

--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -1016,6 +1016,10 @@ bool Loot::CanLoot(Player const* player)
     // is already looted?
     if (!lootStatus)
         return false;
+    
+    // creature set to not lootable
+    if(!((Creature*)m_lootTarget)->GetCanLoot())
+        return false;
 
     // all player that have right too loot have right to loot dropped money
     if ((lootStatus & LOOT_STATUS_CONTAIN_GOLD) != 0 || (lootStatus & LOOT_STATUS_CONTAIN_FFA) != 0)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Add logic for circumstances where we want to set a creature to not lootable flag prior to the Loot check scripts being triggered.
### Proof
<!-- Link resources as proof -->
- https://youtu.be/akFAdhZnlNs
First is without my changes.
Second is with.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Although previous code was setting the flag successfully, the loot check scripts/code would just reapply the lootable flag, resulting in the mob still being lootable to players. I figure the reason for this is due to the fact that the creature is still infact alive while the JustDied function is being triggered. As soon as it does truly die, loot conditions are checked and ultimatly the core reapplies the flag we are trying to remove. (disclaimer here, I could well be wrong :P)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .tele mgt
-.go c Priestess Delrissa
-kill Priestess before you kill her surrounding npcs
-Can you loot her? 

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
