### PR TITLE
Fix memory leak when deleting LoginQueryHolder.

### DIFF
--- a/src/shared/Database/SqlOperations.h
+++ b/src/shared/Database/SqlOperations.h
@@ -124,7 +124,7 @@ class SqlQueryHolder
         std::vector<SqlResultPair> m_queries;
     public:
         SqlQueryHolder() {}
-        ~SqlQueryHolder();
+        virtual ~SqlQueryHolder();
         bool SetQuery(size_t index, const char* sql);
         bool SetPQuery(size_t index, const char* format, ...) ATTR_PRINTF(3, 4);
         void SetSize(size_t size);


### PR DESCRIPTION
## 🍰 Pullrequest

m_accountId and m_guid are leaking when LoginQueryHolder is deleted.

new-delete-type-mismatch
