### PR TITLE
SM Cath fix Mograine/Whitemane fight with CombatAI

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -126,16 +126,15 @@ struct boss_scarlet_commander_mograineAI : public CombatAI
 
     void EnterEvadeMode() override
     {
-        CombatAI::EnterEvadeMode();
-        
         if (m_instance)
         {
-        Creature* pWhitemane = m_instance->GetSingleCreatureFromStorage(NPC_WHITEMANE);
-            if (pWhitemane && !pWhitemane->IsAlive()){
-                pWhitemane->Respawn();
-                if (!(m_instance->GetData(TYPE_MOGRAINE_AND_WHITE_EVENT) == NOT_STARTED) || !(m_instance->GetData(TYPE_MOGRAINE_AND_WHITE_EVENT) == FAIL))
-                    m_instance->SetData(TYPE_MOGRAINE_AND_WHITE_EVENT, FAIL);
-            }
+            if(m_instance->GetData(TYPE_MOGRAINE_AND_WHITE_EVENT) == NOT_STARTED)
+                {
+                    CombatAI::EnterEvadeMode();
+                    return;
+                }
+            if (!(m_instance->GetData(TYPE_MOGRAINE_AND_WHITE_EVENT) == NOT_STARTED) || !(m_instance->GetData(TYPE_MOGRAINE_AND_WHITE_EVENT) == FAIL))
+                m_instance->SetData(TYPE_MOGRAINE_AND_WHITE_EVENT, FAIL);
         }
     }
 
@@ -341,23 +340,22 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
         if (!m_instance)
             return;
 
-        if (Creature* pMograine = m_instance->GetSingleCreatureFromStorage(NPC_MOGRAINE))
-        {
-            if (m_creature->IsAlive() && !pMograine->IsAlive())
-                pMograine->Respawn();
-        }
+        // if (Creature* pMograine = m_instance->GetSingleCreatureFromStorage(NPC_MOGRAINE))
+        // {
+        //     if (m_creature->IsAlive() && !pMograine->IsAlive())
+        //         pMograine->Respawn();
+        // }
     }
 
     void EnterEvadeMode() override
     {
-        CombatAI::EnterEvadeMode();
         if (m_instance)
         {
+            if(m_instance->GetData(TYPE_MOGRAINE_AND_WHITE_EVENT) == NOT_STARTED)
+                CombatAI::EnterEvadeMode();
             if (!(m_instance->GetData(TYPE_MOGRAINE_AND_WHITE_EVENT) == NOT_STARTED) || !(m_instance->GetData(TYPE_MOGRAINE_AND_WHITE_EVENT) == FAIL))
                 m_instance->SetData(TYPE_MOGRAINE_AND_WHITE_EVENT, FAIL);
         }
-        m_creature->SetRespawnDelay(1, true);
-        m_creature->ForcedDespawn();
     }
 
     void MoveInLineOfSight(Unit* /*pWho*/) override

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -304,9 +304,9 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
     boss_high_inquisitor_whitemaneAI(Creature* creature) : CombatAI(creature, WHITEMANE_ACTION_MAX), m_instance(static_cast<instance_scarlet_monastery*>(creature->GetInstanceData()))
     {
         AddTimerlessCombatAction(WHITEMANE_ACTION_DEEP_SLEEP, true);
-        AddCombatAction(WHITEMANE_ACTION_HEAL, false);
-        AddCombatAction(WHITEMANE_ACTION_POWERWORD_SHIELD, false);
-        AddCombatAction(WHITEMANE_ACTION_HOLY_SMITE, false);
+        AddCombatAction(WHITEMANE_ACTION_HEAL, true);
+        AddCombatAction(WHITEMANE_ACTION_POWERWORD_SHIELD, true);
+        AddCombatAction(WHITEMANE_ACTION_HOLY_SMITE, true);
         AddCombatAction(WHITEMANE_ACTION_SCARLET_RESURRECTION, true);
         AddCombatAction(WHITEMANE_ACTION_SCARLET_RESURRECTION_TIMER, false);
         AddCombatAction(WHITEMANE_ACTION_SCARLET_RESURRECTION_ENTER_COMBAT, false);        
@@ -345,6 +345,7 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
         DisableCombatAction(WHITEMANE_ACTION_HEAL);
         DisableCombatAction(WHITEMANE_ACTION_HOLY_SMITE);
         DisableCombatAction(WHITEMANE_ACTION_POWERWORD_SHIELD);
+        DisableCombatAction(WHITEMANE_ACTION_SCARLET_RESURRECTION_ENTER_COMBAT);
 
         if (!m_instance)
             return;
@@ -388,9 +389,9 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
                 if (Creature* pMograine = m_instance->GetSingleCreatureFromStorage(NPC_MOGRAINE))
                     m_creature->SetFacingToObject(pMograine);
         if(uiMotionType == POINT_MOTION_TYPE && uiPointId == 1){            
-            // ResetCombatAction(WHITEMANE_ACTION_HEAL, 10000u);
-            // ResetCombatAction(WHITEMANE_ACTION_POWERWORD_SHIELD, 15000u);
-            // ResetCombatAction(WHITEMANE_ACTION_HOLY_SMITE, 500u);
+            ResetCombatAction(WHITEMANE_ACTION_HEAL, 10000u);
+            ResetCombatAction(WHITEMANE_ACTION_POWERWORD_SHIELD, 15000u);
+            ResetCombatAction(WHITEMANE_ACTION_HOLY_SMITE, 100u);
             SetMeleeEnabled(true);
             m_creature->SetInCombatWithZone();
         }
@@ -469,6 +470,7 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
                     DisableCombatAction(WHITEMANE_ACTION_DOMINATE_MIND);
                     DisableCombatAction(WHITEMANE_ACTION_HEAL);
                     DisableCombatAction(WHITEMANE_ACTION_HOLY_SMITE);
+                    DisableCombatAction(WHITEMANE_ACTION_POWERWORD_SHIELD);
                     DisableCombatAction(action);
                 }
                 return;
