### PR TITLE
BG commands and fix for no-winner games

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -174,7 +174,7 @@ void BattleGround::BroadcastWorker(Do& _do)
 */
 BattleGround::BattleGround(): m_buffChange(false), m_startDelayTime(0), m_arenaBuffSpawned(false), m_startMaxDist(0)
 {
-    m_typeId            = BattleGroundTypeId(0);
+    m_typeId            = BATTLEGROUND_TYPE_NONE;
     m_status            = STATUS_NONE;
     m_clientInstanceId  = 0;
     m_endTime           = 0;
@@ -183,7 +183,7 @@ BattleGround::BattleGround(): m_buffChange(false), m_startDelayTime(0), m_arenaB
     m_invitedHorde      = 0;
     m_arenaType         = ARENA_TYPE_NONE;
     m_isArena           = false;
-    m_winner            = TEAM_NONE;
+    m_winner            = WINNER_NONE;
     m_startTime         = 0;
     m_validStartPositionTimer = 0;
     m_events            = 0;
@@ -750,6 +750,8 @@ void BattleGround::EndBattleGround(Team winner)
         winmsg_id = IsBattleGround() ? LANG_BG_A_WINS : LANG_ARENA_GOLD_WINS;
         PlaySoundToAll(SOUND_ALLIANCE_WINS);
 
+        SetWinner(WINNER_ALLIANCE);
+
         // reversed index for the bg score storage system
         bgScoresWinner = TEAM_INDEX_HORDE;
     }
@@ -758,9 +760,13 @@ void BattleGround::EndBattleGround(Team winner)
         winmsg_id = IsBattleGround() ? LANG_BG_H_WINS : LANG_ARENA_GREEN_WINS;
         PlaySoundToAll(SOUND_HORDE_WINS);
 
+        SetWinner(WINNER_HORDE);
+
         // reversed index for the bg score storage system
         bgScoresWinner = TEAM_INDEX_ALLIANCE;
     }
+    else
+        SetWinner(WINNER_NONE);
 
     // store battleground scores
     if (IsBattleGround() && sWorld.getConfig(CONFIG_BOOL_BATTLEGROUND_SCORE_STATISTICS))
@@ -783,8 +789,6 @@ void BattleGround::EndBattleGround(Team winner)
 
         stmt.PExecute(battleground_id, bgScoresWinner, battleground_bracket, battleground_type);
     }
-
-    SetWinner(winner);
 
     SetStatus(STATUS_WAIT_LEAVE);
     // we must set it this way, because end time is sent in packet!
