### PR TITLE
Update npc_obelisk_triggerAI

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/blades_edge_mountains.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/blades_edge_mountains.cpp
@@ -999,6 +999,11 @@ struct npc_obelisk_triggerAI : public ScriptedAI
                 (*itr)->ResetDoorOrButton();
             }
         }
+        
+        std::list<Creature*> lBunny;
+        GetCreatureListWithEntryInGrid(lBunny, m_creature, NPC_TRIGGER, 100.0f);
+        for (std::list<Creature*>::iterator itr = lBunny.begin(); itr != lBunny.end(); ++itr)
+            (*itr)->RemoveAllAuras();
     }
 
     void UpdateAI(const uint32 uiDiff) override
@@ -1036,11 +1041,6 @@ struct npc_obelisk_triggerAI : public ScriptedAI
                     if (m_uiDoomcryer)
                         m_uiDoomcryer->GetMotionMaster()->MovePoint(1, 2882.60f, 4818.73f, 282.0f);
 
-                    std::list<Creature*> lBunny;
-                    GetCreatureListWithEntryInGrid(lBunny, m_creature, NPC_TRIGGER, 100.0f);
-                    for (std::list<Creature*>::iterator itr = lBunny.begin(); itr != lBunny.end(); ++itr)
-                        (*itr)->RemoveAllAuras();
-
                     m_uiSpawnBoss = true;
                     m_uiMarkForReset = true;
                 }
@@ -1058,7 +1058,7 @@ struct npc_obelisk_triggerAI : public ScriptedAI
                                 for (uint8 i = 0; i < countof(aObeliskEntries); ++i)
                                     GetGameObjectListWithEntryInGrid(lObelisk, (*itr), aObeliskEntries[i], 1.0f);
 
-                                if (!(*itr)->HasAura(SPELL_GREEN_BEAM) && lObelisk.begin() != lObelisk.end())
+                                if (!(*itr)->HasAura(SPELL_GREEN_BEAM) && lBunny.begin() != lBunny.end())
                                 {
                                     (*itr)->CastSpell(m_creature, SPELL_GREEN_BEAM, TRIGGERED_OLD_TRIGGERED);
                                     break;
@@ -1085,9 +1085,15 @@ struct npc_obelisk_triggerAI : public ScriptedAI
             }
             else
                 m_uiResetTimer -= uiDiff;
+        }  
+    }
 
-        }
-
+    void SummonedCreatureJustDied(Creature* /*pSummoned*/) override
+    {
+        std::list<Creature*> lBunny;
+        GetCreatureListWithEntryInGrid(lBunny, m_creature, NPC_TRIGGER, 100.0f);
+        for (std::list<Creature*>::iterator itr = lBunny.begin(); itr != lBunny.end(); ++itr)
+            (*itr)->RemoveAllAuras();
     }
 };
 


### PR DESCRIPTION
No green beams were being casted upon activating all 5 obelisks.
Green beams are supposed to stop casting upon killing m_creature, not upon spawning it.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Previously, there were no green beams being cast whenever you'd activate all 5 obelisks. Furthermore, the beams are supposed to stop casting whenever m_creature dies, not when it spawns in.
To add, I think they're too many spawns of **Blade's Edge - Legion - Invis Bunny (entry = 20736)**
If you check the video below, there are no beams being cast where m_creature spawns. However, turn GM on and look where Doomcryer spawns, you'll notice they're 2 of those bunnies right next to the spawn and they can cast the beam since they are within the search range, causing a few beams from the obelisk to not cast.

### Proof
<!-- Link resources as proof -->
- https://www.youtube.com/watch?v=xvZqhr5hGTk&t=204s (earliest vid I could find)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Pick up 5 keys from anger guards (or add the keys yourself)
- Activate obelisk's within the timeframe
- Let Doomcryer spawn
- Kill her and watch beams stop being casted

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] I couldn't find evidence if the beams stop casting on despawn or when the event resets.
