### PR TITLE
Avoid mobs chainpulling each other

### DIFF
--- a/src/game/AI/BaseAI/UnitAI.cpp
+++ b/src/game/AI/BaseAI/UnitAI.cpp
@@ -561,21 +561,8 @@ void UnitAI::SendAIEventAround(AIEventType eventType, Unit* invoker, uint32 dela
 
         if (!receiverList.empty())
         {
-            if (delay)
-            {
-                AiDelayEventAround* e = new AiDelayEventAround(eventType, invoker ? invoker->GetObjectGuid() : ObjectGuid(), *m_unit, receiverList, miscValue);
-                m_unit->m_events.AddEvent(e, m_unit->m_events.CalculateTime(delay));
-            }
-            else
-            {
-                for (Creature* receiver : receiverList)
-                {
-                    receiver->AI()->ReceiveAIEvent(eventType, m_unit, invoker, miscValue);
-                    // Special case for type 0 (call-assistance)
-                    if (eventType == AI_EVENT_CALL_ASSISTANCE)
-                        receiver->AI()->HandleAssistanceCall(m_unit, invoker);
-                }
-            }
+            AiDelayEventAround* e = new AiDelayEventAround(eventType, invoker ? invoker->GetObjectGuid() : ObjectGuid(), *m_unit, receiverList, miscValue);
+            m_unit->m_events.AddEvent(e, m_unit->m_events.CalculateTime(delay));
         }
     }
 }


### PR DESCRIPTION
## 🍰 Pullrequest
Right now, pulling one mob leads to assistance calls to nearby mobs (which is correct).
However, it seems that all mobs who receive an assistance call, are calling others for assistance again.

This leads to pulling a massive amount of enemies, where rather only one group should be pulled.

Tested in Zul'Farrak stair event.

As seen in [this video](https://www.youtube.com/watch?v=DQJ_el1VbY0) (5/2007), only the enemies that are directly affected by the assistance call are added. 
The other ones are stay out of fight.

The issue was introduced via https://github.com/cmangos/mangos-tbc/commit/ee7174d82f217c630f5770e480d08ec54baafe82. I'm not entirely sure why this 
```cpp
for (Creature* receiver : receiverList)
```
assistance-call loop was added here as it does not seem to have existed before.

**Video:**
Current state of cmangos:
[![Head](https://img.youtube.com/vi/fC2vftdSPgg/0.jpg)](https://youtu.be/fC2vftdSPgg)

State after this patch is applied:
[![Patched](https://img.youtube.com/vi/OwtNlqIumvM/0.jpg)](https://youtu.be/OwtNlqIumvM)



