### PR TITLE
BT: Fix some boss issues

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/black_temple/boss_illidan.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/black_temple/boss_illidan.cpp
@@ -657,6 +657,8 @@ struct boss_illidan_stormrageAI : public CombatAI, private DialogueHelper
             m_creature->RemoveAllAurasOnDeath();
             m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
             m_creature->ClearAllReactives();
+            SetCombatScriptStatus(true);
+            m_creature->SetTarget(nullptr);
 
             DoCastSpellIfCan(nullptr, SPELL_DEATH);
             DoCastSpellIfCan(m_creature, SPELL_TELEPORT_MAIEV, CAST_TRIGGERED);

--- a/src/game/AI/ScriptDevAI/scripts/outland/black_temple/illidari_council.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/black_temple/illidari_council.cpp
@@ -248,7 +248,7 @@ struct mob_illidari_councilAI : public ScriptedAI, public TimerManager
                 voiceAI->StartVoiceEvent();
         }
 
-        m_creature->SetInCombatWithZone();
+        m_creature->SetInCombatWithZone(false);
         for (uint32 i : aCouncilMember)
         {
             Creature* member = m_instance->GetSingleCreatureFromStorage(i);

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -6903,6 +6903,7 @@ void Aura::PeriodicTick()
 
             // some auras remove at specific health level or more or have damage interactions
             bool breakSwitch = false;
+            bool overrideImmune = false;
             switch (GetId())
             {
                 case 43093: case 31956: case 38801:
@@ -6949,7 +6950,8 @@ void Aura::PeriodicTick()
                         aura->m_modifier.m_amount += aura->m_modifier.m_baseAmount;
                         aura->ApplyModifier(true, true);
                     }
-                    // TODO: Reverify that during pally bubble DOT should not tick
+                    // during normal immunities - ticks, only doesnt tick during spite
+                    overrideImmune = (target->HasAura(41376) || target->HasAura(41377));
                     break;
                 }
                 default:
@@ -6965,9 +6967,10 @@ void Aura::PeriodicTick()
                 break;
 
             // Check for immune (not use charges)
-            if (!spellProto->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY)) // confirmed Impaling spine goes through immunity
+            // Aura of anger - video evidence confirms this, but attribute is legit because aura is still applied during
+            if (!spellProto->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY) || overrideImmune) // confirmed Impaling spine goes through immunity
             {
-                if (target->IsImmuneToDamage(GetSpellSchoolMask(spellProto)))
+                if (overrideImmune || target->IsImmuneToDamage(GetSpellSchoolMask(spellProto)))
                 {
                     Unit::SendSpellOrDamageImmune(GetCasterGuid(), target, spellProto->Id);
                     break;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Illidan should no longer have target on outro
Illidari council controller will force combat on itself despite attackability
ROS Spite will now override immunity ignore for Aura of Anger only

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None