### PR TITLE
Fix Crystal Spire of Karabor Effect

### DIFF
--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -2499,7 +2499,7 @@ SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(ProcExecutionData& data
             else if (auraSpellInfo->Id == 40971)
             {
                 // If your target is below $s1% health
-                if (pVictim->GetHealth() > pVictim->GetMaxHealth() * triggerAmount / 100)
+                if (pVictim->GetHealth() - damage > pVictim->GetMaxHealth() * triggerAmount / 100)
                     return SPELL_AURA_PROC_FAILED;
             }
             break;


### PR DESCRIPTION
-Factors in prior hp rather than the players hp after the heal.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Fixes Crystal Spire of Karabor equip effect
### Proof
<!-- Link resources as proof -->
- As of right now it goes against the tooltip. 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Crystal Spire of Karabor bonus healing equip spell - spell=40971, checks the players hp after the heal so as of right now healing a player which is currently below 50% above 50% with one direct spell will cause the auraproc to return failed.

- This change ensures the amount healed is taken off the calculation.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .cast 40971 on yourself
- take yourself below 50% hp and then use a heal guarenteed to heal you above 50%.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
