### PR TITLE
Add LOS check to Bestrial Wrath

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -7634,6 +7634,13 @@ SpellCastResult Spell::OnCheckCast(bool /*strict*/)
 {
     switch (m_spellInfo->Id)
     {
+        case 19574: //Hunter Bestrial Wrath pet LOS check
+        {
+            Pet* m_pet = m_caster->GetPet();
+            if (!m_pet || !m_pet->IsWithinLOSInMap(m_caster))
+                return SPELL_FAILED_LINE_OF_SIGHT;
+            break;
+        }
         case 603: // Curse of Doom
         case 30910:
         {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Currently even if the hunters pet is out of LOS the cast will still go off but nothing will happen.

### Proof
<!-- Link resources as proof -->
https://youtu.be/LamuL4e4Y0E?t=48 - hunter spam casts Bestrial wrath when his pet is on the other side of the pillar. Whilst the pet is out of los the spell fails (I cannot make out the exact error) asoon as the pet comes into LOS it casts as normal.
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Adds LOS cast check on hunters pet

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Be hunter. Cast 19574 whilst your pet is out of los. With change do the oppersite.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
