### PR TITLE
Shadowfang Keep: Fix Arugal Voidwalkers

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/shadowfang_keep/shadowfang_keep.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/shadowfang_keep/shadowfang_keep.cpp
@@ -216,11 +216,12 @@ struct mob_arugal_voidwalkerAI : public ScriptedAI
         m_bWPDone = true;
 
         Creature* pLeader = m_creature->GetMap()->GetCreature(m_leaderGuid);
-        if (pLeader && pLeader->IsAlive())
+        if (pLeader && pLeader->IsAlive() && m_creature != pLeader)
         {
             m_creature->GetMotionMaster()->MoveFollow(pLeader, 1.0f, M_PI / 2 * m_uiPosition);
         }
-        else
+
+        if (pLeader && !pLeader->IsAlive())
         {
             CreatureList lVoidwalkerList;
             Creature* pNewLeader = nullptr;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
If, after killing Fenrus in Shadowfang Keep you wiped or in some other way got out of combat with the voidwalkers, they would start pathing down the staircase and at some point they would start moving straight out of the map to undefined coordinates.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/1204
### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
(Copied from the original issue)
- .go creature fenrus
- Kill the dog
- Don't engage the 4 voidwalkers, just follow them as they start to patrol
- See some of them getting lost, especially at the bottom of the stairs

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Maybe fix them going invisible sometimes as they walk down the stairs? I believe this is caused by them clipping beneath the stairs for a few pixels, so the game culls their visibility and nameplate. No idea how to, tho.
