### PR TITLE
Prevent the console error "MoveSpline::init_spline: zero length spline".

### DIFF
--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -1683,7 +1683,7 @@ void Creature::DeleteFromDB(uint32 lowguid, CreatureData const* data)
     WorldDatabase.CommitTransaction();
 }
 
-void Creature::SetDeathState(DeathState s)
+void Creature::SetDeathState(DeathState s, bool falling)
 {
     if ((s == JUST_DIED && !m_isDeadByDefault) || (s == JUST_ALIVED && m_isDeadByDefault))
     {
@@ -1710,7 +1710,7 @@ void Creature::SetDeathState(DeathState s)
         SetTargetGuid(ObjectGuid());                        // remove target selection in any cases (can be set at aura remove in Unit::SetDeathState)
         SetUInt32Value(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_NONE);
 
-        if (CanFly())
+        if (falling && CanFly())
             i_motionMaster.MoveFall();
 
         Unit::SetDeathState(CORPSE);
@@ -1775,7 +1775,7 @@ void Creature::ForcedDespawn(uint32 timeMSToDespawn, bool onlyAlive)
         return;
 
     if (IsAlive())
-        SetDeathState(JUST_DIED);
+        SetDeathState(JUST_DIED, false);
 
     RemoveCorpse(true);                                     // force corpse removal in the same grid
 

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -1683,7 +1683,7 @@ void Creature::DeleteFromDB(uint32 lowguid, CreatureData const* data)
     WorldDatabase.CommitTransaction();
 }
 
-void Creature::SetDeathState(DeathState s, bool falling)
+void Creature::SetDeathState(DeathState s)
 {
     if ((s == JUST_DIED && !m_isDeadByDefault) || (s == JUST_ALIVED && m_isDeadByDefault))
     {
@@ -1709,9 +1709,6 @@ void Creature::SetDeathState(DeathState s, bool falling)
     {
         SetTargetGuid(ObjectGuid());                        // remove target selection in any cases (can be set at aura remove in Unit::SetDeathState)
         SetUInt32Value(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_NONE);
-
-        if (falling && CanFly())
-            i_motionMaster.MoveFall();
 
         Unit::SetDeathState(CORPSE);
     }
@@ -1775,7 +1772,7 @@ void Creature::ForcedDespawn(uint32 timeMSToDespawn, bool onlyAlive)
         return;
 
     if (IsAlive())
-        SetDeathState(JUST_DIED, false);
+        SetDeathState(JUST_DIED);
 
     RemoveCorpse(true);                                     // force corpse removal in the same grid
 

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -721,7 +721,7 @@ class Creature : public Unit
         // overwrite WorldObject function for proper name localization
         const char* GetNameForLocaleIdx(int32 loc_idx) const override;
 
-        void SetDeathState(DeathState s) override;          // overwrite virtual Unit::SetDeathState
+        void SetDeathState(DeathState s, bool falling = true);          // overwrites Unit::SetDeathState no more
 
         bool LoadFromDB(uint32 guidlow, Map* map);
         virtual void SaveToDB();

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -721,7 +721,7 @@ class Creature : public Unit
         // overwrite WorldObject function for proper name localization
         const char* GetNameForLocaleIdx(int32 loc_idx) const override;
 
-        void SetDeathState(DeathState s, bool falling = true);          // overwrites Unit::SetDeathState no more
+        void SetDeathState(DeathState s) override;
 
         bool LoadFromDB(uint32 guidlow, Map* map);
         virtual void SaveToDB();

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -8713,7 +8713,10 @@ void Unit::SetDeathState(DeathState s)
 
         StopMoving();
         i_motionMaster.Clear(false, true);
-        i_motionMaster.MoveIdle();
+        if (CanFly())
+            i_motionMaster.MoveFall();
+        else
+            i_motionMaster.MoveIdle();
 
         GetCombatManager().StopEvade();
 

--- a/src/game/MotionGenerators/MotionMaster.cpp
+++ b/src/game/MotionGenerators/MotionMaster.cpp
@@ -536,6 +536,12 @@ void MotionMaster::MoveFall()
     if (fabs(z - tz) < 0.1f)
         return;
 
+    if (z < tz)
+    {
+        DEBUG_LOG("MotionMaster::MoveFall: entry %u falling up for %f at map %u (x: %f, y: %f, z: %f).", m_owner->GetEntry(), tz - z, m_owner->GetMap()->GetId(), x, y, z);
+        return;
+    }
+
     Movement::MoveSplineInit init(*m_owner);
     init.MoveTo(x, y, tz);
     init.SetFall();


### PR DESCRIPTION
## 🍰 Pullrequest
For a creature able to flying the following execution pattern was possible:
```C++
Creature::ForcedDespawn(0);
Creature::SetDeathState(JUST_DIED);
    Unit::SetDeathState(JUST_DIED);     // here movement is stopped by:
        StopMoving();
        i_motionMaster.Clear(false, true);
        i_motionMaster.MoveIdle();
     i_motionMaster.MoveFall();         // here movement is reinited to MoveFall() and the error printed
    Unit::SetDeathState(CORPSE);
RemoveCorpse(true);      // at the same tick, prevents any movement animation (just disappearing)
```
There is no way to skip setting `JUST_DIED`, no need to reinit movemet thereafter, and no way to know atm that the `RemoveCorpse()` will follow at the same tick. It must be considered as a design flaw. The proposed fix is far from elegant one, but I'm short of ideas. Either way we need a movement setting control inside of `Creature::SetDeathState(JUST_DIED)`.

### Proof
Not needed.

### Issues
- fixes (partially?) cmangos/issues#2255

### How2Test
Using the 96dda3c3, spend some time at, for example, Light's Hope Chapel, to get the error logged. Retry since this applied. An extensive testing is needed to find another causes of the error, if any.

### Todo / Checklist
When a creature flying at the ground level falls dead, the same error might arise (though I've failed to get the error since this applied). However `Creature::JustDied()` looks to me as a wrong place to compare z-coordinate and the ground level before movement reinit.
The issue must be the same for (all?) cores.