### PR TITLE
Add cannot dodge while casting.

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -2964,7 +2964,7 @@ bool Unit::CanDodgeInCombat() const
 
 bool Unit::CanDodgeInCombat(const Unit* attacker) const
 {
-    if (!attacker || !CanDodgeInCombat())
+    if (!attacker || !CanDodgeInCombat() || IsNonMeleeSpellCasted(false))
         return false;
     // Players can't dodge attacks from behind
     if (GetTypeId() == TYPEID_PLAYER)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Right now players can dodge attacks while casting. This is incorrect.
### Proof
<!-- Link resources as proof -->
- https://www.mmo-champion.com/threads/607978-dodge-while-ur-casting
- https://www.wowhead.com/forums&topic=86262

Struggling to find official proof but it seems common knowledge from people now and back in the day that this is the case. Similar to parry and blocking whilst casting.
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Dodging attacks while casting.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- ".lookup spell dodge"
- Grab all the related dodge increase spells. Cast spells on an attacking mob.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
