### PR TITLE
Silence Clang compiler warnings

### DIFF
--- a/src/game/AI/BaseAI/UnitAI.cpp
+++ b/src/game/AI/BaseAI/UnitAI.cpp
@@ -217,6 +217,7 @@ CanCastResult UnitAI::DoCastSpellIfCan(Unit* target, uint32 spellId, uint32 cast
                     case SPELL_FAILED_BAD_TARGETS:
                     case SPELL_FAILED_DONT_REPORT:
                         return CAST_FAIL_OTHER;
+                    default: break;
                 }
                 sLog.outBasic("DoCastSpellIfCan by %s attempt to cast spell %u but spell failed due to unknown result %u.", m_unit->GetObjectGuid().GetString().c_str(), spellId, result);
                 return CAST_FAIL_OTHER;

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/karazhan.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/karazhan.cpp
@@ -215,12 +215,16 @@ void instance_karazhan::OnObjectCreate(GameObject* pGo)
 void instance_karazhan::OnCreatureRespawn(Creature* creature)
 {
     if (creature->GetEntry() == NPC_BLIZZARD)
+    {
         creature->AI()->SetReactState(REACT_PASSIVE);
+    }
     else if (creature->GetEntry() == NPC_INFERNAL)
+    {
         if (GetData(TYPE_MALCHEZZAR) == IN_PROGRESS)
             return;
         else
             creature->ForcedDespawn(1);
+    }
 }
 
 void instance_karazhan::SetData(uint32 uiType, uint32 uiData)

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/magisters_terrace/boss_selin_fireheart.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/magisters_terrace/boss_selin_fireheart.cpp
@@ -206,6 +206,7 @@ struct boss_selin_fireheartAI : public CombatAI
 
                 DoEndCrystalDraining();
             break;
+            default: break;
         }
     }
 

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/caverns_of_time/hyjal/hyjal.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/caverns_of_time/hyjal/hyjal.cpp
@@ -1556,6 +1556,7 @@ void instance_mount_hyjal::DespawnBase(BaseArea index)
             if (Creature* creature = GetSingleCreatureFromStorage(NPC_THRALL))
                 creature->ForcedDespawn();
             break;
+        default: break;
     }
 }
 
@@ -1577,6 +1578,7 @@ void instance_mount_hyjal::SpawnBase(BaseArea index, bool spawnLeader = true)
                 if (Creature* creature = GetSingleCreatureFromStorage(NPC_THRALL))
                     creature->Respawn();
                 break;
+            default: break;
         }
     }
 }
@@ -1609,7 +1611,7 @@ void instance_mount_hyjal::RetreatBase(BaseArea index)
             }
             break;
         }
-
+        default: break;
     }
 
     SetData(TYPE_WIN, SPECIAL);
@@ -1637,6 +1639,7 @@ void instance_mount_hyjal::OverrunBase(BaseArea index)
             m_invasionWaves = 14;
             SpawnInvasionWave(14, true);
             break;
