### PR TITLE
Fix failure to update GUARDIAN_PET damage stats.

### DIFF
--- a/src/game/Entities/Pet.cpp
+++ b/src/game/Entities/Pet.cpp
@@ -1417,7 +1417,7 @@ void Pet::InitStatsForLevel(uint32 petlevel)
         case GUARDIAN_PET:
         {
             SelectLevel(petlevel);  // guardians reuse CLS function SelectLevel, so we stop here
-            return;
+            break;
         }
         default:
             sLog.outError("Pet have incorrect type (%u) for level handling.", getPetType());


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
GUARDIAN_PET's are doing 1-3 damage right now due to a return where a break should be.
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes all GUARDIAN_PET doing between 1-3 damage.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Summon treants as a boomkin.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
