### PR TITLE
Set DualWield & Damage On Creature Equipment Updates.

### DIFF
--- a/src/game/AI/ScriptDevAI/include/sc_creature.cpp
+++ b/src/game/AI/ScriptDevAI/include/sc_creature.cpp
@@ -363,13 +363,24 @@ void ScriptedAI::SetEquipmentSlots(bool loadDefault, int32 mainHand, int32 offHa
     }
 
     if (mainHand >= 0)
+    { 
         m_creature->SetVirtualItem(VIRTUAL_ITEM_SLOT_0, mainHand);
+        m_creature->UpdateDamagePhysical(BASE_ATTACK);            
+    }
 
     if (offHand >= 0)
+    { 
         m_creature->SetVirtualItem(VIRTUAL_ITEM_SLOT_1, offHand);
-
+        if(offHand == 1)
+            m_creature->SetCanDualWield(true);
+        else
+            m_creature->SetCanDualWield(false);
+    }
     if (ranged >= 0)
+    {
         m_creature->SetVirtualItem(VIRTUAL_ITEM_SLOT_2, ranged);
+        m_creature->UpdateDamagePhysical(RANGED_ATTACK);
+    }
 }
 
 // Hacklike storage used for misc creatures that are expected to evade of outside of a certain area.


### PR DESCRIPTION
## 🍰 Pullrequest
When a creature changes weapons or goes from not dual wielding to dual wielding. I notice that the function SetCandualWield is not being applied unless individually coded into a creatures script. This would ensure any equipment changes correctly setup a mob to dual wield or undo dual wielding whilst also ensuring correct damage ouput.

Could well be the wrong way to go about this, if anyone has any input feel free.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- One notable bosses where this comes into play is Prince in karazhan. In the second phase he equips his axes and starts dual wielding, the result is an offhand attack that does between 1-5 damage. Then when he unequips the axes in the last phase he continues to be set to dual wield which is incorrect. You can set it manually in the script but I thought a blanket check would be ideal rather than doing it individually.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Fight Prince Malchezaar in Karazhan. Without the change in P2 his offhand attack will be really low and in P3 he will still continue to do dual attacks with his fists.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- See if theres a blanket way to apply 
SetCanDualWield(true); - If dualwielding.
&
UpdateDamagePhysical(BASE_ATTACK);
on creature spawn if they have equipment/dualW. Princes axe being a good example, right now without doing the above code on spawn it to will do both a 1-4 damage offhand and mainhand attack. Also occurs with ranged equipment, one example being the Ambushers during the Lurker Below fight in SSC.