+        default: break;
     }
 }
 

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/caverns_of_time/hyjal/hyjalAI.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/caverns_of_time/hyjal/hyjalAI.cpp
@@ -189,6 +189,7 @@ void hyjalAI::ReceiveAIEvent(AIEventType eventType, Unit* sender, Unit* /*invoke
             Win();
             break;
         }
+        default: break;
     }
 }
 

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/dustwallow_marsh.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/dustwallow_marsh.cpp
@@ -970,6 +970,7 @@ struct mob_invis_firework_helper : public Scripted_NoMovementAI
     void UpdateAI(const uint32 uiDiff) override
     {
         if (m_uiFireworkTimer)
+        {
             if (m_uiFireworkTimer < uiDiff)
             {
                 if (++m_uiFireworkCounter >= 5)
@@ -991,7 +992,10 @@ struct mob_invis_firework_helper : public Scripted_NoMovementAI
                 }
             }
             else
+            {
                 m_uiFireworkTimer -= uiDiff;
+            }
+        }
     }
 };
 

--- a/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/sethekk_halls/boss_anzu.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/sethekk_halls/boss_anzu.cpp
@@ -438,6 +438,7 @@ struct npc_anzu_bird_spiritAI : public ScriptedAI
                 FreezeSpirits();
                 break;
             }
+            default: break;
         }
     }
 

--- a/src/game/AI/ScriptDevAI/scripts/outland/black_temple/boss_illidan.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/black_temple/boss_illidan.cpp
@@ -843,6 +843,7 @@ struct boss_illidan_stormrageAI : public CombatAI, private DialogueHelper
                 ResetTimer(ILLIDAN_ACTION_PHASE_TRANSITION, 1000u);
                 break;
             }
+            default: break;
         }
     }
 
@@ -906,6 +907,7 @@ struct boss_illidan_stormrageAI : public CombatAI, private DialogueHelper
                 ResetCombatAction(ILLIDAN_ACTION_TRANSFORM, GetInitialActionTimer(ILLIDAN_ACTION_TRANSFORM));
                 break;
             }
+            default: break;
         }
     }
 
@@ -1099,6 +1101,7 @@ struct boss_illidan_stormrageAI : public CombatAI, private DialogueHelper
                 //TODO
                 break;
             }
+            default: break;
         }
         if (nextTimer)
             ResetTimer(ILLIDAN_ACTION_PHASE_TRANSITION, nextTimer);

--- a/src/game/AI/ScriptDevAI/scripts/outland/black_temple/boss_teron_gorefiend.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/black_temple/boss_teron_gorefiend.cpp
@@ -174,6 +174,7 @@ struct boss_teron_gorefiendAI : public ScriptedAI, public CombatActions
                     m_introDone = true;
                 }
                 break;
+            default: break;
         }
     }
 

--- a/src/game/AI/ScriptDevAI/scripts/outland/netherstorm.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/netherstorm.cpp
@@ -181,7 +181,9 @@ struct npc_manaforge_spawnAI : public ScriptedAI
         Creature *manaforge;
 
         if (m_manaforgeGuid)
-            if ((manaforge = m_creature->GetMap()->GetCreature(m_manaforgeGuid)))
+        {
+            manaforge = m_creature->GetMap()->GetCreature(m_manaforgeGuid);
+            if (manaforge)
             {
                 uint32 uiManaforgeEntry = manaforge->GetEntry();
 
@@ -230,6 +232,7 @@ struct npc_manaforge_spawnAI : public ScriptedAI
                     m_creature->GetMotionMaster()->MovePoint(uiMPID, fX, fY, m_creature->GetPositionZ());
                 }
             }
+        }
     }
 
     void UpdateAI(const uint32 /*uiDiff*/) override

--- a/src/game/AI/ScriptDevAI/scripts/outland/netherstorm.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/netherstorm.cpp
@@ -181,7 +181,7 @@ struct npc_manaforge_spawnAI : public ScriptedAI
         Creature *manaforge;
 
         if (m_manaforgeGuid)
-            if (manaforge = m_creature->GetMap()->GetCreature(m_manaforgeGuid))
+            if ((manaforge = m_creature->GetMap()->GetCreature(m_manaforgeGuid)))
             {
                 uint32 uiManaforgeEntry = manaforge->GetEntry();
 
@@ -476,7 +476,7 @@ struct npc_manaforge_control_consoleAI : public ScriptedAI
                             pAdd->GetMotionMaster()->MovePoint(0, m_afAraTechCoords[i + 3][0], m_afAraTechCoords[i + 3][1], m_afAraTechCoords[i + 3][2]);
                         }
                     if (!urand(0, 2)) // 1 in 3 chance to spawn a engineer