@@ -497,6 +499,7 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
                 ResetTimer(WHITEMANE_ACTION_HEAL, 13000u);
                 ResetTimer(WHITEMANE_ACTION_POWERWORD_SHIELD, urand(22000, 45000));
                 ResetTimer(WHITEMANE_ACTION_HOLY_SMITE, urand(3500, 5000));
+                SetActionReadyStatus(WHITEMANE_ACTION_DOMINATE_MIND, true);
                 DisableCombatAction(WHITEMANE_ACTION_SCARLET_RESURRECTION_NO_COMBAT);
                 DisableCombatAction(action);
                 return;

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -166,7 +166,6 @@ struct boss_scarlet_commander_mograineAI : public ScriptedAI
 
             m_bHasDied = true;
             m_bFakeDeath = true;
-            SetDeathPrevention(false);
         }
     }
 
@@ -194,6 +193,7 @@ struct boss_scarlet_commander_mograineAI : public ScriptedAI
             m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
             m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
             m_creature->SetStandState(UNIT_STAND_STATE_STAND);
+            SetDeathPrevention(false);
             // spell has script target on Whitemane
             DoCastSpellIfCan(m_creature, SPELL_LAYONHANDS);
 

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -62,7 +62,6 @@ struct boss_scarlet_commander_mograineAI : public ScriptedAI
     boss_scarlet_commander_mograineAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
         m_pInstance = (ScriptedInstance*)pCreature->GetInstanceData();
-        SetReactState(REACT_AGGRESSIVE);
         Reset();
     }
 

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -136,7 +136,6 @@ struct boss_scarlet_commander_mograineAI : public CombatAI
                 if (!(m_instance->GetData(TYPE_MOGRAINE_AND_WHITE_EVENT) == NOT_STARTED) || !(m_instance->GetData(TYPE_MOGRAINE_AND_WHITE_EVENT) == FAIL))
                     m_instance->SetData(TYPE_MOGRAINE_AND_WHITE_EVENT, FAIL);
             }
-            
         }
     }
 
@@ -315,7 +314,7 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
         {
             case WHITEMANE_ACTION_HEAL: return 13000u;
             case WHITEMANE_ACTION_POWERWORD_SHIELD: return urand(22000, 45000);
-            case WHITEMANE_ACTION_HOLY_SMITE: return urand(3500, 8000);
+            case WHITEMANE_ACTION_HOLY_SMITE: return urand(3500, 7000);
             default: return 0; // never occurs but for compiler
         }
     }
@@ -380,8 +379,8 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
             if(m_instance)
                 if (Creature* pMograine = m_instance->GetSingleCreatureFromStorage(NPC_MOGRAINE))
                     m_creature->SetFacingToObject(pMograine);
