### PR TITLE
Fix Screaming Hall Door in Shadow Labyrinth

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -239,6 +239,7 @@ UPDATE creature_template SET ScriptName='boss_grandmaster_vorpil' WHERE entry=18
 UPDATE creature_template SET ScriptName='boss_blackheart_the_inciter' WHERE entry=18667;
 UPDATE creature_template SET ScriptName='boss_ambassador_hellmaw' WHERE entry=18731;
 UPDATE creature_template SET ScriptName='npc_void_traveler' WHERE entry=19226;
+UPDATE gameobject_template SET ScriptName='go_screaming_hall_door' WHERE entry=183295;
 
 /* AZSHARA */
 UPDATE creature_template SET ScriptName='npc_rizzle_sprysprocket' WHERE entry=23002;

--- a/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/instance_shadow_labyrinth.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/instance_shadow_labyrinth.cpp
@@ -190,14 +190,12 @@ InstanceData* GetInstanceData_instance_shadow_labyrinth(Map* pMap)
     return new instance_shadow_labyrinth(pMap);
 }
 
-
 struct go_screaming_hall_door : public GameObjectAI
 {
-    go_screaming_hall_door(GameObject* go) : GameObjectAI(go)
-    {
-        m_doorCheckNearbyPlayersTimer = 1000;
-        m_doorOpen = false;
-    }
+    go_screaming_hall_door(GameObject* go) : GameObjectAI(go), 
+        m_doorCheckNearbyPlayersTimer(1000), 
+        m_doorOpen(false)
+    {}
 
     uint32 m_doorCheckNearbyPlayersTimer;
     bool m_doorOpen;
@@ -216,7 +214,6 @@ struct go_screaming_hall_door : public GameObjectAI
                 {
                     m_go->Use(player);
                     m_doorOpen = true;
-
                 });
             }
             m_doorCheckNearbyPlayersTimer = 1000;

--- a/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/instance_shadow_labyrinth.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/instance_shadow_labyrinth.cpp
@@ -90,8 +90,6 @@ void instance_shadow_labyrinth::SetData(uint32 uiType, uint32 uiData)
             break;
 
         case TYPE_VORPIL:
-            if (uiData == DONE)
-                // DoUseDoorOrButton(GO_SCREAMING_HALL_DOOR); should be handled when players move close to -166.0127, -270.3628, 17.0875, SMSG_UPDATE_WORLD_STATE VariableID: 13437 - Value: 247303520
             m_auiEncounter[2] = uiData;
             break;
 
@@ -192,10 +190,56 @@ InstanceData* GetInstanceData_instance_shadow_labyrinth(Map* pMap)
     return new instance_shadow_labyrinth(pMap);
 }
 
+
+struct go_screaming_hall_door : public GameObjectAI
+{
+    go_screaming_hall_door(GameObject* go) : GameObjectAI(go)
+    {
+        m_doorCheckNearbyPlayersTimer = 1000;
+        m_doorOpen = false;
+    }
+
+    uint32 m_doorCheckNearbyPlayersTimer;
+    bool m_doorOpen;
+
+    void UpdateAI(const uint32 diff) override
+    {
+        if (m_doorOpen)
+            return;
+
+        if (m_doorCheckNearbyPlayersTimer <= diff)
+        {
+            // If player is in 35y range of door, open it if Vorpil boss is done
+            if (m_go->GetInstanceData()->GetData(TYPE_VORPIL) == DONE)
+            {
+                m_go->GetMap()->ExecuteDistWorker(m_go, 35.0f, [&](Player * player)
+                {
+                    m_go->Use(player);
+                    m_doorOpen = true;
+
+                });
+            }
+            m_doorCheckNearbyPlayersTimer = 1000;
+        }
+        else
+            m_doorCheckNearbyPlayersTimer -= diff;
+    }
+};
+
+GameObjectAI* GetAIgo_screaming_hall_door(GameObject* go)
+{
+    return new go_screaming_hall_door(go);
+}
+
 void AddSC_instance_shadow_labyrinth()
 {
     Script* pNewScript = new Script;
     pNewScript->Name = "instance_shadow_labyrinth";
     pNewScript->GetInstanceData = &GetInstanceData_instance_shadow_labyrinth;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "go_screaming_hall_door";
+    pNewScript->GetGameObjectAI = &GetAIgo_screaming_hall_door;
     pNewScript->RegisterSelf();
 }

--- a/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/shadow_labyrinth.h
+++ b/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/shadow_labyrinth.h
@@ -23,7 +23,7 @@ enum
     NPC_CONTAINMENT_BEAM    = 21159,
 
     GO_REFECTORY_DOOR       = 183296,                       // door opened when blackheart the inciter dies
-    GO_SCREAMING_HALL_DOOR  = 183295,                       // door opened when grandmaster vorpil dies
+    GO_SCREAMING_HALL_DOOR  = 183295,                       // door opened when grandmaster vorpil dies and player comes in range
 
     SAY_HELLMAW_INTRO       = -1555000,
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Currently the  Screaming Hall Door in Shadow Labyrinth does not open automaticly nor players are able to click on it to open it manually, so it is not possible to get to murmur.
The door now checks every second if a player is in range and if so, it would be opened.

### Proof
<!-- Link resources as proof -->
https://youtu.be/LujKi3oJAq0?t=559 (no tbc vid, but it is visible when the door should be opened)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
