### PR TITLE
Adding JustDisorientedTarget for creatures that use spells like scatt…

### DIFF
--- a/src/game/AI/BaseAI/UnitAI.h
+++ b/src/game/AI/BaseAI/UnitAI.h
@@ -438,6 +438,7 @@ class UnitAI
         virtual void JustRootedTarget(SpellEntry const* spellInfo, Unit* victim) { JustStoppedMovementOfTarget(spellInfo, victim); }
         virtual void JustStunnedTarget(SpellEntry const* spellInfo, Unit* victim) { JustStoppedMovementOfTarget(spellInfo, victim); }
         virtual void JustStoppedMovementOfTarget(SpellEntry const* /*spellInfo*/, Unit* /*victim*/) {}
+        virtual void JustDisorientedTarget(SpellEntry const* spellInfo, Unit* victim) { JustStoppedMovementOfTarget(spellInfo, victim); }
 
         // AI selection - works in connection with IsPossessCharmType
         virtual bool CanHandleCharm() { return false; }

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -4262,6 +4262,15 @@ void Aura::HandleModConfuse(bool apply, bool Real)
     if (!apply && GetTarget()->HasAuraType(SPELL_AURA_MOD_CONFUSE))
         return;
 
+    if (apply)
+    {
+        Unit* target = GetTarget();
+        Unit* caster = GetCaster();
+        if (caster)
+            if (UnitAI* ai = caster->AI())
+                ai->JustDisorientedTarget(GetSpellProto(), target);
+    }
+
     GetTarget()->SetConfused(apply, GetCasterGuid(), GetId());
 
     GetTarget()->getHostileRefManager().HandleSuppressed(apply);


### PR DESCRIPTION
…er shot to distance their self after.

## 🍰 Pullrequest
Creatures that use "confusing" spells like [Scatter Shot](https://www.wowhead.com/spell=23601/scatter-shot) can now distance their self if CastFlag - CAST_DISTANCE_YOURSELF is given.

For example [Shattered hand sharpshooter](https://www.wowhead.com/npc=16704/shattered-hand-sharpshooter#abilities;mode:normal)