### PR TITLE
Make Travis work at least

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ matrix:
 
     # osx builds on clang x64
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode10.2
       arch: amd64
       compiler: clang
       env:


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Travis used to fail on OSX because an OSX Version unsupported by Homebrew was used. This PR changes the OSX Version to 10.14, the oldest OSX supported by Homebrew.