-        if(uiMotionType == POINT_MOTION_TYPE && uiPointId == 1){      
-            SetCombatScriptStatus(false);      
+        if(uiMotionType == POINT_MOTION_TYPE && uiPointId == 1){
+            SetCombatScriptStatus(false);
             ResetCombatAction(WHITEMANE_ACTION_HEAL, 10000u);
             ResetCombatAction(WHITEMANE_ACTION_POWERWORD_SHIELD, 15000u);
             ResetCombatAction(WHITEMANE_ACTION_HOLY_SMITE, 100u);
@@ -413,7 +412,7 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
             }
             case WHITEMANE_ACTION_HOLY_SMITE:
             {
-                if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_HOLYSMITE) == CAST_OK)                    
+                if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_HOLYSMITE) == CAST_OK)
                     ResetCombatAction(action, GetSubsequentActionTimer(action));
                 return;
             }
@@ -451,7 +450,7 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
             }
             case WHITEMANE_ACTION_DOMINATE_MIND:
             {
-                if(urand(1, 1000) == 1){
+                if(!urand(0, 1000)){
                     Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0);
                     if(target)
                         DoCastSpellIfCan(target, SPELL_DOMINATEMIND);
@@ -463,7 +462,6 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
                 if (m_bCanResurrect)
                 {
                     SetActionReadyStatus(WHITEMANE_ACTION_SCARLET_RESURRECTION_NO_COMBAT, true);
-                    // ResetCombatAction(WHITEMANE_ACTION_SCARLET_RESURRECTION, 7000u);
                     ResetCombatAction(WHITEMANE_ACTION_SCARLET_RESURRECTION, 3000u);
                     DisableCombatAction(WHITEMANE_ACTION_DOMINATE_MIND);
                     DisableCombatAction(WHITEMANE_ACTION_HEAL);
@@ -490,9 +488,9 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
             {
                 m_creature->GetMotionMaster()->MoveChase(m_creature->GetVictim());
                 m_bDidResurrect = false;
-                ResetTimer(WHITEMANE_ACTION_HEAL, 13000u);
-                ResetTimer(WHITEMANE_ACTION_POWERWORD_SHIELD, urand(22000, 45000));
-                ResetTimer(WHITEMANE_ACTION_HOLY_SMITE, urand(3500, 5000));
+                ResetTimer(WHITEMANE_ACTION_HEAL, GetSubsequentActionTimer(WHITEMANE_ACTION_HEAL));
+                ResetTimer(WHITEMANE_ACTION_POWERWORD_SHIELD, GetSubsequentActionTimer(WHITEMANE_ACTION_POWERWORD_SHIELD));
+                ResetTimer(WHITEMANE_ACTION_HOLY_SMITE, GetSubsequentActionTimer(WHITEMANE_ACTION_HOLY_SMITE));
                 SetActionReadyStatus(WHITEMANE_ACTION_DOMINATE_MIND, true);
                 SetCombatMovement(true);
                 DisableCombatAction(WHITEMANE_ACTION_SCARLET_RESURRECTION_NO_COMBAT);

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -286,8 +286,6 @@ struct boss_high_inquisitor_whitemaneAI : public ScriptedAI
             if (m_creature->IsAlive() && !pMograine->IsAlive())
                 pMograine->Respawn();
         }
-
-        SetDeathPrevention(true);
     }
 
     void JustReachedHome() override
@@ -352,7 +350,6 @@ struct boss_high_inquisitor_whitemaneAI : public ScriptedAI
                 m_bDidResurrect = true;
                 m_creature->GetMotionMaster()->Clear();
                 SetCombatMovement(true);
-                SetDeathPrevention(false);
             }
             else
             {

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -315,7 +315,7 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
         {
             case WHITEMANE_ACTION_HEAL: return 13000u;
             case WHITEMANE_ACTION_POWERWORD_SHIELD: return urand(22000, 45000);
-            case WHITEMANE_ACTION_HOLY_SMITE: return urand(3500, 5000);
+            case WHITEMANE_ACTION_HOLY_SMITE: return urand(3500, 8000);
             default: return 0; // never occurs but for compiler
         }
     }
@@ -413,13 +413,8 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
             }
             case WHITEMANE_ACTION_HOLY_SMITE:
             {
-                if(urand(1,3) <= 2)
-                {
-                    if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_HOLYSMITE) == CAST_OK)                    
-                        ResetCombatAction(action, GetSubsequentActionTimer(action));
-                } else {
-                    DelayCombatAction(WHITEMANE_ACTION_HOLY_SMITE, 1500u);
-                }
+                if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_HOLYSMITE) == CAST_OK)                    
+                    ResetCombatAction(action, GetSubsequentActionTimer(action));
                 return;
             }
             case WHITEMANE_ACTION_POWERWORD_SHIELD:
