### PR TITLE
Fix Seal of Rightousness Spell Coeff/Damage.

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -6945,7 +6945,7 @@ int32 Unit::SpellBonusWithCoeffs(SpellEntry const* spellProto, int32 total, int3
     // Not apply this to creature casted spells
     if (GetTypeId() == TYPEID_UNIT && !((Creature*)this)->IsPet())
         coeff = 1.0f;
-    // Check for table values
+    // For Seal of Rightousness
     else if(spellProto->SpellVisual == 7986)
     {
         Item* item = ((Player*)this)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
@@ -6956,6 +6956,7 @@ int32 Unit::SpellBonusWithCoeffs(SpellEntry const* spellProto, int32 total, int3
         else
             coeff = .092f * speed;
     }
+    // Check for table values
     else if (SpellBonusEntry const* bonus = sSpellMgr.GetSpellBonusData(spellProto->Id))
     {
         coeff = damagetype == DOT ? bonus->dot_damage : bonus->direct_damage;

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -6946,6 +6946,16 @@ int32 Unit::SpellBonusWithCoeffs(SpellEntry const* spellProto, int32 total, int3
     if (GetTypeId() == TYPEID_UNIT && !((Creature*)this)->IsPet())
         coeff = 1.0f;
     // Check for table values
+    else if(spellProto->SpellVisual == 7986)
+    {
+        Item* item = ((Player*)this)->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+        float speed = (item ? item->GetProto()->Delay : BASE_ATTACK_TIME) / 1000.0f;
+
+        if (item && item->GetProto()->InventoryType == INVTYPE_2HWEAPON)
+            coeff = .108f * speed;
+        else
+            coeff = .092f * speed;
+    }
     else if (SpellBonusEntry const* bonus = sSpellMgr.GetSpellBonusData(spellProto->Id))
     {
         coeff = damagetype == DOT ? bonus->dot_damage : bonus->direct_damage;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Seal of Rightousness co-eff is way off as noted by Dramatime here-
https://github.com/cmangos/issues/issues/2022

Although I cleaned up Dramatimes version of the code to be less bloated and rely on spellvisual rather than spell ids, the investigation and fix is credited to him. 
### Proof
<!-- Link resources as proof -->
- https://github.com/cmangos/issues/issues/2022

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Seal of Rightousness co-eff/damage

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Pop Seal of Rightousness and attack. Holy spell power required.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
