### PR TITLE
Fixes wrong erase operation in CreatureLinkingMgr

### DIFF
--- a/src/game/Entities/CreatureLinkingMgr.cpp
+++ b/src/game/Entities/CreatureLinkingMgr.cpp
@@ -511,7 +511,7 @@ void CreatureLinkingHolder::ProcessSlaveGuidList(CreatureLinkingEvent eventType,
         if (!pSlave)
         {
             // Remove old guid first
-            slaveGuidList.erase(slave_itr++);
+            slave_itr = slaveGuidList.erase(slave_itr);
             continue;
         }
 


### PR DESCRIPTION
Repro:
- Remove any one creature instance from Magtheridon
- Aggro, sometimes causes crash

