### PR TITLE
Fix Stoneskin Gargoyles in Naxxramas

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -865,6 +865,7 @@ UPDATE creature_template SET ScriptName='npc_gurthock' WHERE entry=18471;
 
 /* NAXXRAMAS */
 UPDATE instance_template SET ScriptName='instance_naxxramas' WHERE map=533;
+UPDATE creature_template SET ScriptName="mob_naxxramasGargoyle" WHERE entry=16168;
 UPDATE creature_template SET ScriptName='boss_anubrekhan' WHERE entry=15956;
 UPDATE creature_template SET ScriptName='boss_faerlina' WHERE entry=15953;
 UPDATE creature_template SET ScriptName='boss_maexxna' WHERE entry=15952;

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
@@ -1100,10 +1100,14 @@ bool ProcessEventId_naxxramas(uint32 eventId, Object* source, Object* /*target*/
 
 struct mob_naxxramasGargoyleAI : public ScriptedAI
 {
-    instance_naxxramas* m_instance;
+    //instance_naxxramas* m_instance;
     mob_naxxramasGargoyleAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
-	m_instance = (instance_naxxramas*)pCreature->GetInstanceData();
+        m_creature->GetCombatManager().SetLeashingCheck([&](Unit*, float x, float y, float z)
+        {
+            return y > -3476.f && x > 2963.f && z > 297.6f;
+        });
+	    //m_instance = (instance_naxxramas*)pCreature->GetInstanceData();
         Reset();
         goStoneform();
 
@@ -1163,11 +1167,6 @@ struct mob_naxxramasGargoyleAI : public ScriptedAI
     {
         if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
             return;
-
-        m_creature->GetCombatManager().SetLeashingCheck([&](Unit*, float x, float y, float z)
-        {
-            return y > -3476.f && x > 2963.f && z > 297.6f;
-        });
 
         if (m_creature->GetHealthPercent() < 30.0f && !m_creature->HasAura(28995))
         {

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
@@ -1190,12 +1190,6 @@ struct mob_naxxramasGargoyleAI : public ScriptedAI
     }
 };
 
-UnitAI* GetAI_mob_naxxramasGargoyle(Creature* creature)
-{
-	return new mob_naxxramasGargoyleAI(creature);
-}
-
-
 void AddSC_instance_naxxramas()
 {
     Script* newScript = new Script;
@@ -1205,7 +1199,7 @@ void AddSC_instance_naxxramas()
 
     newScript = new Script;
     newScript->Name = "mob_naxxramasGargoyle";
-    newScript->GetAI = &GetAI_mob_naxxramasGargoyle;
+    newScript->GetAI = &GetNewAIInstance<mob_naxxramasGargoyleAI>;
     newScript->RegisterSelf();
 
     newScript = new Script;

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
@@ -1100,14 +1100,12 @@ bool ProcessEventId_naxxramas(uint32 eventId, Object* source, Object* /*target*/
 
 struct mob_naxxramasGargoyleAI : public ScriptedAI
 {
-    //instance_naxxramas* m_instance;
     mob_naxxramasGargoyleAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
         m_creature->GetCombatManager().SetLeashingCheck([&](Unit*, float x, float y, float z)
         {
             return y > -3476.f && x > 2963.f && z > 297.6f;
         });
-	    //m_instance = (instance_naxxramas*)pCreature->GetInstanceData();
         Reset();
         goStoneform();
 

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
@@ -1164,7 +1164,7 @@ struct mob_naxxramasGargoyleAI : public ScriptedAI
         if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
             return;
 
-        if (m_creature->GetPositionX() > 2963.0f && m_creature->GetPositionY() > -3476.0f)
+        if (m_creature->GetPositionX() > 2963.0f && m_creature->GetPositionY() > -3476.0f && m_creature->GetPositionZ() > 297.6f)
 	    {
 		    m_creature->AI()->EnterEvadeMode();
             return;

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
@@ -1164,11 +1164,10 @@ struct mob_naxxramasGargoyleAI : public ScriptedAI
         if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
             return;
 
-        if (m_creature->GetPositionX() > 2963.0f && m_creature->GetPositionY() > -3476.0f && m_creature->GetPositionZ() > 297.6f)
-	    {
-		    m_creature->AI()->EnterEvadeMode();
-            return;
-	    }
+        m_creature->GetCombatManager().SetLeashingCheck([&](Unit*, float x, float y, float z)
+        {
+            return y > -3476.f && x > 2963.f && z > 297.6f;
+        });
 
         if (m_creature->GetHealthPercent() < 30.0f && !m_creature->HasAura(28995))
         {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Stoneskin Gargoyles in the plague quarter will now reset when pulled outside of the plague quarter doors.
The first Stoneskin Gargoyle in the plague quarter will no longer cast Acid Volley

Stoneskin Scriptdev code was adapted/ported from [vmangos](https://github.com/vmangos/core/blob/development/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/instance_naxxramas.cpp)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
Fixes https://github.com/cmangos/issues/issues/2383

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
Go into naxxramas and pull the stoneskin gargoyles.
Make sure stoneskin gargoyles in other quarters are unaffected.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Independent testing