@@ -508,6 +503,7 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
             case WHITEMANE_ACTION_SCARLET_RESURRECTION_NO_COMBAT:
             {
                 m_creature->AttackStop(true);
+                return;
             }
             case WHITEMANE_ACTION_WAITING_FOR_COMBAT:
             {
@@ -515,6 +511,7 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
                 {
                     m_creature->SetFacingToObject(pMograine);
                 }
+                return;
             }
         }
     }

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -384,7 +384,7 @@ struct boss_high_inquisitor_whitemaneAI : public ScriptedAI
                 SetCombatMovement(false);
                 m_creature->AttackStop(true);
                 float fX, fY, fZ;
-                pMograine->GetContactPoint(m_creature, fX, fY, fZ, INTERACTION_DISTANCE);
+                pMograine->GetContactPoint(m_creature, fX, fY, fZ, INTERACTION_DISTANCE/2.f);
                 m_creature->GetMotionMaster()->Clear();
                 m_creature->GetMotionMaster()->MovePoint(2, fX, fY, fZ, FORCED_MOVEMENT_RUN);
             }

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -87,6 +87,7 @@ struct boss_scarlet_commander_mograineAI : public ScriptedAI
         m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
         m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
         m_creature->SetStandState(UNIT_STAND_STATE_STAND);
+        SetDeathPrevention(true);
     }
 
     void MoveInLineOfSight(Unit* pWho) override
@@ -135,15 +136,11 @@ struct boss_scarlet_commander_mograineAI : public ScriptedAI
         }            
     }
 
-    void DamageTaken(Unit* /*dealer*/, uint32& damage, DamageEffectType /*damagetype*/, SpellEntry const* /*spellInfo*/) override
+    void JustPreventedDeath(Unit* /*attacker*/) override
     {
-        if (damage < m_creature->GetHealth() || m_bHasDied)
-            return;
-
         if (!m_pInstance)
             return;
 
-        // On first death, fake death and open door, as well as initiate whitemane if exist
         if (Creature* pWhitemane = m_pInstance->GetSingleCreatureFromStorage(NPC_WHITEMANE))
         {
             m_pInstance->SetData(TYPE_MOGRAINE_AND_WHITE_EVENT, IN_PROGRESS);
@@ -169,8 +166,7 @@ struct boss_scarlet_commander_mograineAI : public ScriptedAI
 
             m_bHasDied = true;
             m_bFakeDeath = true;
-
-            damage = std::min(damage, m_creature->GetHealth() - 1);
+            SetDeathPrevention(false);
         }
     }
 

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -374,7 +374,7 @@ struct boss_high_inquisitor_whitemaneAI : public ScriptedAI
             {
                 SetCombatMovement(false);
                 float fX, fY, fZ;
-                pMograine->GetContactPoint(m_creature, fX, fY, fZ, CONTACT_DISTANCE);
+                pMograine->GetContactPoint(m_creature, fX, fY, fZ, INTERACTION_DISTANCE);
                 m_creature->GetMotionMaster()->Clear();
                 m_creature->GetMotionMaster()->MovePoint(0, fX, fY, fZ, FORCED_MOVEMENT_RUN);
             }

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -181,7 +181,6 @@ struct boss_scarlet_commander_mograineAI : public CombatAI
             m_instance->SetData(TYPE_MOGRAINE_AND_WHITE_EVENT, IN_PROGRESS);
 
             pWhitemane->GetMotionMaster()->MovePoint(1, 1163.113370f, 1398.856812f, 32.527786f, FORCED_MOVEMENT_RUN);
-            pWhitemane->AI()->SetCombatScriptStatus(true);
 
             DoScriptText(SAY_WH_INTRO, pWhitemane);
 
@@ -302,7 +301,6 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
         AddTimerlessCombatAction(WHITEMANE_ACTION_DOMINATE_MIND, true);
         AddTimerlessCombatAction(WHITEMANE_ACTION_SCARLET_RESURRECTION_NO_COMBAT, false);
         AddTimerlessCombatAction(WHITEMANE_ACTION_WAITING_FOR_COMBAT, false);
-        SetMeleeEnabled(false);
 
         Reset();
     }
@@ -339,12 +337,6 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
 
         if (!m_instance)
             return;
