### PR TITLE
do not push next waypoint, when path is not initialized

### DIFF
--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -378,6 +378,10 @@ static const uint32 PreSendTime     = 1500;
 // build and send path to next node
 void WaypointMovementGenerator<Creature>::SendNextWayPointPath(Creature& creature)
 {
+    // when the path isn't correctly initialized, do not attempt to send waypoints
+    if (!i_path)
+        return;
+
     // make sure to reset spline index as its new path
     m_nodeIndexes.clear();
 


### PR DESCRIPTION
## 🍰 Pullrequest
Gracefully handle missing waypoints/paths by ignoring them.

### Proof
The Crone spawns her cyclones and the servers continues to run.

### Issues
resolves cmangos/mangos-tbc#2245

### Todo / Checklist
- Add waypoints for the cyclones
- Are there any other underlying problems with uninitialized paths? Why does this code segment run with the cyclones? Why not with others?
- Do **not** add a log message; there are log messages for missing waypoints/paths already.
