### PR TITLE
Ruse of the Ashtongue quest complete

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_eye/boss_alar.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_eye/boss_alar.cpp
@@ -187,11 +187,11 @@ struct boss_alarAI : public ScriptedAI
         if (m_pInstance)
             m_pInstance->SetData(TYPE_ALAR, DONE);
 
-        std::list<Player*> playerList;
-        GetPlayerListWithEntryInWorld(playerList, m_creature, 150.0f);
-        for (auto& player : playerList)
-            if (player->GetQuestStatus(QUEST_RUSE_ASHTONGUE) == QUEST_STATUS_INCOMPLETE && player->HasAura(SPELL_ASHTONGUE_RUSE))
-                player->AreaExploredOrEventHappens(QUEST_RUSE_ASHTONGUE);
+        Map::PlayerList const& players = m_pInstance->instance->GetPlayers();
+        for (const auto& player : players)
+            if (Player* pPlayer = player.getSource())
+                if (pPlayer->GetQuestStatus(QUEST_RUSE_ASHTONGUE) == QUEST_STATUS_INCOMPLETE && pPlayer->HasAura(SPELL_ASHTONGUE_RUSE))
+                    pPlayer->AreaExploredOrEventHappens(QUEST_RUSE_ASHTONGUE);
     }
 
     void JustSummoned(Creature* pSummoned) override


### PR DESCRIPTION
#🍰 Pullrequest
<!-- Describe the Pullrequest. -->
-Resolves problem with previous code which only handled players that were alive. When infact this quest should complete even if the player is dead. SPELL_ASHTONGUE_RUSE persists through death.
### Proof
<!-- Link resources as proof -->
Hard to find offical confirmation but the aura persists through death and I remember this quest personally being completed for all raid members with the aura up, dead or alive on the kill.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Dead players at encounter end (boss dies) not being picked up in current find player code

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
.quest add 10946
.tele tk
-use quest item in bags
.die on yourself
.die (alar - first boss)

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
