### PR TITLE
Fix a crash on Shirrak - Focus fire cast

### DIFF
--- a/src/game/Entities/DynamicObject.cpp
+++ b/src/game/Entities/DynamicObject.cpp
@@ -217,9 +217,9 @@ void DynamicObject::OnPersistentAreaAuraEnd()
             if (Unit* owner = GetCaster())
                 owner->CastSpell(nullptr, 30631, TRIGGERED_OLD_TRIGGERED, nullptr, nullptr, GetObjectGuid());
             break;
-        case 32286: // Shirakk - Focus fire
+        case 32286: // Shirrak - Focus fire
             if (Unit* owner = GetCaster())
-                owner->CastSpell(nullptr, 32301, TRIGGERED_OLD_TRIGGERED, nullptr, nullptr, GetObjectGuid());
+                owner->CastSpell(nullptr, 32301, TRIGGERED_OLD_TRIGGERED);
             break;
     }
 }


### PR DESCRIPTION
idea: killerwife

## 🍰 Pullrequest
Fix crash when Shirrak the Dead Watcher casts Focus Fire

### Proof
- None

### Issues
- fixes https://github.com/cmangos/issues/issues/2000
- fixes https://github.com/cmangos/issues/issues/2234

- relates to https://github.com/cmangos/issues/issues/2192

### How2Test
Aggro Shirrak, wait until he casts focus fire -> no crash anymore

### Todo / Checklist
- [X] None
