### PR TITLE
Fix targetless pet spells

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -4786,6 +4786,7 @@ SpellCastResult Spell::CheckCast(bool strict)
         uint32 targetType = m_spellInfo->EffectImplicitTargetA[i];
         switch (targetType)
         {
+            case TARGET_UNIT_CASTER_MASTER:
             case TARGET_UNIT_CASTER: break; // never check anything
             case TARGET_UNIT_CASTER_PET: // special pet checks
             {


### PR DESCRIPTION
### 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
- Spells with TARGET_UNIT_CASTER_MASTER as their target currently require a target from the player ingame to work. A notable example is a warlocks voidwalker's sacrifice spell. Currently if you press it without a target it errors out ingame (invalid target), with a target it works fine. This is incorrect, the spell should work with or without a player target. 
- This change ensures no target is necesscary in the core spell checks.
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Spells with TARGET_UNIT_CASTER_MASTER as their spell target currently require the player(master) to have a target.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Be a warlock
- Learn Sacrifice on your voidwalker pet
- Summon voidwalker
- Try to use Sacrifice (pet spell) without a target.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
