### PR TITLE
Fix Seal of Blood getting Spell co-eff

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -1547,6 +1547,19 @@ void Unit::CalculateSpellDamage(SpellNonMeleeDamage* spellDamageInfo, int32 dama
 
     if (!pVictim)
         return;
+    
+    if (spellInfo->SpellIconID == 2293) //Seal of blood
+    {
+        bool crit = RollSpellCritOutcome(pVictim, damageSchoolMask, spellInfo);
+        // if crit add critical bonus
+        if (crit)
+        {
+            spellDamageInfo->HitInfo |= MELEE_HIT_CRIT;
+            damage = CalculateCritAmount(pVictim, damage, spellInfo);
+        }
+        spellDamageInfo->damage = damage;
+        return;
+    }
 
     if (spellInfo->HasAttribute(SPELL_ATTR_EX3_NO_DONE_BONUS))
     {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Seal of blood is getting Spell damage co-eff causing it to do crazy amounts of damage, this spell should have no co-eff. 

This is another change that may be achieved in a more efficent manner, this is just to highlight the problem, open discussion and show you my personal fix.

It's kind of unique in the sense that I think its the only spell that shouldn't have a co-eff but seems to atm and procs off melee critical chance rather than spell.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Seal of blood getting player spell bonus co-eff

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Pop seal of blood on a character with high spell bonus damage 
- hit something

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