@@ -1281,7 +1285,7 @@ void BattleGround::RemovePlayerAtLeave(ObjectGuid playerGuid, bool isOnTransport
 */
 void BattleGround::Reset()
 {
-    SetWinner(TEAM_NONE);
+    SetWinner(WINNER_NONE);
     SetStatus(STATUS_WAIT_QUEUE);
     SetStartTime(0);
     SetEndTime(0);

--- a/src/game/BattleGround/BattleGround.h
+++ b/src/game/BattleGround/BattleGround.h
@@ -323,8 +323,8 @@ class BattleGround
         uint32 GetMinPlayersPerTeam() const { return m_minPlayersPerTeam; }
 
         int32 GetStartDelayTime() const     { return m_startDelayTime; }
-        ArenaType GetArenaType() const          { return m_arenaType; }
-        Team GetWinner() const              { return m_winner; }
+        ArenaType GetArenaType() const      { return m_arenaType; }
+        BattleGroundWinner GetWinner() const{ return m_winner; }
         uint32 GetBattlemasterEntry() const;
         uint32 GetBonusHonorFromKill(uint32 kills) const;
 
@@ -342,7 +342,7 @@ class BattleGround
         void SetRated(bool state)           { m_isRated = state; }
         void SetArenaType(ArenaType type)   { m_arenaType = type; }
         void SetArenaorBGType(bool isArena) { m_isArena = isArena; }
-        void SetWinner(Team winner)         { m_winner = winner; }
+        void SetWinner(BattleGroundWinner winner) { m_winner = winner; }
 
         void ModifyStartDelayTime(int diff) { m_startDelayTime -= diff; }
         void SetStartDelayTime(int time)    { m_startDelayTime = time; }
@@ -644,7 +644,7 @@ class BattleGround
         BattleGroundStatus m_status;
         BattleGroundBracketId m_bracketId;
         ArenaType  m_arenaType;                             // 2=2v2, 3=3v3, 5=5v5
-        Team   m_winner;
+        BattleGroundWinner m_winner;
 
         uint32 m_clientInstanceId;                          // the instance-id which is sent to the client and without any other internal use
         uint32 m_startTime;

--- a/src/game/BattleGround/BattleGroundMgr.cpp
+++ b/src/game/BattleGround/BattleGroundMgr.cpp
@@ -1433,7 +1433,7 @@ void BattleGroundMgr::BuildPvpLogDataPacket(WorldPacket& data, BattleGround* bg)
     else
     {
         data << uint8(1);                                  // bg ended
-        data << uint8(bg->GetWinner());                    // who wins
+        data << uint8(bg->GetWinner());                    // who won
     }
 
     data << (int32)(bg->GetPlayerScoresSize());
@@ -1458,10 +1458,7 @@ void BattleGroundMgr::BuildPvpLogDataPacket(WorldPacket& data, BattleGround* bg)
                 if (Player* player = sObjectMgr.GetPlayer(itr->first))
                     team = player->GetTeam();
 
-            if (bg->GetWinner() == team && team != TEAM_NONE)
-                data << uint8(1);
-            else
-                data << uint8(0);
+            data << uint8(team == ALLIANCE ? 1 : 0); // green or yellow
         }
         data << (int32)score->damageDone;            // damage done
         data << (int32)score->healingDone;           // healing done

--- a/src/game/BattleGround/BattleGroundMgr.cpp
+++ b/src/game/BattleGround/BattleGroundMgr.cpp
@@ -1433,7 +1433,7 @@ void BattleGroundMgr::BuildPvpLogDataPacket(WorldPacket& data, BattleGround* bg)
     else
     {
         data << uint8(1);                                  // bg ended
-        data << uint8(bg->GetWinner() == ALLIANCE ? 1 : 0);// who win
+        data << uint8(bg->GetWinner());                    // who wins
     }
 
     data << (int32)(bg->GetPlayerScoresSize());

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -217,13 +217,6 @@ ChatCommand* ChatHandler::getCommandTable()
         { nullptr,          0,                  false, nullptr,                                             "", nullptr }
     };
 
-    static ChatCommand bgCommandTable[] =
-    {
-        { "start",          SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugBattlegroundStartCommand,   "", nullptr },
-        { "",               SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugBattlegroundCommand,        "", nullptr },
-        { nullptr,          0,                  false, nullptr,                                             "", nullptr }
-    };
-
     static ChatCommand debugPerformanceCommandTable[] =
     {
         { "tempspawn",      SEC_ADMINISTRATOR,  false, &ChatHandler::HandleShowTemporarySpawnList,          "", nullptr },
@@ -235,7 +228,7 @@ ChatCommand* ChatHandler::getCommandTable()
     {
         { "anim",           SEC_GAMEMASTER,     false, &ChatHandler::HandleDebugAnimCommand,                "", nullptr },
         { "arena",          SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugArenaCommand,               "", nullptr },
-        { "bg",             SEC_ADMINISTRATOR,  false, nullptr,                                             "", bgCommandTable },
+        { "bg",             SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugBattlegroundCommand,        "", nullptr },
         { "flight",         SEC_GAMEMASTER,     false, &ChatHandler::HandleDebugFlyCommand,                 "", nullptr },
         { "getitemstate",   SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugGetItemStateCommand,        "", nullptr },
         { "lootrecipient",  SEC_GAMEMASTER,     false, &ChatHandler::HandleDebugGetLootRecipientCommand,    "", nullptr },
@@ -841,6 +834,13 @@ ChatCommand* ChatHandler::getCommandTable()
         { nullptr,          0,                  false, nullptr,                                        "", nullptr }
     };
 
+    static ChatCommand battlegroundCommandTable[] =
+    {
+        { "start",         SEC_GAMEMASTER,     false,  &ChatHandler::HandleBattlegroundStartCommand,   "", nullptr },
+        { "stop",          SEC_GAMEMASTER,     false,  &ChatHandler::HandleBattlegroundStopCommand,    "", nullptr },
+        { nullptr,         0,                  false,  nullptr,                                        "", nullptr }
+    };
+
     static ChatCommand commandTable[] =
     {
         { "account",        SEC_PLAYER,         true,  nullptr,                                        "", accountCommandTable  },
@@ -876,7 +876,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "titles",         SEC_GAMEMASTER,     false, nullptr,                                        "", titlesCommandTable   },
         { "trigger",        SEC_GAMEMASTER,     false, nullptr,                                        "", triggerCommandTable  },
         { "wp",             SEC_GAMEMASTER,     false, nullptr,                                        "", wpCommandTable       },
-
+        { "bg",             SEC_GAMEMASTER,     false, nullptr,                                        "", battlegroundCommandTable },
         { "aura",           SEC_ADMINISTRATOR,  false, &ChatHandler::HandleAuraCommand,                "", nullptr },
         { "unaura",         SEC_ADMINISTRATOR,  false, &ChatHandler::HandleUnAuraCommand,              "", nullptr },
         { "announce",       SEC_MODERATOR,      true,  &ChatHandler::HandleAnnounceCommand,            "", nullptr },

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -747,6 +747,10 @@ class ChatHandler
         bool HandleWarEffortCommand(char* args);
         bool HandleExpansionRelease(char* args);
 
+        // Battleground
+        bool HandleBattlegroundStartCommand(char* args);
+        bool HandleBattlegroundStopCommand(char* args);
+
         //! Development Commands
         bool HandleSaveAllCommand(char* args);
 

--- a/src/game/Chat/Level2.cpp
+++ b/src/game/Chat/Level2.cpp
@@ -16,6 +16,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include "Battleground.h"
 #include "Common.h"
 #include "Database/DatabaseEnv.h"
 #include "Server/DBCStores.h"
@@ -4965,5 +4966,48 @@ bool ChatHandler::HandleBagsCommand(char* args)
                 player->SendNewItem(item, 1, false, true);
         }
     }
