### PR TITLE
Use 3D distance when checking for nearby polygons.

### DIFF
--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -137,8 +137,7 @@ dtPolyRef PathFinder::getPathPolyByPosition(const dtPolyRef* polyPath, uint32 po
         return INVALID_POLYREF;
 
     dtPolyRef nearestPoly = INVALID_POLYREF;
-    float minDist2d = std::numeric_limits<float>::max();
-    float minDist3d = 0.0f;
+    float minDist3d = std::numeric_limits<float>::max();
 
     for (uint32 i = 0; i < polyPathSize; ++i)
     {
@@ -146,22 +145,21 @@ dtPolyRef PathFinder::getPathPolyByPosition(const dtPolyRef* polyPath, uint32 po
         if (dtStatusFailed(m_navMeshQuery->closestPointOnPoly(polyPath[i], point, closestPoint, nullptr)))
             continue;
 
-        float d = dtVdist2DSqr(point, closestPoint);
-        if (d < minDist2d)
+        float d = dtVdistSqr(point, closestPoint);
+        if (d < minDist3d)
         {
-            minDist2d = d;
+            minDist3d = d;
             nearestPoly = polyPath[i];
-            minDist3d = dtVdistSqr(point, closestPoint);
         }
 
-        if (minDist2d < 1.0f) // shortcut out - close enough for us
+        if (minDist3d < 1.0f) // shortcut out - close enough for us
             break;
     }
 
     if (distance)
         *distance = dtMathSqrtf(minDist3d);
 
-    return (minDist2d < 3.0f) ? nearestPoly : INVALID_POLYREF;
+    return (minDist3d < 3.0f) ? nearestPoly : INVALID_POLYREF;
 }
 
 dtPolyRef PathFinder::getPolyByLocation(const float* point, float* distance) const


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Remove pathfinding issues caused by incorrectly picking the nearest polygon to the destination point.
These cases happen where there are multiple platforms. If the player is on platform level 0 and the chasing creature is coming from a level 1 platform, it will pick a polygon that is closer to the creature (on level 1), ignoring height at all.

This can be reproduced for example in Blackwing Lair - Vaelastrasz' room (the balconies).


### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Go to Blackwing Lair, Vaelastrasz' room, stay under the balcony and pull a creature from the pack that is located behind the gate on the platform above. Without this change, the creature will come to a point above your head.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
