### PR TITLE
Add SelectFlag forr Interupts (check for casting players)

### DIFF
--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -1700,6 +1700,11 @@ inline Unit* CreatureEventAI::GetTargetByType(uint32 target, Unit* actionInvoker
             if (!resTarget)
                 isError = true;
             return resTarget;
+        case TARGET_T_HOSTILE_RANDOM_CASTING:
+            resTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, forSpellId, SELECT_FLAG_PLAYER_CASTING | selectFlags);
+            if (!resTarget)
+                isError = true;
+            return resTarget;
         case TARGET_T_ACTION_INVOKER:
             if (!actionInvoker)
                 isError = true;

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -181,6 +181,7 @@ enum Target
     TARGET_T_HOSTILE_RANDOM_MANA            = 16,           // Random target with mana
     TARGET_T_NEAREST_AOE_TARGET             = 17,           // Nearest target for aoe
     TARGET_T_HOSTILE_FARTHEST_AWAY          = 18,           // Farthest away target, excluding melee range
+    TARGET_T_HOSTILE_RANDOM_CASTING         = 19,           // Casting Target
 };
 
 enum EventFlags : uint32

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -2193,6 +2193,9 @@ bool Creature::MeetsSelectAttackingRequirement(Unit* pTarget, SpellEntry const* 
         if ((selectFlags & SELECT_FLAG_IN_LOS) && !IsWithinLOSInMap(pTarget))
             return false;
 
+        if ((selectFlags & SELECT_FLAG_PLAYER_CASTING) && !pTarget->IsNonMeleeSpellCasted(false))
+            return false;
+
         if (!pTarget->isAlive())
             return false;
 

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -383,6 +383,7 @@ enum SelectFlags
     SELECT_FLAG_POWER_NOT_MANA      = 0x1000,               // Used in some dungeon encounters
     SELECT_FLAG_USE_EFFECT_RADIUS   = 0x2000,               // For AOE targeted abilities which have correct data in effect index 0
     SELECT_FLAG_SKIP_TANK           = 0x4000,               // Not getVictim - tank is not always top threat
+    SELECT_FLAG_PLAYER_CASTING      = 0x8000,               // For Interupts on casting targets
     SELECT_FLAG_SKIP_CUSTOM         =0x10000,               // skips custom target
 };
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Adding new flag for SelectAttackingTarget. This is getting used from mobs that use interupt spells like pummel/silence on Players that are casting spells.
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
