### PR TITLE
Fix Warrior Playerbots pull

### DIFF
--- a/src/game/PlayerBot/AI/PlayerbotWarriorAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotWarriorAI.h
@@ -31,7 +31,7 @@ enum
 
 enum WarriorSpells
 {
-    AUTO_SHOT_2                     = 75,
+    AUTO_SHOT_2                     = 3018,
     BATTLE_SHOUT_1                  = 6673,
     BATTLE_STANCE_1                 = 2457,
     BERSERKER_RAGE_1                = 18499,


### PR DESCRIPTION
Warrior AI used to try to use the Hunter ability "Autoshot" to pull targets, but because it's a hunter ability and not a warrior ability, range checks would always fail and warriors could never pull mobs on command. Changed the ability from autoshot to use the warrior's Shoot ability (3018)

## 🍰 Pullrequest
Changed the Warrior Playerbot AI to use the correct Shoot ability, so it can actually follow through with the Pull command

### Issues
No known issue was opened for this, but whenever you tried to give your warrior the pull command, it would say it is out of range, until the master moved close enough to the target that the target would be body pulled, at which point the pull command would switch to saying: Can't pull because a party member is somehow busy

### How2Test
Create a Warrior character with a ranged weapon, add that player to your group as a bot and tell it to pull, this behavior will be observed