### PR TITLE
[Strath] Do not close door behind black guards

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/stratholme/instance_stratholme.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/stratholme/instance_stratholme.cpp
@@ -449,7 +449,6 @@ void instance_stratholme::SetData(uint32 uiType, uint32 uiData)
             {
                 if (Creature* pBaron = GetSingleCreatureFromStorage(NPC_BARON))
                     DoScriptText(SAY_UNDEAD_DEFEAT, pBaron);
-                DoOpenSlaughterhouseDoor(true);
                 DoUseDoorOrButton(GO_ZIGGURAT_DOOR_5);
             }
             m_auiEncounter[uiType] = uiData;
@@ -1064,7 +1063,7 @@ void instance_stratholme::Update(uint32 uiDiff)
         {
             // Open the Slaughterhouse door and set a timer to close it after 10 sec to let some time to the 5 Black Guards to move out
             DoOpenSlaughterhouseDoor(true);
-            m_uiSlaughterDoorTimer = 10000;
+            m_uiSlaughterDoorTimer = 0;
 
             for (GuidList::const_iterator itr = m_luiGuardGUIDs.begin(); itr != m_luiGuardGUIDs.end(); ++itr)
             {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
When the Black Guards appear after defeating Ramstein and the spooky skellys, 5 black guards spawn after a minute and the door to the slaughterhouse opens. The door should not close unless the group wipes to the skeletons.

Expected behavior is that the door remains open. Current behavior is that the door closes after 10 seconds, no matter what (including if the group/player(s) have defeated the guards within that timeframe). This is incorrect.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Go into Strath UD
- `.die` all bosses in the gauntlet
- `.die` all the abominations in the slaughter plaza
- `.die` Ramstein and the lil skellys
- Wait for the 5 guards to spawn and 1) either kill them all immediately to observe the door not closing again after 10 seconds or 2) wait for any amount of time and observe that the door will not close unless the event is failed.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Testing. I've not been up to the task of actually working or playing or doing anything really, so these changes are untested.