-                        if (pAdd = m_creature->SummonCreature(NPC_ARA_ENGI, m_afAraTechCoords[0][0], m_afAraTechCoords[0][1], m_afAraTechCoords[0][2], 0.0f, TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 120000))
+                        if ((pAdd = m_creature->SummonCreature(NPC_ARA_ENGI, m_afAraTechCoords[0][0], m_afAraTechCoords[0][1], m_afAraTechCoords[0][2], 0.0f, TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 120000)))
                             pAdd->GetMotionMaster()->MovePoint(0, m_afAraTechCoords[3][0], m_afAraTechCoords[3][1], m_afAraTechCoords[3][2]);
                 }
                 else if (route == 1)
@@ -488,7 +488,7 @@ struct npc_manaforge_control_consoleAI : public ScriptedAI
                             pAdd->GetMotionMaster()->MovePoint(0, m_afAraTechCoords[i + 3][0], m_afAraTechCoords[i + 3][1], m_afAraTechCoords[i + 3][2]);
                         }
                     if (!urand(0, 2)) // 1 in 3 chance to spawn a engineer
-                        if (pAdd = m_creature->SummonCreature(NPC_ARA_ENGI, m_afAraTechCoords[6][0], m_afAraTechCoords[6][1], m_afAraTechCoords[6][2], 0.0f, TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 120000))
+                        if ((pAdd = m_creature->SummonCreature(NPC_ARA_ENGI, m_afAraTechCoords[6][0], m_afAraTechCoords[6][1], m_afAraTechCoords[6][2], 0.0f, TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 120000)))
                             pAdd->GetMotionMaster()->MovePoint(0, m_afAraTechCoords[9][0], m_afAraTechCoords[9][1], m_afAraTechCoords[9][2]);
                 }
                 else
@@ -500,7 +500,7 @@ struct npc_manaforge_control_consoleAI : public ScriptedAI
                             pAdd->GetMotionMaster()->MovePoint(0, m_afAraTechCoords[i + 3][0], m_afAraTechCoords[i + 3][1], m_afAraTechCoords[i + 3][2]);
                         }
                     if (!urand(0, 2)) // 1 in 3 chance to spawn a engineer
-                        if (pAdd = m_creature->SummonCreature(NPC_ARA_ENGI, m_afAraTechCoords[12][0], m_afAraTechCoords[12][1], m_afAraTechCoords[12][2], 0.0f, TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 120000))
+                        if ((pAdd = m_creature->SummonCreature(NPC_ARA_ENGI, m_afAraTechCoords[12][0], m_afAraTechCoords[12][1], m_afAraTechCoords[12][2], 0.0f, TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 120000)))
                             pAdd->GetMotionMaster()->MovePoint(0, m_afAraTechCoords[15][0], m_afAraTechCoords[15][1], m_afAraTechCoords[15][2]);
                 }
                 m_uiWaveTimer = 15000;
@@ -549,7 +549,7 @@ struct npc_manaforge_control_consoleAI : public ScriptedAI
                 if ((pAdd = m_creature->SummonCreature(NPC_ARA_GORKLONN, m_afAraTechCoords[12][0], m_afAraTechCoords[12][1], m_afAraTechCoords[12][2], 4.44f, TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 120000)))
                 {
                     Player* pPlayer;
-                    if (pPlayer = m_creature->GetMap()->GetPlayer(m_playerGuid))
+                    if ((pPlayer = m_creature->GetMap()->GetPlayer(m_playerGuid)))
                         pAdd->AI()->AttackStart(pPlayer);
                     else
                         pAdd->GetMotionMaster()->MovePoint(0, m_afAraTechCoords[15][0], m_afAraTechCoords[15][1], m_afAraTechCoords[15][2]);

--- a/src/game/AI/ScriptDevAI/scripts/outland/shadowmoon_valley.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/shadowmoon_valley.cpp
@@ -4573,6 +4573,7 @@ struct npc_bt_battle_sensor : public ScriptedAI
                             senderAI->m_bIsWaypointing = false;
                         break;
                     }
