### PR TITLE
Polymorph dismount fix

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -3750,7 +3750,7 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
             target->SetUInt32Value(UNIT_FIELD_MOUNTDISPLAYID, 16314);
 
         // polymorph case
-        if (Real && target->GetTypeId() == TYPEID_PLAYER && target->IsPolymorphed())
+        if (Real && target->GetTypeId() == TYPEID_PLAYER && GetSpellProto()->Mechanic == 17)
         {
             // for players, start regeneration after 1s (in polymorph fast regeneration case)
             // only if caster is Player (after patch 2.4.2)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Fix to dismount when a player gets polymorph. The target->IsPolymorphed() check doesnt seem to be working in this cirsumstance, I think it might be due to this check being triggered prior to the polymorph aura being applied to the target (I debugged it quite a while go, going off my memory). This change fixes it, I've had it for a good month or 2 now in my core. 

The only thing is I'm not sure if it's the best approach. This is more to highlight the problem and open possiblities for additional contribution from developers.
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes players not getting dismounted when polymorph

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Sheep mounted player (ground mount)

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
