### PR TITLE
Spell: Remove SPELL_ATTR_LEVEL_DAMAGE_CALCULATION doubly adding basePointsPerLevel

### DIFF
--- a/src/game/Entities/Object.cpp
+++ b/src/game/Entities/Object.cpp
@@ -2881,9 +2881,6 @@ int32 WorldObject::CalculateSpellEffectValue(Unit const* target, SpellEntry cons
         bool damage = false;
         if (uint32 aura = spellProto->EffectApplyAuraName[effect_index])
         {
-            // TODO: to be incorporated into the main per level calculation after research
-            value += int32(std::max(0, int32(unitCaster->getLevel() - spellProto->maxLevel)) * basePointsPerLevel);
-
             switch (aura)
             {
                 case SPELL_AURA_PERIODIC_DAMAGE:


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
basePointsPerLevel are no longer being calculated and added twice

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes https://github.com/cmangos/issues/issues/2419

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Applies to multiple spells, easiest is to test as in the linked issue by getting in combat with Sethekk Guards in the Sethekk Halls
- Find other spells where this applies and test with them

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
