### PR TITLE
Make Coilfang Frenzies not spawn in shallow water

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -20735,7 +20735,8 @@ void Player::UpdateTerainEnvironmentFlags(Map* m, float x, float y, float z)
                                     CastSpell(this, liquidSpellId, TRIGGERED_OLD_TRIGGERED);
                                 else
                                 {
-                                    SummonCreature(21508, 0, 0, 0, 0, TEMPSPAWN_TIMED_OOC_DESPAWN, 2000);
+                                    if (this->IsInSwimmableWater() && this->GetPositionZ() < -20.f)
+                                        SummonCreature(21508, 0, 0, 0, 0, TEMPSPAWN_TIMED_OOC_DESPAWN, 2000);
                                     // Special update timer for the SSC water
                                     m_positionStatusUpdateTimer = 2000;
                                 }

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -20735,7 +20735,7 @@ void Player::UpdateTerainEnvironmentFlags(Map* m, float x, float y, float z)
                                     CastSpell(this, liquidSpellId, TRIGGERED_OLD_TRIGGERED);
                                 else
                                 {
-                                    if (this->IsInSwimmableWater() && this->GetPositionZ() < -20.f)
+                                    if (IsInSwimmableWater())
                                         SummonCreature(21508, 0, 0, 0, 0, TEMPSPAWN_TIMED_OOC_DESPAWN, 2000);
                                     // Special update timer for the SSC water
                                     m_positionStatusUpdateTimer = 2000;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Stop Coilfang Frenzys spawning in the wrong places

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes https://github.com/cmangos/issues/issues/2425
### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- `.go cr morogrim`