+
+    return true;
+}
+
+bool ChatHandler::HandleBattlegroundStartCommand(char* args)
+{
+    Player* player = m_session->GetPlayer();
+
+    if (!player)
+        return false;
+
+    BattleGround* bg = player->GetBattleGround();
+    if (!bg)
+    {
+        SendSysMessage("You are not in a battleground.");
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    bg->SetStartDelayTime(0);
+    PSendSysMessage("Battleground started [%s][%u]", bg->GetName(), bg->GetInstanceId());
+
+    return true;
+}
+
+bool ChatHandler::HandleBattlegroundStopCommand(char* args)
+{
+    Player* player = m_session->GetPlayer();
+
+    if (!player)
+        return false;
+
+    BattleGround* bg = player->GetBattleGround();
+    if (!bg)
+    {
+        SendSysMessage("You are not in a battleground.");
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    bg->EndBattleGround(TEAM_NONE);
+    PSendSysMessage("Battleground stopped [%s][%u]", bg->GetName(), bg->GetInstanceId());
+
     return true;
 }

--- a/src/game/Chat/Level2.cpp
+++ b/src/game/Chat/Level2.cpp
@@ -16,7 +16,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include "Battleground.h"
+#include "BattleGround.h"
 #include "Common.h"
 #include "Database/DatabaseEnv.h"
 #include "Server/DBCStores.h"

--- a/src/game/Chat/debugcmds.cpp
+++ b/src/game/Chat/debugcmds.cpp
@@ -691,17 +691,6 @@ bool ChatHandler::HandleDebugBattlegroundCommand(char* /*args*/)
     return true;
 }
 
-bool ChatHandler::HandleDebugBattlegroundStartCommand(char* /*args*/)
-{
-    if (auto bg = m_session->GetPlayer()->GetBattleGround())
-    {
-        bg->SetStartDelayTime(-1);
-        return true;
-    }
-
-    return false;
-}
-
 bool ChatHandler::HandleDebugArenaCommand(char* /*args*/)
 {
     sBattleGroundMgr.ToggleArenaTesting();

--- a/src/game/Globals/SharedDefines.h
+++ b/src/game/Globals/SharedDefines.h
@@ -594,6 +594,13 @@ enum Team
     ALLIANCE            = 469,
 };
 
+enum BattleGroundWinner
+{
+    WINNER_HORDE        = 0,
+    WINNER_ALLIANCE     = 1,
+    WINNER_NONE         = 2
+};
+
 enum PvpTeamIndex
 {
     TEAM_INDEX_ALLIANCE = 0,


### PR DESCRIPTION
## 🍰 Pullrequest
Ports over BG start/stop commands from vmangos into its own sub-command menu instead of the existing under debug.
Also fixes issues where handling of a BG ending in a draw didn't exist, either by the new stop command or premature timer due to not enough players.

The rationale for moving the command to its own submenu is because it doesn't really belong under debug, especially if more commands should be added (such as the `.bg info` command from vmangos too to gather data on queues and in-progress BGs), and other useful GM-related tooling.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Enter a BG and force start it via `.bg start` and end it shortly after with `.bg stop`. The game should end with no winner.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
