### PR TITLE
Rework of main timer in WorldRunnable.cpp, smoother updates

### DIFF
--- a/src/mangosd/WorldRunnable.cpp
+++ b/src/mangosd/WorldRunnable.cpp
@@ -42,33 +42,32 @@ void WorldRunnable::run()
     WorldDatabase.ThreadStart();                            // let thread do safe mySQL requests (one connection call enough)
     sWorld.InitResultQueue();
 
-    uint32 realCurrTime = 0;
-    uint32 realPrevTime = WorldTimer::tick();
-
-    uint32 prevSleepTime = 0;                               // used for balanced full tick time length near WORLD_SLEEP_CONST
+    uint32 diffTick = WorldTimer::tick(); // initialize world timer vars
+    uint32 diffTime = 0; // used to compute real time elapsed in World::Update()
+    uint32 overCounter = 0; // count overtime loops
 
     ///- While we have not World::m_stopEvent, update the world
     while (!World::IsStopped())
     {
         ++World::m_worldLoopCounter;
-        realCurrTime = WorldTimer::getMSTime();
 
-        uint32 diff = WorldTimer::tick();
+        diffTick = WorldTimer::tick();
+        sWorld.Update(diffTick);
+        diffTime = WorldTimer::getMSTime() - WorldTimer::tickTime();
 
-        sWorld.Update(diff);
-        realPrevTime = realCurrTime;
-
-        // diff (D0) include time of previous sleep (d0) + tick time (t0)
-        // we want that next d1 + t1 == WORLD_SLEEP_CONST
-        // we can't know next t1 and then can use (t0 + d1) == WORLD_SLEEP_CONST requirement
-        // d1 = WORLD_SLEEP_CONST - t0 = WORLD_SLEEP_CONST - (D0 - d0) = WORLD_SLEEP_CONST + d0 - D0
-        if (diff <= WORLD_SLEEP_CONST + prevSleepTime)
+        // we have to wait WORLD_SLEEP_CONST max between loops
+        // don't wait if over
+        if (diffTime < WORLD_SLEEP_CONST)
         {
-            prevSleepTime = WORLD_SLEEP_CONST + prevSleepTime - diff;
-            MaNGOS::Thread::Sleep(prevSleepTime);
+            MaNGOS::Thread::Sleep(WORLD_SLEEP_CONST - diffTime);
         }
+#ifdef MANGOS_DEBUG
         else
-            prevSleepTime = 0;
+        {
+            ++overCounter;
+            sLog.outString("WorldRunnable:run Long loop #%d : %dms (total : %d loop(s), %.3f%%)", World::m_worldLoopCounter, diffTime, overCounter, (float)(100*overCounter) / (float)World::m_worldLoopCounter);
+        }
+#endif
 
 #ifdef _WIN32
         if (m_ServiceStatus == 0)


### PR DESCRIPTION
## 🍰 Pullrequest
Smoother timer method. Current timing relies on the previous duration of update, but update durations are very inequal.
* Clean unused vars
* Rework of main timer

### Proof
"we want that next d1 + t1 == WORLD_SLEEP_CONST", what else

### Issues
The duration of an update doesn't express the duration of the following update.

### How2Test
Have a slow server and monitor all vars for each loop then build a nice graph with gnuplot :)

### Todo / Checklist
May be more appropriate to have a mean or a median to compute WORLD_SLEEP_CONST rather to have a constant.
