### PR TITLE
Update the build requirements to CMake 3.1 and C++ 14 compiler support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 # Minimum required cmake version to run the build
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 # Will cache object files if ccache is available
 # Must be set at top of cmake outside of project header
@@ -26,6 +26,11 @@ if(CCACHE_PROGRAM)
 endif()
 
 project(CMaNGOS_TBC)
+
+# Require C++ 14 support
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Define here name of the binaries
 set(CMANGOS_BINARY_SERVER_NAME "mangosd")

--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -1,21 +1,6 @@
 # Set build-directive (used in core to tell which buildtype we used)
 add_definitions(-D_BUILD_DIRECTIVE='"$(CONFIGURATION)"')
 
-# Check C++11 compiler support
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX14)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-elseif(COMPILER_SUPPORTS_CXX11)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-elseif(COMPILER_SUPPORTS_CXX0X)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-else()
-  message(FATAL_ERROR "Error, CMaNGOS requires a compiler that supports C++11!")
-endif()
-
 if(WARNINGS)
   set(WARNING_FLAGS "-W -Wall -Wextra -Winit-self -Wfatal-errors")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNING_FLAGS}")

--- a/cmake/compiler/gcc/settings.cmake
+++ b/cmake/compiler/gcc/settings.cmake
@@ -1,18 +1,6 @@
 # Set build-directive (used in core to tell which buildtype we used)
 add_definitions(-D_BUILD_DIRECTIVE='"${CMAKE_BUILD_TYPE}"')
 
-# Check C++11 compiler support
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX11)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-elseif(COMPILER_SUPPORTS_CXX0X)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-else()
-  message(FATAL_ERROR "Error, CMaNGOS requires a compiler that supports C++11!")
-endif()
-
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
   set(ARM_FLAGS "-latomic")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARM_FLAGS}")


### PR DESCRIPTION
Notes:
* CMake 3.1 was released in December 2014, so this seems like a very modest requirement these days.
* We started requiring C++ 11 support in compilers in October 2015, so requiring C++ 14 support about five years later also seems like a fair requirement. Practically speaking, this means you'll need at the very least Visual Studio 2015, GCC 5 or Clang 3.4 (or equivalent in Xcode on macOS).

Let's see what our CI thinks about this. As far as I can see we don't need any adjustments on our CI setup, because we're already using recent systems and compilers (GCC 7, Clang 7, VS 2019)...

