### PR TITLE
Arathi Bassin flag debug proposal

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -1550,13 +1550,18 @@ void BattleGround::SpawnBGObject(ObjectGuid guid, uint32 respawntime)
         return;
     if (respawntime == 0)
     {
-        // we need to change state from GO_JUST_DEACTIVATED to GO_READY in case battleground is starting again
+        obj->Respawn(); // respawn => SetRespawnTime(0);
+        if (obj->GetGoType() == GAMEOBJECT_TYPE_BUTTON)
+            obj->SetInUse(false);   // GO_STATE_READY
         if (obj->GetLootState() == GO_JUST_DEACTIVATED)
             obj->SetLootState(GO_READY);
-        obj->Respawn();
-    }
-    else
-    {
+    } else {
+        // flags are buttons (except neutral flags) : need to force state update to clients
+        if (obj->GetGoType() == GAMEOBJECT_TYPE_BUTTON)
+        {
+            obj->SetInUse(true);    // GO_STATE_ACTIVE
+            obj->SendForcedObjectUpdate();
+        }
         obj->SetLootState(GO_JUST_DEACTIVATED);
         obj->SetRespawnDelay(respawntime);
         obj->SetForcedDespawn();


### PR DESCRIPTION
## 🍰 Pullrequest
Issue [#1250](https://github.com/cmangos/issues/issues/1250)

Based on the comments from Kelno in #1250 bug report :

> "The client expects gameobject state to change after having clicked a button, it prevents clicking it until it has received that state change."

So my aim was to find the good state changes and their order to have the client taking that change in account.

### Tests :
Take 2 characters (opposite faction) in arathi bassin
Go to the same flag, alternate to take it at different states (contested or faction owned)

Also fix the same problem for flags in alterac valley.

### Misc in DB (a little related to this fix) :
Change Alterac Cim Flag 'flags' field to 0 like other cim flags (DB Gob template id 179287).
Change "GAMEOBJECT_TYPE_FLAGDROP" (26) to "GAMEOBJECT_TYPE_FLAGSTAND" (24) for EY flags. (DB Gob template ids 184380 184381 184382)

### Ideas
Have to test a similar fix on ".npc move" and ".gobject move" commands (like the comment from Shauren suggests it, in [PR295](https://github.com/cmangos/mangos-tbc/pull/295))... 
