### PR TITLE
Dirty deeds Rogue Talent Fix

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -7682,7 +7682,7 @@ uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackTyp
         AuraList const& mOverrideClassScript = GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
         for (auto i : mOverrideClassScript)
         {
-            if (!(i->GetSpellProto() || i->GetSpellProto()->SpellIconID || spellProto->SpellFamilyName || i->GetMiscValue()))
+            if (!(i->GetSpellProto() && i->GetSpellProto()->SpellIconID && spellProto->SpellFamilyName && i->GetMiscValue()))
                 continue;
             if (!(i->GetSpellProto()->SpellIconID == 216 && i->GetMiscValue() > 6400 && i->GetMiscValue() < 6600 && spellProto->SpellFamilyName == 8))
                 continue;

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -7682,28 +7682,29 @@ uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackTyp
         AuraList const& mOverrideClassScript = GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
         for (auto i : mOverrideClassScript)
         {
-            if (!(i->isAffectedOnSpell(spellProto)))
+            if (!(i->GetSpellProto() || i->GetSpellProto()->SpellIconID || spellProto->SpellFamilyName || i->GetMiscValue()))
+                continue;
+            if (!(i->GetSpellProto()->SpellIconID == 216 && i->GetMiscValue() > 6400 && i->GetMiscValue() < 6600 && spellProto->SpellFamilyName == 8))
                 continue;
             switch (i->GetMiscValue())
             {
                 // Dirty Deeds
-                case 6427:
-                case 6428:
-                    if (pVictim->HasAuraState(AURA_STATE_HEALTHLESS_35_PERCENT))
-                    {
-                        Aura* eff0 = i->GetHolder()->m_auras[EFFECT_INDEX_0];
-                        if (!eff0)
-                        {
-                            sLog.outError("Spell structure of DD (%u) changed.", i->GetId());
-                            continue;
-                        }
-
-                        // effect 0 have expected value but in negative state
-                        DonePercent *= (-eff0->GetModifier()->m_amount + 100.0f) / 100.0f;
-                    }
-                    break;
+            case 6427:
+            case 6580:
+                if (pVictim->GetHealthPercent() < 35)
+                {
+                    DonePercent *= 1.5f;
+                }
+                break;
+            case 6428:
+            case 6579:
+                if (pVictim->GetHealthPercent() < 35)
+				{                 
+                    DonePercent *= 1.10f;
+                }
+                break;
             }
-        }
+		}
     }
 
     // final calculation


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Rogue talent isnt working at all, the current code fails to pick up the dirty deeds aura on the player.

This personal fix is pretty disgusting and could be much better but just bringing awareness to the problem and showing my personal fix. I did this change a little while ago, it works but ye it could use a revisit, I've got some unnesscary stuff in there thats for sure. At the time I was being a bit over-zelous with the notion of avoiding crashes lol.
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes rogue dirty deeds talent.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Take the talent in the Sub tree on a rogue, get a mob to less than 35% and check the damage output. Currently it does not increase.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