+                    default: break;
                 }
 
                 break;
@@ -4658,6 +4659,7 @@ struct npc_bt_battle_sensor : public ScriptedAI
                             senderAI->m_bIsWaypointing = false;
                         break;
                     }
+                    default: break;
                 }
 
                 break;
@@ -4725,6 +4727,7 @@ struct npc_bt_battle_sensor : public ScriptedAI
                         }
                         break;
                     }
+                    default: break;
                 }
 
                 break;
@@ -4786,6 +4789,7 @@ struct npc_bt_battle_sensor : public ScriptedAI
                         }
                         break;
                     }
+                    default: break;
                 }
 
                 break;
@@ -4812,6 +4816,7 @@ struct npc_bt_battle_sensor : public ScriptedAI
                         m_caalenGuid = senderGuid;
                         break;
                     }
+                    default: break;
                 }
 
                 break;
@@ -4846,6 +4851,7 @@ struct npc_bt_battle_sensor : public ScriptedAI
                         if (Creature* senderAI = dynamic_cast<Creature*>(sender))
                             senderAI->ForcedDespawn(90000);
                         break;
+                    default: break;
                 }
 
                 break;

--- a/src/game/AI/ScriptDevAI/scripts/outland/world_outland.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/world_outland.cpp
@@ -579,6 +579,7 @@ struct world_map_outland : public ScriptedMap, public TimerManager
                 vendor->HandleEmote(EMOTE_STATE_USESTANDING);
                 vendor->SetCanFly(false);
                 break;
+            default: break;
         }
     }
 
@@ -732,6 +733,7 @@ struct world_map_outland : public ScriptedMap, public TimerManager
                 initialSpawnCount = PHASE_3_INITIAL_SPAWN_COUNT;
                 break;
             }
+            default: break;
         }
         for (uint32 i = 0; i < initialSpawnCount; ++i)
             SpawnRandomBashirMob();
@@ -752,6 +754,7 @@ struct world_map_outland : public ScriptedMap, public TimerManager
             case BASHIR_PHASE_TRANSITION_3:
                 vendor = tech->SummonCreature(NPC_AETHER_TECH_MASTER, bashirSpawnPositions[7][0], bashirSpawnPositions[7][1], bashirSpawnPositions[7][2], bashirSpawnPositions[7][3], TEMPSPAWN_CORPSE_TIMED_DESPAWN, 1000, true, true, 1);
                 break;
+            default: break;
         }
         vendor->Mount(MOUNT_NETHER_RAY_DISPLAY_ID);
         tech->AI()->SendAIEvent(AI_EVENT_CUSTOM_A, tech, tech);
@@ -775,6 +778,7 @@ struct world_map_outland : public ScriptedMap, public TimerManager
             case BASHIR_PHASE_ALL_VENDORS_SPAWNED:
                 ResetTimer(BASHIR_ACTION_OUTRO, (4 * 60 + 40) * IN_MILLISECONDS); // 4 minutes 40 seconds
                 break;
+            default: break;
         }
     }
 
@@ -801,6 +805,7 @@ struct world_map_outland : public ScriptedMap, public TimerManager
                 mob = tech->SummonCreature(NPC_GRAND_COLLECTOR, bashirSpawnPositions[12][0], bashirSpawnPositions[12][1], bashirSpawnPositions[12][2], bashirSpawnPositions[12][3], TEMPSPAWN_CORPSE_TIMED_DESPAWN, 2 * 60 * IN_MILLISECONDS, true);
                 mob->CastSpell(nullptr, SPELL_SPIRIT_SPAWN_IN, TRIGGERED_NONE);
                 break;
+            default: break;
         }
     }
 
@@ -820,6 +825,7 @@ struct world_map_outland : public ScriptedMap, public TimerManager
             case BASHIR_PHASE_3:
                 DoScriptText(SAY_TECH_PHASE_3, tech);
                 break;
