### PR TITLE
Send aura durations for self on login

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -19360,6 +19360,7 @@ void Player::SendInitialPacketsAfterAddToMap()
             auraList.front()->ApplyModifier(true, true);
     }
 
+    SendAuraDurationsForTarget(this);
     SendEnchantmentDurations();                             // must be after add to map
     SendItemDurations();                                    // must be after add to map
 }


### PR DESCRIPTION
## 🍰 Pullrequest
The Lua function [UnitBuff()](https://wow.gamepedia.com/API_UnitBuff) returns information regarding an aura in a specific slot. One of the return values is the aura's duration. However, on login and map change these values seem to be cleared from the client making this Lua call not work properly. The result is breaking some AddOns like [ProcIndicator](https://github.com/Oldsalt0/ProcIndicator) until the buff is refreshed and the client has a new duration to track.


### Proof
Uncertain if this was how it really worked in TBC, but seeing as TrinityCore sends self-aura durations on client login in the same area, I don't see why this would harm anything, and since you should assume Lua APIs work, this seems like an appropriate fix.

### Issues
- None tracked

### How2Test
- Use the [addon](https://github.com/Oldsalt0/ProcIndicator) mentioned above, or dump the value of `UnitBuff("player",1)` using an addon like [DevTools](https://www.wowinterface.com/downloads/info3999-DevTools.html) when having only one aura, such as Blessing of Might. Relog, and notice that the dump no longer includes information such as the duration remaining.
- Use the branch in the PR and repeat the step above. You will receive aura duration information on login.

Difference between the two:
![image](https://user-images.githubusercontent.com/30731/91199874-bfaba400-e6fe-11ea-8874-2cfc08d54bdd.png)


### Todo / Checklist
- [x] None