-
-        // if (Creature* pMograine = m_instance->GetSingleCreatureFromStorage(NPC_MOGRAINE))
-        // {
-        //     if (m_creature->IsAlive() && !pMograine->IsAlive())
-        //         pMograine->Respawn();
-        // }
     }
 
     void EnterEvadeMode() override
@@ -371,6 +363,13 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
         CombatAI::AttackStart(pWho);
     }
 
+    void EnterCombat(Unit* /*enemy*/) override
+    {
+            ResetCombatAction(WHITEMANE_ACTION_HEAL, 10000u);
+            ResetCombatAction(WHITEMANE_ACTION_POWERWORD_SHIELD, 15000u);
+            ResetCombatAction(WHITEMANE_ACTION_HOLY_SMITE, 100u);
+    }
+
     void MovementInform(uint32 uiMotionType, uint32 uiPointId) override
     {
         if (uiMotionType == POINT_MOTION_TYPE && uiPointId == 2)
@@ -378,11 +377,6 @@ struct boss_high_inquisitor_whitemaneAI : public CombatAI
                 if (Creature* pMograine = m_instance->GetSingleCreatureFromStorage(NPC_MOGRAINE))
                     m_creature->SetFacingToObject(pMograine);
         if(uiMotionType == POINT_MOTION_TYPE && uiPointId == 1){
-            SetCombatScriptStatus(false);
-            ResetCombatAction(WHITEMANE_ACTION_HEAL, 10000u);
-            ResetCombatAction(WHITEMANE_ACTION_POWERWORD_SHIELD, 15000u);
-            ResetCombatAction(WHITEMANE_ACTION_HOLY_SMITE, 100u);
-            SetMeleeEnabled(true);
             m_creature->SetInCombatWithZone();
         }
     }

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/instance_scarlet_monastery.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/instance_scarlet_monastery.cpp
@@ -93,6 +93,7 @@ uint32 instance_scarlet_monastery::GetData(uint32 uiData) const
         return m_auiEncounter[0];
     if (uiData == TYPE_ASHBRINGER_EVENT)
         return m_auiEncounter[1];
+
     return 0;
 }
 

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/instance_scarlet_monastery.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/instance_scarlet_monastery.cpp
@@ -85,6 +85,8 @@ void instance_scarlet_monastery::SetData(uint32 uiType, uint32 uiData)
     }
     else if (uiType == TYPE_ASHBRINGER_EVENT)
         m_auiEncounter[1] = uiData;
+    else if (uiType == TYPE_WHITEMANE_DEFEATED)
+        m_whitemaneDefeated = true;
 }
 
 uint32 instance_scarlet_monastery::GetData(uint32 uiData) const
@@ -93,7 +95,8 @@ uint32 instance_scarlet_monastery::GetData(uint32 uiData) const
         return m_auiEncounter[0];
     if (uiData == TYPE_ASHBRINGER_EVENT)
         return m_auiEncounter[1];
-
+    if (uiData == TYPE_WHITEMANE_DEFEATED)
+        return m_whitemaneDefeated;
     return 0;
 }
 

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/instance_scarlet_monastery.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/instance_scarlet_monastery.cpp
@@ -85,8 +85,6 @@ void instance_scarlet_monastery::SetData(uint32 uiType, uint32 uiData)
     }
     else if (uiType == TYPE_ASHBRINGER_EVENT)
         m_auiEncounter[1] = uiData;
-    else if (uiType == TYPE_WHITEMANE_DEFEATED)
-        m_whitemaneDefeated = true;
 }
 
 uint32 instance_scarlet_monastery::GetData(uint32 uiData) const
@@ -95,8 +93,6 @@ uint32 instance_scarlet_monastery::GetData(uint32 uiData) const
         return m_auiEncounter[0];
     if (uiData == TYPE_ASHBRINGER_EVENT)
         return m_auiEncounter[1];
-    if (uiData == TYPE_WHITEMANE_DEFEATED)
-        return m_whitemaneDefeated;
     return 0;
 }
 

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/instance_scarlet_monastery.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/instance_scarlet_monastery.cpp
@@ -22,6 +22,7 @@ SDCategory: Scarlet Monastery
 EndScriptData */
 
 #include "AI/ScriptDevAI/include/sc_common.h"
+#include "AI/ScriptDevAI/include/sc_instance.h"
 #include "scarlet_monastery.h"
 
 instance_scarlet_monastery::instance_scarlet_monastery(Map* pMap) : ScriptedInstance(pMap)