+            default: break;
         }
         for (ObjectGuid guid : m_bashirEnemySpawns)
             if (Creature* spawn = instance->GetCreature(guid))
@@ -1163,6 +1169,7 @@ struct world_map_outland : public ScriptedMap, public TimerManager
                 m_shartuulSpawnSequenceStage = 14;
                 break;
             }
+            default: break;
         }
     }
 
@@ -1228,6 +1235,7 @@ struct world_map_outland : public ScriptedMap, public TimerManager
                 {
                     case PHASE_1_FELGUARD_DEGRADER_ADDS: entry = urand(0, 1) ? NPC_FEL_IMP_DEFENDER : NPC_FELHOUND_DEFENDER; break;
                     case PHASE_3_DOOMGUARD_PUNISHER_ADDS: entry = NPC_GANARG_UNDERLING; break;
+                    default: break;
                 }
 
                 uint32 spellId = GetSpellIdForEntry(entry);

--- a/src/game/BattleGround/BattleGroundEY.cpp
+++ b/src/game/BattleGround/BattleGroundEY.cpp
@@ -305,6 +305,7 @@ void BattleGroundEY::ProcessCaptureEvent(GameObject* go, uint32 towerId, Team te
         case ALLIANCE:  SpawnEvent(towerId, TEAM_INDEX_ALLIANCE, true); break;
         case HORDE:     SpawnEvent(towerId, TEAM_INDEX_HORDE,    true); break;
         case TEAM_NONE: SpawnEvent(towerId, TEAM_INDEX_NEUTRAL,  true); break;
+        default: break;
     }
 }
 

--- a/src/game/BattleGround/BattleGroundMgr.cpp
+++ b/src/game/BattleGround/BattleGroundMgr.cpp
@@ -2113,6 +2113,7 @@ void BattleGroundMgr::RewardArenaSeason(uint32 seasonId)
                     case ARENA_TYPE_5v5:
                         sortedTeams[2].push_back(at);
                         break;
+                    default: break;
                 }
             }
         }

--- a/src/game/Spells/Scripts/Scripting/ClassScripts/ScalingAuras.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/ScalingAuras.cpp
@@ -230,6 +230,7 @@ struct WarlockPetScaling4 : public AuraScript
                     if (owner->IsPlayer())
                         value = static_cast<Player*>(owner)->GetFloatValue(PLAYER_FIELD_MOD_MANA_REGEN) * 0.1f * 5.f;
                 break;
+            default: break;
         }
         return value;
     }
@@ -320,6 +321,7 @@ struct MagePetScaling4 : public AuraScript
                 if (Unit* owner = caster->GetOwner())
                     value = (owner->GetResistance(SPELL_SCHOOL_SHADOW) * 0.4f);
                 break;
+            default: break;
         }
         return value;
     }
@@ -398,6 +400,7 @@ struct PriestPetScaling4 : public AuraScript
         {
             case EFFECT_INDEX_0: // resistance
                 break;
+            default: break;
         }
         return value;
     }
@@ -464,6 +467,7 @@ struct ElementalPetScaling4 : public AuraScript
         {
             case EFFECT_INDEX_0: // resistance
                 break;
+            default: break;
         }
         return value;
     }
@@ -542,6 +546,7 @@ struct DruidPetScaling4 : public AuraScript
         {
             case EFFECT_INDEX_0: // resistance
                 break;
+            default: break;
         }
         return value;
     }
@@ -665,6 +670,7 @@ struct InfernalPetScaling4 : public AuraScript
                 break;
             case EFFECT_INDEX_1: // mana regen
                 break;
