### PR TITLE
Warrior: Spell Reflection vs GO

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -837,20 +837,28 @@ void Spell::AddUnitTarget(Unit* target, uint8 effectMask, CheckException excepti
     // If target reflect spell back to caster
     if (targetInfo.missCondition == SPELL_MISS_REFLECT)
     {
-        // Victim reflects, apply reflect procs
-        m_caster->ProcDamageAndSpell(ProcSystemArguments(target, PROC_FLAG_NONE, PROC_FLAG_TAKEN_SPELL_MAGIC_DMG_CLASS_NEG, PROC_EX_REFLECT, 1, BASE_ATTACK, m_spellInfo));
-        // Calculate reflected spell result on caster
-        targetInfo.reflectResult =  m_caster->SpellHitResult(m_caster, m_spellInfo, targetInfo.effectMask, m_reflectable);
-        // Caster reflects back spell which was already reflected by victim
-        if (targetInfo.reflectResult == SPELL_MISS_REFLECT)
-        {
-            // Apply reflect procs on self
-            m_caster->ProcDamageAndSpell(ProcSystemArguments(m_caster, PROC_FLAG_NONE, PROC_FLAG_TAKEN_SPELL_MAGIC_DMG_CLASS_NEG, PROC_EX_REFLECT, 1, BASE_ATTACK, m_spellInfo));
-            // Full circle: it's impossible to reflect further, "Immune" shows up
-            targetInfo.reflectResult = SPELL_MISS_IMMUNE;
-        }
-        // Increase time interval for reflected spells by 1.5
-        targetInfo.timeDelay += targetInfo.timeDelay >> 1;
+        if (!m_originalCasterGUID.IsUnit())
+		{
+			target->ProcDamageAndSpell(ProcSystemArguments(nullptr, PROC_FLAG_TAKEN_SPELL_MAGIC_DMG_CLASS_NEG, PROC_FLAG_NONE , PROC_EX_REFLECT, 1, BASE_ATTACK, m_spellInfo));
+			targetInfo.reflectResult == SPELL_MISS_REFLECT;
+		}
+		else
+		{
+			// Victim reflects, apply reflect procs
+			m_caster->ProcDamageAndSpell(ProcSystemArguments(target, PROC_FLAG_NONE, PROC_FLAG_TAKEN_SPELL_MAGIC_DMG_CLASS_NEG, PROC_EX_REFLECT, 1, BASE_ATTACK, m_spellInfo));
+			// Calculate reflected spell result on caster
+			targetInfo.reflectResult = m_caster->SpellHitResult(m_caster, m_spellInfo, targetInfo.effectMask, m_reflectable);
+			// Caster reflects back spell which was already reflected by victim
+			if (targetInfo.reflectResult == SPELL_MISS_REFLECT)
+			{
+				// Apply reflect procs on self
+				m_caster->ProcDamageAndSpell(ProcSystemArguments(m_caster, PROC_FLAG_NONE, PROC_FLAG_TAKEN_SPELL_MAGIC_DMG_CLASS_NEG, PROC_EX_REFLECT, 1, BASE_ATTACK, m_spellInfo));
+				// Full circle: it's impossible to reflect further, "Immune" shows up
+				targetInfo.reflectResult = SPELL_MISS_IMMUNE;
+			}
+			// Increase time interval for reflected spells by 1.5
+			targetInfo.timeDelay += targetInfo.timeDelay >> 1;
+		}
     }
     else
         targetInfo.reflectResult = SPELL_MISS_NONE;


### PR DESCRIPTION
## 🍰 Pullrequest
Thanks to @killerwife for help
### Proof
- None
### Issues
- Resolve problem with **Spell Reflection** of **GameObject** casted spells.
**Warrior: Spell Reflection** now **nulify** GO casted spells.
### How2Test
- You need 2 characters for test ( best: Warrior and Hunter class )
1. [Hunter] Spawn **Freezing Trap** ( spellid: 14311 )
2. [Warrior] Put **Spell Reflection on** ( spellid: 23920 )
3. [Warrior] Move across trap with **Spell Reflection on**
### Todo / Checklist
- [X] None
