### PR TITLE
Fix Totem of Spirit core crash

### DIFF
--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -949,7 +949,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(ProcExecutionData& data)
                     // aura only affect the spirit totem, since this is the one that need to be in range.
                     // It is possible though, that player is the one who should actually have the aura
                     // and check for presense of spirit totem, but then we can't script the dummy.
-                    if (!pCaster->IsPet())
+                    if (!pCaster || !pCaster->IsPet())
                         return SPELL_AURA_PROC_FAILED;
 
                     // Summon the soul of the spirit and cast the visual


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Seems a nullptr is being produced in this set of code.
`Creature* pCaster = dynamic_cast<Creature*>(triggeredByAura->GetCaster());`

### Proof
<!-- Link resources as proof -->

```
DetailID = 1
	Count:    2
	Exception #:  0XC0000005
	Stack:        
		mangosd!Creature::IsPet [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\entities\creature.h @ 584]
		mangosd!Unit::HandleDummyAuraProc+0x7db [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\spells\unitauraprochandler.cpp @ 948]
		mangosd!Unit::ProcDamageAndSpellFor+0x2af [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\spells\unitauraprochandler.cpp @ 543]
		mangosd!Unit::ProcDamageAndSpell+0xa6 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\spells\unitauraprochandler.cpp @ 447]
		mangosd!Unit::Kill+0x3c4 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\entities\unit.cpp @ 1039]
		mangosd!Unit::DealDamage+0x511 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\entities\unit.cpp @ 961]
		mangosd!Unit::DealSpellDamage+0x275 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\entities\unit.cpp @ 1748]
		mangosd!Spell::DoAllEffectOnTarget+0x699 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\spells\spell.cpp @ 1102]
		mangosd!Spell::handle_delayed+0x6d [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\spells\spell.cpp @ 3413]
		mangosd!SpellEvent::Execute+0xc6 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\spells\spell.cpp @ 7633]
		mangosd!EventProcessor::Update+0xb7 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\framework\utilities\eventprocessor.cpp @ 47]
		mangosd!Unit::Update+0x82 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\entities\unit.cpp @ 460]
		mangosd!Creature::Update+0x335 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\entities\creature.cpp @ 645]
		mangosd!Pet::Update+0x165 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\entities\pet.cpp @ 734]
		mangosd!Map::Update+0x61e [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\maps\map.cpp @ 684]
		mangosd!MapManager::Update+0x79 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\maps\mapmanager.cpp @ 187]
		mangosd!World::Update+0x219 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\game\world\world.cpp @ 1509]
		mangosd!WorldRunnable::run+0x68 [d:\mangos compile\github\targetingrework\mangos-tbc-master\src\mangosd\worldrunnable.cpp @ 65]
		mangosd!std::_Invoker_functor::_Call+0x6 [c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.16.27023\include\type_traits @ 16707566]
		mangosd!std::invoke+0x6 [c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.16.27023\include\type_traits @ 16707566]
		mangosd!std::_LaunchPad<std::unique_ptr<std::tuple<void (__cdecl*)(void *),void *>,std::default_delete<std::tuple<void (__cdecl*)(void *),void *> > > >::_Execute+0x6 [c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.16.27023\include\thr\xthread @ 238]
		mangosd!std::_LaunchPad<std::unique_ptr<std::tuple<void (__cdecl*)(void *),void *>,std::default_delete<std::tuple<void (__cdecl*)(void *),void *> > > >::_Run+0x52 [c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.16.27023\include\thr\xthread @ 245]
		mangosd!std::_LaunchPad<std::unique_ptr<std::tuple<void (__cdecl*)(void *),void *>,std::default_delete<std::tuple<void (__cdecl*)(void *),void *> > > >::_Go+0x69 [c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.16.27023\include\thr\xthread @ 230]
		mangosd!std::_Pad::_Call_func+0x9 [c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.16.27023\include\thr\xthread @ 209]
		ucrtbase!o__realloc_base+0x60
		KERNEL32!BaseThreadInitThunk+0x22
		ntdll!RtlUserThreadStart+0x34


```


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fix core crash

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Not 100% sure how to replicate. 

This totem doesnt have a spell area restriction which it probz needs as well. So on my server people can pop it anyway which is probz faciliating the core crash. I've also put a entry in spell_area for the totem spawn spell (36107), as to restrict to the Shadowmoon Valley.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
