### PR TITLE
Correct Faerlina's outer door

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/naxxramas.h
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/naxxramas.h
@@ -121,7 +121,7 @@ enum
     GO_ARAC_ANUB_DOOR           = 181126,                   // encounter door
     GO_ARAC_ANUB_GATE           = 181195,                   // open after boss is dead
     GO_ARAC_FAER_WEB            = 181235,                   // encounter door
-    GO_ARAC_FAER_DOOR           = 194022,                   // after faerlina, to outer ring
+    GO_ARAC_FAER_DOOR           = 181167,                   // after faerlina, to outer ring
     GO_ARAC_MAEX_INNER_DOOR     = 181197,                   // encounter door
     GO_ARAC_MAEX_OUTER_DOOR     = 181209,                   // right before maex
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Previously there was no outer door from Faerlina to the outer ring of Naxxramas and it also had the wrong Gameobject ID in the source

Fixed this issue in conjunction with tbc-db PR https://github.com/cmangos/tbc-db/pull/818

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
