### PR TITLE
Update Lakota Windsong EscortAI

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/thousand_needles.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/thousand_needles.cpp
@@ -155,6 +155,7 @@ struct npc_lakota_windsongAI : public npc_escortAI
                 DoSpawnBandits(ID_AMBUSH_3);
                 break;
             case 46:
+                DoScriptText(SAY_LAKO_END, m_creature);
                 if (Player* pPlayer = GetPlayerForEscort())
                     pPlayer->RewardPlayerAndGroupAtEventExplored(QUEST_FREE_AT_LAST, m_creature);
                 break;
@@ -167,6 +168,11 @@ struct npc_lakota_windsongAI : public npc_escortAI
             m_creature->SummonCreature(NPC_GRIM_BANDIT,
                                        m_afBanditLoc[i + uiAmbushId][0], m_afBanditLoc[i + uiAmbushId][1], m_afBanditLoc[i + uiAmbushId][2], 0.0f,
                                        TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 60000);
+    }
+
+    void JustSummoned(Creature* pSummoned) override
+    {
+        pSummoned->AI()->AttackStart(m_creature);
     }
 };
 


### PR DESCRIPTION
Added missing DoScriptText for when the escort ends
Added summoned creature attack on spawn

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Lakota Windsong (https://classic.wowhead.com/npc=10646/lakota-windsong) was missing the end text after finishing escort. 
Furthermore, bandits on spawn don't have a target, this should fix that and make it as close to blizzlike as possible.

### Proof
<!-- Link resources as proof -->
- How it should word -> https://www.youtube.com/watch?v=8QzqZycqYF8&feature=emb_title

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Accept quest Free at Last (4904) from Lakota Windsong in Thousand Needles
- Let escort play through along with the summons


### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
