### PR TITLE
add send ai to master function

### DIFF
--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -1345,6 +1345,13 @@ bool CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             SetRootSelf(action.immobilizedState.apply, action.immobilizedState.combatOnly);
             break;
         }
+        case ACTION_T_SEND_AI_TO_MASTER:
+        {
+            if (Unit* target = m_creature->GetMap()->GetCreatureLinkingHolder()->GetMaster(m_creature))
+                if (target->IsAlive())
+                    m_creature->AI()->SendAIEvent(AIEventType(action.sendEvent.eventType), m_creature, target);
+            break;
+        }
         default:
             sLog.outError("%s::ProcessAction(): action(%u) not implemented", GetAIName().data(), static_cast<uint32>(action.type));
             return false;

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -142,6 +142,7 @@ enum EventAI_ActionType
     ACTION_T_SET_FACING                 = 59,               // Target, 0 - set, 1 - reset
     ACTION_T_SET_SPELL_SET              = 60,               // SetId
     ACTION_T_SET_IMMOBILIZED_STATE      = 61,               // state (true - rooted), combatonly (true - autoremoved on combat stop)
+    ACTION_T_SEND_AI_TO_MASTER          = 62,               // Sending custom AI event to linking master
 
     ACTION_T_END,
 };
@@ -549,6 +550,11 @@ struct CreatureEventAI_Action
             uint32 apply;
             uint32 combatOnly;
         } immobilizedState;
+        // ACTION_T_SEND_AI_TO_MASTER
+        struct
+        {
+            uint32 eventType;
+        } sendEvent;
         // RAW
         struct
         {

--- a/src/game/AI/EventAI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/EventAI/CreatureEventAIMgr.cpp
@@ -1083,6 +1083,13 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                         break;
                     case ACTION_T_SET_IMMOBILIZED_STATE:
                         break;
+                    case ACTION_T_SEND_AI_TO_MASTER:
+                        if (action.sendEvent.eventType >= MAXIMAL_AI_EVENT_EVENTAI)
+                        {
+                            sLog.outErrorEventAI("Event %u Action %u uses invalid event type %u (must be less than %u), skipping", i, j + 1, action.sendEvent.eventType, MAXIMAL_AI_EVENT_EVENTAI);
+                            continue;
+                        }
+                        break;
                     default:
                         sLog.outErrorEventAI("Event %u Action %u have currently not checked at load action type (%u). Need check code update?", i, j + 1, temp.action[j].type);
                         break;

--- a/src/game/Entities/CreatureLinkingMgr.cpp
+++ b/src/game/Entities/CreatureLinkingMgr.cpp
@@ -771,4 +771,31 @@ bool CreatureLinkingHolder::TryFollowMaster(Creature* pCreature)
     return false;
 }
 
+// Function to get the Master of a Group
+Unit* CreatureLinkingHolder::GetMaster(Creature* pCreature)
+{
+    CreatureLinkingInfo const* pInfo = sCreatureLinkingMgr.GetLinkedTriggerInformation(pCreature);
+    if (!pInfo)
+        return false;
+
+    Creature* pMaster = nullptr;
+    if (pInfo->mapId != INVALID_MAP_ID)                     // entry case
+    {
+        BossGuidMapBounds finds = m_masterGuid.equal_range(pInfo->masterId);
+        for (BossGuidMap::const_iterator itr = finds.first; itr != finds.second; ++itr)
+        {
+            pMaster = pCreature->GetMap()->GetCreature(itr->second);
+            if (pMaster && IsSlaveInRangeOfMaster(pCreature, pMaster, pInfo->searchRange))
+                break;
+        }
+    }
+    else                                                    // guid case
+    {
+        CreatureData const* masterData = sObjectMgr.GetCreatureData(pInfo->masterDBGuid);
+        CreatureInfo const* cInfo = ObjectMgr::GetCreatureTemplate(masterData->id);
+        pMaster = pCreature->GetMap()->GetCreature(ObjectGuid(cInfo->GetHighGuid(), cInfo->Entry, pInfo->masterDBGuid));
+    }
+
+    return pMaster;
+}
 /*! @} */

--- a/src/game/Entities/CreatureLinkingMgr.h
+++ b/src/game/Entities/CreatureLinkingMgr.h
@@ -165,6 +165,9 @@ class CreatureLinkingHolder
         // This function lets a slave refollow his master
         bool TryFollowMaster(Creature* pCreature);
 
+        // Function to get the Master of a Group
+        Unit* GetMaster(Creature* pCreature);
+
     private:
         // Structure associated to a master (entry case)
         struct InfoAndGuids


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Currently we are able to send special AI events to nearby creatures. With this function we can send these AIs to master NPCs from creature linking.
Why do we need this?
In Shattered Halls every group with a legionnair has a different way to handle the death of a friendly creature. 
### Proof
<!-- Link resources as proof -->
atm every creature sends AI Event B on Death to nearby legionnair. So, if you pull Mobs from the first group to the 2nd group and kill them in the range of the 2nd legionnair, he will get this AI Event and will try to spawn a new mob/get enrage. 

Thats wrong like you can see in this video:
https://www.youtube.com/watch?v=iA75EO3UGpM
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
Didnt had any issue at any group i currently scripted local.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
Cant realy test this atm cause my legionnair script didnt got uploaded yet.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
