### PR TITLE
Fix temp weapon enchant proccing from bleeds

### DIFF
--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -449,7 +449,7 @@ void Unit::ProcDamageAndSpell(ProcSystemArguments&& data)
     if (data.attacker)
     {
 		// trigger weapon enchants for weapon based spells; exclude spells that stop attack, because may break CC
-		if (data.attacker->GetTypeId() == TYPEID_PLAYER && (data.procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)) != 0 && (data.procFlagsAttacker == PROC_FLAG_SUCCESSFUL_MELEE_HIT || data.attType == OFF_ATTACK))
+		if (data.attacker->GetTypeId() == TYPEID_PLAYER && (data.procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)) != 0 && data.procFlagsAttacker != PROC_FLAG_ON_DO_PERIODIC)
 			if (!data.procSpell || (data.procSpell->EquippedItemClass == ITEM_CLASS_WEAPON && !data.procSpell->HasAttribute(SPELL_ATTR_STOP_ATTACK_TARGET)))
 				static_cast<Player*>(data.attacker)->CastItemCombatSpell(data.victim, data.attType, data.procSpell ? !IsNextMeleeSwingSpell(data.procSpell) : false);
         data.attacker->m_spellProcsHappening = false;

--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -449,7 +449,7 @@ void Unit::ProcDamageAndSpell(ProcSystemArguments&& data)
     if (data.attacker)
     {
 		// trigger weapon enchants for weapon based spells; exclude spells that stop attack, because may break CC
-		if (data.attacker->GetTypeId() == TYPEID_PLAYER && (data.procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)) != 0)
+		if (data.attacker->GetTypeId() == TYPEID_PLAYER && (data.procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)) != 0 && data.procFlagsAttacker == 4)
 			if (!data.procSpell || (data.procSpell->EquippedItemClass == ITEM_CLASS_WEAPON && !data.procSpell->HasAttribute(SPELL_ATTR_STOP_ATTACK_TARGET)))
 				static_cast<Player*>(data.attacker)->CastItemCombatSpell(data.victim, data.attType, data.procSpell ? !IsNextMeleeSwingSpell(data.procSpell) : false);
         data.attacker->m_spellProcsHappening = false;

--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -449,7 +449,7 @@ void Unit::ProcDamageAndSpell(ProcSystemArguments&& data)
     if (data.attacker)
     {
 		// trigger weapon enchants for weapon based spells; exclude spells that stop attack, because may break CC
-		if (data.attacker->GetTypeId() == TYPEID_PLAYER && (data.procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)) != 0 && data.procFlagsAttacker == 4)
+		if (data.attacker->GetTypeId() == TYPEID_PLAYER && (data.procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)) != 0 && (data.procFlagsAttacker == 4 || data.attType == OFF_ATTACK))
 			if (!data.procSpell || (data.procSpell->EquippedItemClass == ITEM_CLASS_WEAPON && !data.procSpell->HasAttribute(SPELL_ATTR_STOP_ATTACK_TARGET)))
 				static_cast<Player*>(data.attacker)->CastItemCombatSpell(data.victim, data.attType, data.procSpell ? !IsNextMeleeSwingSpell(data.procSpell) : false);
         data.attacker->m_spellProcsHappening = false;

--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -449,7 +449,7 @@ void Unit::ProcDamageAndSpell(ProcSystemArguments&& data)
     if (data.attacker)
     {
 		// trigger weapon enchants for weapon based spells; exclude spells that stop attack, because may break CC
-		if (data.attacker->GetTypeId() == TYPEID_PLAYER && (data.procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)) != 0 && (data.procFlagsAttacker == 4 || data.attType == OFF_ATTACK))
+		if (data.attacker->GetTypeId() == TYPEID_PLAYER && (data.procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)) != 0 && (data.procFlagsAttacker == PROC_FLAG_SUCCESSFUL_MELEE_HIT || data.attType == OFF_ATTACK))
 			if (!data.procSpell || (data.procSpell->EquippedItemClass == ITEM_CLASS_WEAPON && !data.procSpell->HasAttribute(SPELL_ATTR_STOP_ATTACK_TARGET)))
 				static_cast<Player*>(data.attacker)->CastItemCombatSpell(data.victim, data.attType, data.procSpell ? !IsNextMeleeSwingSpell(data.procSpell) : false);
         data.attacker->m_spellProcsHappening = false;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Right now crippling poisen can be procced from bleed effects when crippling poisen is set on the main hand, not the off hand. Properly affects windfury as well or similar temp weapon enchants.

This change ensures the attack is from a melee weapon rather than a dot spell.
### Proof
<!-- Link resources as proof -->
![image](https://user-images.githubusercontent.com/47720837/75612818-26b91900-5b1f-11ea-9ed4-c655370b263e.png)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Weapon enchant proccing when it shouldnt be

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- add crippling posien to the main hand of your weapon, get it to proc on a mob and then put rupture on the mob. Dont attack and watch as the rupture will refresh crippling poisen.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
