### PR TITLE
CombatManager to use ThreatRadius

### DIFF
--- a/src/game/Combat/CombatManager.cpp
+++ b/src/game/Combat/CombatManager.cpp
@@ -20,6 +20,7 @@
 
 #include "Entities/Pet.h"
 #include "Maps/Map.h"
+#include "World/World.h"
 
 CombatManager::CombatManager(Unit* owner) : m_owner(owner), m_evadeTimer(0), m_evadeState(EVADE_NONE), m_combatTimer(0), m_leashingDisabled(false), m_leashingCheck(nullptr)
 {
@@ -87,7 +88,7 @@ void CombatManager::Update(const uint32 diff)
                         float x, y, z, o;
                         creatureOwner->GetCombatStartPosition(x, y, z, o);
                         // homebox not confirmed on classic
-                        if (creatureOwner->GetDistance2d(x, y) > 30.0f)
+                        if (creatureOwner->GetDistance2d(x, y) > sWorld.getConfig(CONFIG_FLOAT_THREAT_RADIUS))
                             creatureOwner->HandleExitCombat();
                     }
                 }


### PR DESCRIPTION
## 🍰 Pullrequest
CombatManager to use "unused" ThreatRadius instead of fixed 30.0f value.

### Issues
fixes an issue were creatures summoned further than 30.0f from target/owner would lead them to go back to their spawning location. [fixes #2184](https://github.com/cmangos/issues/issues/2184)

### How2Test
Start Apprentice Mirveda encounter (npc_apprentice_mirvedaAI) and check if creatures keep fighting the player and Mirveda (fixed) once they reach them.