### PR TITLE
Tree of life passive bonus to work with Swiftmend

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -3988,7 +3988,10 @@ void Spell::EffectHeal(SpellEffectIndex eff_idx)
             int32 tickcount = GetSpellDuration(targetAura->GetSpellProto()) / targetAura->GetSpellProto()->EffectAmplitude[idx];
 
             unitTarget->RemoveAurasByCasterSpell(targetAura->GetId(), targetAura->GetCasterGuid());
-
+            
+            if(unitTarget->HasAura(34123)) //Tree Of Life Bonus Heal Passive
+                addhealth += int32(m_caster->GetStat(STAT_SPIRIT) / 4);
+            
             addhealth += tickheal * tickcount;
         }
         else if (m_spellInfo->SpellFamilyName == SPELLFAMILY_POTION)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Heals from swiftmend are currently not taking into account the tree of life aura bonus where 25% of the tree formed healer's total spirit should be included onto the swiftmend heal amount as a bonus.
### Proof
<!-- Link resources as proof -->
- https://imgur.com/a/wb3zjYz **Without** the fix. First not in tree form, second in tree form.
- https://imgur.com/a/zX3Dvm5 **With** the fix. First is in tree form second without. (differnet char to first - base spirit count is 133)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Swiftmend heal not taking into account tree of life healing bonus

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Go druid, learn treeform
- Cast tree form, pop a rejuv and use swiftmend instantly. See heal.
- Repeat steps without going into treeform.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
