### PR TITLE
Fix typo in pdump causing SQL errors

### DIFF
--- a/src/game/Tools/PlayerDump.cpp
+++ b/src/game/Tools/PlayerDump.cpp
@@ -213,7 +213,7 @@ std::string CreateDumpString(char const* tableName, QueryResult* result)
             ss << ", ";
 
         if (fields[i].IsNULL())
-            ss << "nullptr";
+            ss << "NULL";
         else
         {
             std::string s =  fields[i].GetCppString();


### PR DESCRIPTION
## 🍰 Pullrequest
Seems at some point the string `NULL` was replaced with a C++ `nullptr` when this needed to remain as such for proper MySQL importing.

### Proof
<!-- Link resources as proof -->
- N/A

### Issues
- None

### How2Test
Use `.pdump write` on a character, and try to reimport it. You'll get SQL errors. Look inside the .sql file to see "nullptr" written as apart of the INSERT statement.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [x] None
