### PR TITLE
Quest-The Fel and the Furious-Object Activation

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -8404,7 +8404,7 @@ void Spell::EffectActivateObject(SpellEffectIndex eff_idx)
                     gameObjTarget->SendGameObjectCustomAnim(gameObjTarget->GetObjectGuid());
                     break;
                 case 38054:
-                    gameObjTarget->Use(m_caster);
+                    gameObjTarget->Use(m_caster->GetCharmer());
                     break;
                 default:
                 {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
https://tbcdb.com/?quest=10613

Player takes control of a Felreaver and uses spell https://tbcdb.com/?spell=38055 which triggers https://tbcdb.com/?spell=38054.

Activating the object grants the quest progress however as it is right now the felreaver being control uses(activates the object) not the player, so no quest progress is granted. This code ensures the gameobject use is coming from the player rather than the controlled creature.
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Charmed creature activates quest objective rather than player, resulting in no quest progress.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- take quest 10613
- Take control of felreaver
- Use the fire missle spell, you will see it activate a random stoned infernal, but no progress towards the quest will be given to the player.
- To the same test with this code and the player will now get progress towards quest completion.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
