### PR TITLE
 Fix ending for quest "Force Commander Danath"

### DIFF
--- a/sql/updates/mangos/s2398_02_mangos_quest_fix.sql
+++ b/sql/updates/mangos/s2398_02_mangos_quest_fix.sql
@@ -1,0 +1,4 @@
+INSERT INTO `script_texts` (`entry`, `content_default`, `comment`) VALUES ('-1999930', 'Welcome to Honor Hold, $n.  It\'s good to have you.', 'Force Commander Danath Trollbane (Entry: 16819)');
+DELETE FROM dbscript_string WHERE entry = "2000001300";
+DELETE FROM dbscripts_on_quest_end WHERE id = "10254";
+UPDATE quest_template SET CompleteScript = "0" WHERE entry = "10254";

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_peninsula.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_peninsula.cpp
@@ -1490,10 +1490,15 @@ enum
 
     MAX_SEARCH_DIST = 2170,
 
-    OBJECT_MAGTHERIDONS_HEAD = 184640
+    OBJECT_MAGTHERIDONS_HEAD = 184640,
 
     //	NPC_DANATH_TROLLBANE = 16819,
     //	NPC_NAZGREL = 3230
+
+    // More Danath Trollbane Quest Scripts
+    QUEST_FORCE_COMMANDER_DANATH = 10254,
+    SAY_TROLLBANE_1 = -1999930,
+    SPELL_SALUTE = 6245
 };
 
 // 16819/force-commander-danath-trollbane
@@ -1552,6 +1557,7 @@ struct npc_danath_trollbaneAI : public ScriptedAI
 
     void ReceiveAIEvent(AIEventType eventType, Unit* pSender, Unit* pInvoker, uint32 /*miscValue*/) override
     {
+        // Quest Magtheridon
         if (eventType == AI_EVENT_START_EVENT && pSender == m_creature) // sanity check
             if (!m_bYelling) // don't override anything if yelling already...
             {
@@ -1560,6 +1566,13 @@ struct npc_danath_trollbaneAI : public ScriptedAI
                 m_guidInvoker = pInvoker->GetObjectGuid();
                 m_bYelling = true;
             }
+
+        // Quest Force Commander Danath
+        if (eventType == AI_EVENT_CUSTOM_A && pSender == m_creature) // sanity check
+        {
+            DoScriptText(SAY_TROLLBANE_1, m_creature, pInvoker);
+            DoCastSpellIfCan(m_creature, SPELL_SALUTE);
+        }
     }
 };
 
@@ -1569,6 +1582,11 @@ bool QuestComplete_npc_trollbane(Player* pPlayer, Creature* pCreature, const Que
     {
         // And trigger yelling
         pCreature->AI()->SendAIEvent(AI_EVENT_START_EVENT, pPlayer, pCreature);
+    }
+
+    if (pQuest->GetQuestId() == QUEST_FORCE_COMMANDER_DANATH)
+    {
+        pCreature->AI()->SendAIEvent(AI_EVENT_CUSTOM_A, pPlayer, pCreature);
     }
 
     return true;


### PR DESCRIPTION
The database ending script gets blocked from core cause it already use QuestComplete via script.

## 🍰 Pullrequest
Script the ending for Quest Force Commander Danath via Core.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