+            default: break;
         }
         return value;
     }

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -792,7 +792,7 @@ void Spell::AddUnitTarget(Unit* target, uint8 effectMask, CheckException excepti
     targetInfo.heartbeatResistChance = 0;
 
     // Calculate hit result
-    targetInfo.missCondition = (m_ignoreHitResult ? SPELL_MISS_NONE : m_caster->SpellHitResult(target, m_spellInfo, targetInfo.effectMask, m_reflectable, &(targetInfo.heartbeatResistChance)));
+    targetInfo.missCondition = (m_ignoreHitResult ? SPELL_MISS_NONE : m_caster->SpellHitResult(target, m_spellInfo, targetInfo.effectMask, m_reflectable, &targetInfo.heartbeatResistChance));
 
     // spell fly from visual cast object
     WorldObject* affectiveObject = GetAffectiveCasterObject();

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -792,7 +792,7 @@ void Spell::AddUnitTarget(Unit* target, uint8 effectMask, CheckException excepti
     targetInfo.heartbeatResistChance = 0;
 
     // Calculate hit result
-    targetInfo.missCondition = (m_ignoreHitResult ? SPELL_MISS_NONE : m_caster->SpellHitResult(target, m_spellInfo, targetInfo.effectMask, m_reflectable, &targetInfo.heartbeatResistChance));
+    targetInfo.missCondition = (m_ignoreHitResult ? SPELL_MISS_NONE : m_caster->SpellHitResult(target, m_spellInfo, targetInfo.effectMask, m_reflectable, &(targetInfo.heartbeatResistChance)));
 
     // spell fly from visual cast object
     WorldObject* affectiveObject = GetAffectiveCasterObject();
@@ -7296,6 +7296,7 @@ void Spell::GetSpellRangeAndRadius(SpellEffectIndex effIndex, float& radius, boo
                     if (data.enumerator == TARGET_ENUMERATOR_CHAIN || data.enumerator == TARGET_ENUMERATOR_AOE || data.enumerator == TARGET_ENUMERATOR_CONE)
                         radius = 200.f;
                     break;
+                default: break;
             }
         }
     }

--- a/src/game/Spells/SpellTargets.cpp
+++ b/src/game/Spells/SpellTargets.cpp
@@ -453,6 +453,7 @@ void SpellTargetMgr::Initialize()
                                         ignore = true;
                                         break;
                                     }
+                                    default: break;
                                 }
                                 if (ignore)
                                     data.targetMask[effIdxSource][rightSource] |= (1 << effIdxTarget);

--- a/src/game/World/WorldState.cpp
+++ b/src/game/World/WorldState.cpp
@@ -244,6 +244,7 @@ void WorldState::Save(SaveIds saveId)
             SaveHelper(loveData, SAVE_ID_LOVE_IS_IN_THE_AIR);
             break;
         }
+        default: break;
     }
 }
 

--- a/src/mangosd/CliRunnable.cpp
+++ b/src/mangosd/CliRunnable.cpp
@@ -135,7 +135,7 @@ bool ChatHandler::GetDeletedCharacterInfoList(DeletedInfoList& foundList, std::s
     {
         if (resultChar->GetRowCount() > 100)
         {
-            PSendSysMessage("Too many results %llu. Narrow it down.", resultChar->GetRowCount());
+            PSendSysMessage("Too many results %lu. Narrow it down.", resultChar->GetRowCount());
             SetSentErrorMessage(true);
             delete resultChar;
             return false;

--- a/src/mangosd/CliRunnable.cpp
+++ b/src/mangosd/CliRunnable.cpp
@@ -135,7 +135,7 @@ bool ChatHandler::GetDeletedCharacterInfoList(DeletedInfoList& foundList, std::s
     {
         if (resultChar->GetRowCount() > 100)
         {
-            PSendSysMessage("Too many results %lu. Narrow it down.", resultChar->GetRowCount());
+            PSendSysMessage("Too many results %u. Narrow it down.", (uint32)resultChar->GetRowCount());
             SetSentErrorMessage(true);
             delete resultChar;
             return false;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes current clang compiler warnings.
Most are caused by switch statements that don't handle every case. Some are evaluations of assignments, some are dangling else statements and one is what Clang sees as an evaluation of an address