### PR TITLE
Resolve darkweaver_syth adds not despawning

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/sethekk_halls/boss_darkweaver_syth.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/sethekk_halls/boss_darkweaver_syth.cpp
@@ -98,10 +98,16 @@ struct boss_darkweaver_sythAI : public ScriptedAI
             case 2: DoScriptText(SAY_AGGRO_3, m_creature); break;
         }
     }
+    
+    void JustReachedHome() override
+    {
+        m_creature->RemoveGuardians();
+    }
 
     void JustDied(Unit* /*pKiller*/) override
     {
         DoScriptText(SAY_DEATH, m_creature);
+        m_creature->RemoveGuardians();
     }
 
     void KilledUnit(Unit* /*pVictim*/) override


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
The summoned npcs during the fight seem to not despawn sometimes, and if they dont despawn they end up causing this werid bug where adds will continue to spawn until the spawned adds change to npcs I think from blackwing lair. 

This seems to work as a reliable way to get the boss spawned guardians to always despawn.
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Boss adds not despawning on kill or failed attempt

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Go into mana tombs
- Fight first boss until adds spawn
- Kill yourself and see if the adds despawn on boss evade.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
