### PR TITLE
Fix incorrectly applied stealth detection increase

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -8404,6 +8404,14 @@ float Unit::GetVisibleDistance(Unit const* target, bool alert) const
     //-Stealth Mod(positive like Master of Deception) and Stealth Detection(negative like paranoia)
     // based on wowwiki every 5 mod we have 1 more level diff in calculation
     visibleDistance += (int32(target->GetTotalAuraModifier(SPELL_AURA_MOD_STEALTH_DETECT)) - stealthMod) / 5.0f;
+    if(target->HasAura(2836)) //Remove spell Detect Traps stealth detection increase(only applies to traps)
+    {
+      if(Aura* aura = ((Player*)target)->GetAura(2836, EFFECT_INDEX_0))
+      { 
+        float detectmod = (aura->GetModifier()->m_amount) / 5.0f;
+        visibleDistance = visibleDistance - detectmod;
+      }
+    }
     visibleDistance = visibleDistance > MAX_PLAYER_STEALTH_DETECT_RANGE ? MAX_PLAYER_STEALTH_DETECT_RANGE : visibleDistance;
 
     if (visibleDistance < 1.5f)

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -8404,14 +8404,8 @@ float Unit::GetVisibleDistance(Unit const* target, bool alert) const
     //-Stealth Mod(positive like Master of Deception) and Stealth Detection(negative like paranoia)
     // based on wowwiki every 5 mod we have 1 more level diff in calculation
     visibleDistance += (int32(target->GetTotalAuraModifier(SPELL_AURA_MOD_STEALTH_DETECT)) - stealthMod) / 5.0f;
-    if(target->HasAura(2836)) //Remove spell Detect Traps stealth detection increase(only applies to traps)
-    {
-      if(Aura* aura = ((Player*)target)->GetAura(2836, EFFECT_INDEX_0))
-      { 
-        float detectmod = (aura->GetModifier()->m_amount) / 5.0f;
-        visibleDistance = visibleDistance - detectmod;
-      }
-    }
+    if(Aura* aura = ((Player*)target)->GetAura(2836, EFFECT_INDEX_0)) //Remove spell Detect Traps stealth detection increase(only applies to traps)
+        visibleDistance = visibleDistance - ((aura->GetModifier()->m_amount) / 5.0f); 
     visibleDistance = visibleDistance > MAX_PLAYER_STEALTH_DETECT_RANGE ? MAX_PLAYER_STEALTH_DETECT_RANGE : visibleDistance;
 
     if (visibleDistance < 1.5f)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Removes the increased stealth detection from Detect Traps(2836) when Unit visibility is being checked.
### Proof
<!-- Link resources as proof -->
- https://imgur.com/E83Zb6t with the Detect Trap spell learnt

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Removes non-blizzlike stealth detection caused by Detect Traps bonus being used for unit calculations rather than just the trap object.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- 2 players, both stealth, check stealth visibility for both.
- .learn 2836 on 1
- Test stealth visability again.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
