### PR TITLE
Fix Traps -> Ignore Totems

### DIFF
--- a/src/game/Grids/GridNotifiers.h
+++ b/src/game/Grids/GridNotifiers.h
@@ -894,6 +894,10 @@ namespace MaNGOS
             WorldObject const& GetFocusObject() const { return *i_obj; }
             bool operator()(Unit* u) const
             {
+                // ignore totems
+                if (u->GetTypeId() == TYPEID_UNIT && ((Creature*)u)->IsTotem())
+                    return false;
+                
                 return u->isAlive() && i_obj->CanAttackSpell(u) && i_obj->IsWithinDistInMap(u, i_range) && i_obj->IsWithinLOSInMap(u);
             }
         private:


### PR DESCRIPTION


## 🍰 Pullrequest
Thanks to @killerwife for help

### Proof
- None

### Issues
**Traps** will no longer trigger on **totems**.
https://github.com/cmangos/issues/issues/1817

### How2Test
- You need 2 characters for test ( best: Shaman and Hunter class )
1. [Shaman] Spawn any type of totem, for example **Stoneskin Totem** ( spellid: 25509 )
2. [Hunter] Spawn any type of trap, for example **Freezing Trap** ( spellid: 14311 ) on position of trap **Result:** Trap will ignoring totem
### Todo / Checklist
- [X] None
