### PR TITLE
Fix for "account onlinelist" command

### DIFF
--- a/src/mangosd/CliRunnable.cpp
+++ b/src/mangosd/CliRunnable.cpp
@@ -477,7 +477,7 @@ bool ChatHandler::HandleAccountOnlineListCommand(char* args)
 
     ///- Get the list of accounts ID logged to the realm
     //                                                 0            1         2        3        4
-    QueryResult* result = LoginDatabase.PQuery("SELECT distinct id, username, ip, gmlevel, expansion FROM account a join account_logons b on(a.id=b.accountId) WHERE active_realm_id = %u", realmID);
+    QueryResult* result = LoginDatabase.PQuery("SELECT distinct a.id, username, ip, gmlevel, expansion FROM account a join account_logons b on(a.id=b.accountId) WHERE active_realm_id = %u", realmID);
 
     return ShowAccountListHelper(result, &limit);
 }


### PR DESCRIPTION
Fix for "account onlinelist" command  (ERROR: Column 'id' in field list is ambiguous)

## 🍰 Pullrequest


### Proof
2021-03-02 16:14:13 SQL: SELECT distinct id, username, ip, gmlevel, expansion FROM account a join account_logons b on(a.id=b.accountId) WHERE active_realm_id = 1
2021-03-02 16:14:13 query ERROR: Column 'id' in field list is ambiguous

### Issues
command not working

### How2Test
use account onlinelist command

