### PR TITLE
Lifebloom final bloom should be able to crit

### DIFF
--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2352,6 +2352,9 @@ UPDATE `spell_template` SET `MaxAffectedTargets`=1 WHERE `id` IN(45785,45892);
 -- Fire Bloom
 UPDATE `spell_template` SET `MaxAffectedTargets`=5 WHERE `id` IN(45641);
 
+-- Lifebloom final bloom should be able to crit - requires DmgClass 1
+UPDATE `spell_template` SET `DmgClass`=1 WHERE `id` IN(33778);
+
 -- ============================================================
 -- WOTLK section
 -- ============================================================


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Final heal effect is not critting due to incorrect DmgClass set in db.
### Proof
<!-- Link resources as proof -->
 https://github.com/Yatzii93/TBC5MAN-Bug-Tracker/issues/58
![image](https://user-images.githubusercontent.com/47720837/98580386-ca1a1a80-22b7-11eb-9064-fe2686a1fc77.png)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Resolves problem whereby Lifeblooms final heal effect doesn't take into account the players crit chance.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Cast lifebloom on a target and let the hot aura drop off.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
