### PR TITLE
Fix Distract Spell breaking Stealth of Target

### DIFF
--- a/src/game/Spells/SpellMgr.h
+++ b/src/game/Spells/SpellMgr.h
@@ -1079,6 +1079,7 @@ inline bool IsPositiveEffect(const SpellEntry* spellproto, SpellEffectIndex effI
 
     switch (spellproto->Id) // Spells whose effects are always positive
     {
+        case 1725:  // Rogue Distract
         case 24742: // Magic Wings
         case 29880: // Mana Shield - Arcane Anomaly 16488
         case 42867:


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
With this PR Distract does not break stealth of its target anymore.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes https://github.com/cmangos/issues/issues/2415

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create 2 Rogues
- Learn spell 1725
- Both rogues enter stealth and duel
- Cast Distract
- Profit

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Maybe some flags in the database for that spell are incorrect, this spell is interpreted as attack/having a negative effect, so it breaks target stealth. I don't know how spell flags work and I couldn't see anything wrong according to https://github.com/cmangos/issues/wiki/spell_template#attributesex so I hardcoded the spell as a positive effect.
