### PR TITLE
Add removal of Broken Pack on Kilrek spawn

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/boss_terestian_illhoof.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/boss_terestian_illhoof.cpp
@@ -235,6 +235,7 @@ struct boss_terestianAI : public ScriptedAI, public CombatActions
                 m_kilrekGuid = pSummoned->GetObjectGuid();
                 if (m_creature->isInCombat())
                     pSummoned->SetInCombatWithZone();
+                m_creature->RemoveAurasDueToSpell(SPELL_BROKEN_PACT);
                 break;
             case NPC_DEMONCHAINS:
                 pSummoned->CastSpell(pSummoned, SPELL_DEMON_CHAINS, TRIGGERED_NONE);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Currently Broken Pact is staying on the boss after the first Kilrek kill. It's missing the removeal on the respawns.
### Proof
<!-- Link resources as proof -->
- https://youtu.be/yaYM17AZtbc - If's really shitty quality but you can see the buff go onto the boss on the first Kilrek kill and then disappears once it's resummoned. 
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Broken Pack should be removed on Kil'rek summon.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Engage Illhoof, kill Kilrek to have Broken Pact be cast onto the boss. Wait Kil'rek to be resummoned and witness Broken Pact still being present on the boss.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
