### PR TITLE
Fix for Playerbots not returning list with learnable talents on "talent learn"-command

### DIFF
--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -9590,7 +9590,26 @@ void PlayerbotAI::_HandleCommandTalent(std::string& text, Player& fromPlayer)
                     if (!spellInfo || !SpellMgr::IsSpellValid(spellInfo, m_bot, false))
                         continue;
 
-                    out << "|cff4e96f7|Htalent:" << talentInfo->RankID[curtalent_maxrank] << ":" << curtalent_maxrank << "|h[" << spellInfo->SpellName[GetMaster()->GetSession()->GetSessionDbcLocale()] << "]|h|r";
+					// Get default locale for Spellnames by Master
+					// e.g. 0 = eng | 3 = ger etc.
+					int loc = GetMaster()->GetSession()->GetSessionDbcLocale();
+					
+					// fallback if master is not found/empty ?? correct me here if I'm wrong. :)
+					if (!GetMaster())
+					{
+						loc = m_bot->GetSession()->GetSessionDbcLocale();
+					}
+					
+					// Get Spells Name for link based on locale
+					const char* bot_spell_to_learn = spellInfo->SpellName[loc];
+
+					// fallback if nothing in current locale but locale is supported/found (e.g. spellname not available in loc = 3)
+					if (spellInfo->SpellName[loc][0] == '\0')
+					{
+						bot_spell_to_learn = spellInfo->SpellName[0];
+					}
+					
+					out << "|cff4e96f7|Htalent:" << talentInfo->RankID[curtalent_maxrank] << ":" << curtalent_maxrank << "|h[" << bot_spell_to_learn << "]|h|r";
                 }
             }
             SendWhisper(out.str(), fromPlayer);

--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -9590,26 +9590,26 @@ void PlayerbotAI::_HandleCommandTalent(std::string& text, Player& fromPlayer)
                     if (!spellInfo || !SpellMgr::IsSpellValid(spellInfo, m_bot, false))
                         continue;
 
-					// Get default locale for Spellnames by Master
-					// e.g. 0 = eng | 3 = ger etc.
-					int loc = GetMaster()->GetSession()->GetSessionDbcLocale();
-					
-					// fallback if master is not found/empty ?? correct me here if I'm wrong. :)
-					if (!GetMaster())
-					{
-						loc = m_bot->GetSession()->GetSessionDbcLocale();
-					}
-					
-					// Get Spells Name for link based on locale
-					const char* bot_spell_to_learn = spellInfo->SpellName[loc];
+                    // Get default locale for Spellnames by Master
+                    // e.g. 0 = eng | 3 = ger etc.
+                    int loc = GetMaster()->GetSession()->GetSessionDbcLocale();
 
-					// fallback if nothing in current locale but locale is supported/found (e.g. spellname not available in loc = 3)
-					if (spellInfo->SpellName[loc][0] == '\0')
-					{
-						bot_spell_to_learn = spellInfo->SpellName[0];
-					}
-					
-					out << "|cff4e96f7|Htalent:" << talentInfo->RankID[curtalent_maxrank] << ":" << curtalent_maxrank << "|h[" << bot_spell_to_learn << "]|h|r";
+                    // fallback if master is not found/empty ?? correct me here if I'm wrong. :)
+                    if (!GetMaster())
+                    {
+                        loc = m_bot->GetSession()->GetSessionDbcLocale();
+                    }
+
+                    // Get Spells Name for link based on locale
+                    const char* bot_spell_to_learn = spellInfo->SpellName[loc];
+
+                    // fallback if nothing in current locale but locale is supported/found (e.g. spellname not available in loc = 3)
+                    if (spellInfo->SpellName[loc][0] == '\0')
+                    {
+                        bot_spell_to_learn = spellInfo->SpellName[0];
+                    }
+
+                    out << "|cff4e96f7|Htalent:" << talentInfo->RankID[curtalent_maxrank] << ":" << curtalent_maxrank << "|h[" << bot_spell_to_learn << "]|h|r";
                 }
             }
             SendWhisper(out.str(), fromPlayer);


### PR DESCRIPTION
## 🍰 We are bot. We want to tell you what we can learn. 🤖 
As the Title says: Currently the Playerbot is returning the following output:
"talents I can learn: [], [], []" at least if the client locale is deDE = 3

I've added some fallbacks for that and now you should always get a list of learnable talents "links" to shift+lmb click on by doing "talent learn [MySuperDuperNewTalent]" :)

Please feel free to correct me here.

### Proof
- Compile with Playerbots on (without fix)
- Ask your Bot "talent learn" 
- Output should be "[]" at least for deDE locale (others not tested)

### Issues
- None I'm aware of but hey if you had this problem ... try this fix. ❤️ 

### How2Test
- Compile with fix
- Ask your Bot "talent learn"
- Profit

### Todo / Checklist
- [ ] Correct me if I'm not totally wrong with the "master"-check. I mean it's working for me now but you know better diese. :3

Have a wonderful day.