@@ -79,7 +80,40 @@ void instance_scarlet_monastery::SetData(uint32 uiType, uint32 uiData)
         if (uiData == IN_PROGRESS)
             DoUseDoorOrButton(GO_WHITEMANE_DOOR);
         if (uiData == FAIL)
-            DoUseDoorOrButton(GO_WHITEMANE_DOOR);
+            {
+                {
+                    Creature* pWhitemane = GetSingleCreatureFromStorage(NPC_WHITEMANE);
+                    if(!pWhitemane)
+                        return;
+                    Creature* pMograine = GetSingleCreatureFromStorage(NPC_MOGRAINE);
+                    if(!pMograine)
+                        return;
+                    if(pWhitemane->IsAlive() && pMograine->IsAlive())
+                    {
+                        pWhitemane->ForcedDespawn();
+                        pWhitemane->Respawn();
+                        pMograine->ForcedDespawn();
+                        pMograine->Respawn();
+                        DoUseDoorOrButton(GO_WHITEMANE_DOOR);
+                        m_auiEncounter[0] = NOT_STARTED;
+                        return;
+                    }
+                    if(!pMograine->IsAlive() && pWhitemane->IsAlive())
+                    {
+                        pWhitemane->ForcedDespawn();
+                        pWhitemane->Respawn();
+                        DoUseDoorOrButton(GO_WHITEMANE_DOOR);
+                        m_auiEncounter[0] = uiData;
+                        return;
+                    }
+                    if(!pWhitemane->IsAlive() && pMograine->IsAlive())
+                    {
+                        pMograine->ForcedDespawn();
+                        m_auiEncounter[0] = uiData;
+                        return;
+                    }
+                }
+            }
 
         m_auiEncounter[0] = uiData;
     }

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/scarlet_monastery.h
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/scarlet_monastery.h
@@ -11,7 +11,6 @@ enum
 
     TYPE_MOGRAINE_AND_WHITE_EVENT   = 1,
     TYPE_ASHBRINGER_EVENT           = 2,
-    TYPE_WHITEMANE_DEFEATED         = 3,
 
     NPC_MOGRAINE                    = 3976,
     NPC_WHITEMANE                   = 3977,
@@ -45,7 +44,6 @@ class instance_scarlet_monastery : public ScriptedInstance
 
     private:
         uint32 m_auiEncounter[MAX_ENCOUNTER];
-        bool m_whitemaneDefeated = false;
 };
 
 #endif

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/scarlet_monastery.h
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/scarlet_monastery/scarlet_monastery.h
@@ -11,6 +11,7 @@ enum
 
     TYPE_MOGRAINE_AND_WHITE_EVENT   = 1,
     TYPE_ASHBRINGER_EVENT           = 2,
+    TYPE_WHITEMANE_DEFEATED         = 3,
 
     NPC_MOGRAINE                    = 3976,
     NPC_WHITEMANE                   = 3977,
@@ -44,6 +45,7 @@ class instance_scarlet_monastery : public ScriptedInstance
 
     private:
         uint32 m_auiEncounter[MAX_ENCOUNTER];
+        bool m_whitemaneDefeated = false;
 };
 
 #endif


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Basically the same as https://github.com/cmangos/mangos-tbc/pull/427 but with a crude CombatAI implementation
Additional issues fixed:
Whitemane now completes her run to the first waypoint before engaging
Whitemane resurrects Mograine earlier in the sleep phase

Issue that could not be fixed:
Whitemane doesn't salute to Mograine after resurrecting him. I tried, I failed.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create Character
- Set character level to 40
- `.additem 7146`
- `.tele scarletmonastery`
- Enter the left locked door to get to Scarlet Monastery Cathedral
- `.gm on` is probably easiest
- Move to the cathedral
- `.die` everything inside except for Scarlet Commander Mograine
- On yourself do:
- `.mod stam 100000`
- `.mod ap 5000`
- `.gm off` and engage Mograine
- After Mograine has died, Whitemane will appear and start casting Smite on you
- When Whitemane gets to 50% health, she'll cast Deep Sleep on everyone in range and resurrect Mograine
- Hit them until they both die

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Somehow get Salute working?

### Known Issues
- Playerbots don't quite play nicely with this script, as they seem to be able to continue hitting Mograine while he's faking death, thus re-aggroing him. This causes him to follow the playerbot around while lying on the ground and being untargetable. Don't know how to fix this :(
