### PR TITLE
Hackfix for Ashcrombe not really wanting to look at the door

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/shadowfang_keep/shadowfang_keep.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/shadowfang_keep/shadowfang_keep.cpp
@@ -86,7 +86,11 @@ struct npc_shadowfang_prisonerAI : public npc_escortAI
                 break;
             case 12:
                 if (m_uiNpcEntry == NPC_ASH)
-                    DoCastSpellIfCan(m_creature, SPELL_UNLOCK);
+                    {
+                        m_creature->GetMotionMaster()->PauseWaypoints(2000);
+                        DoCastSpellIfCan(m_creature, SPELL_UNLOCK);
+                        m_creature->SetFacingToObject(m_pInstance->GetSingleGameObjectFromStorage(GO_COURTYARD_DOOR));
+                    }
                 else
                     DoScriptText(EMOTE_UNLOCK_DOOR_AD, m_creature);
                 break;
@@ -113,8 +117,10 @@ struct npc_shadowfang_prisonerAI : public npc_escortAI
                 }
                 break;
             case 16:
-                if (m_uiNpcEntry == NPC_ASH)
+                if (m_uiNpcEntry == NPC_ASH){
                     DoScriptText(EMOTE_VANISH_AS, m_creature);
+                    m_creature->ForcedDespawn();
+                }
                 break;
         }
     }

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/shadowfang_keep/shadowfang_keep.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/shadowfang_keep/shadowfang_keep.cpp
@@ -117,7 +117,8 @@ struct npc_shadowfang_prisonerAI : public npc_escortAI
                 }
                 break;
             case 16:
-                if (m_uiNpcEntry == NPC_ASH){
+                if (m_uiNpcEntry == NPC_ASH)
+                {
                     DoScriptText(EMOTE_VANISH_AS, m_creature);
                     m_creature->ForcedDespawn();
                 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Makes Ashcrombe look at the door while unlocking and despawn upon finishing his teleport.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Hack fixes https://github.com/cmangos/wotlk-db/issues/363

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create alliance character
- `.gm on`
- `.tele sfk`
- `.die` on the worgen boss
- talk to and follow ashcrombe

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Fix door-adjacent waypoints in DB. I have no idea how to do that, someone else will have to.
- [ ] Make this thing not-hack-fix-y. The entire door-sequence is sequenced by timed waypoints, instead of a proper script. I don't know how to do it properly, but this seems very improper.
