### PR TITLE
Fix distance checks to reach all caged orcs

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/blood_furnace/instance_blood_furnace.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/blood_furnace/instance_blood_furnace.cpp
@@ -220,7 +220,7 @@ void instance_blood_furnace::OnPlayerEnter(Player* /*player*/)
                 {
                     if (GameObject* pDoor = instance->GetGameObject(m_aBroggokEvent[i].m_cellGuid))
                     {
-                        if (pOrc->IsWithinDistInMap(pDoor, 5.0f) && pOrc->GetPositionZ() < 10.0f)
+                        if (pOrc->IsWithinDistInMap(pDoor, 15.0f) && pOrc->GetPositionZ() < 15.0f)
                         {
                             pOrc->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE); // ones in cages
                             pOrc->setFaction(14); // sniffed value
@@ -387,7 +387,7 @@ void instance_blood_furnace::DoSortBroggokOrcs()
             {
                 if (GameObject* pDoor = instance->GetGameObject(i.m_cellGuid))
                 {
-                    if (pOrc->IsWithinDistInMap(pDoor, 5.0f) && pOrc->GetPositionZ() < 10.0f)
+                    if (pOrc->IsWithinDistInMap(pDoor, 15.0f) && pOrc->GetPositionZ() < 15.0f)
                     {
                         i.m_sSortedOrcGuids.insert(pOrc->GetObjectGuid());
                         if (!pOrc->isAlive())


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Right now the checks are to short, only the orcs up against the gate are being selected. The result is back orcs that can be aggro'd which causes some hilarious buggy interaction whereas all the orcs in that cage will aggro, including the one that isn't selectable, a new friend some would say, a combat bug others. Either way this resolves the issue.
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- as described above

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
- Go to third boss in Blood Furnace, notice how you can target the orcs furtherest in the back of the cages.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
