### PR TITLE
Add missing Include for Clang v11

### DIFF
--- a/contrib/vmap_extractor/vmapextract/wmo.h
+++ b/contrib/vmap_extractor/vmapextract/wmo.h
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <set>
+#include <memory>
 #include "vec3d.h"
 #include "loadlib/loadlib.h"
 #include <unordered_set>


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
An include is missing in `wmo.h` that's required to build the vmap extractor with Clang v11
