### PR TITLE
[Zul'Gurub] Fix Thekal-Fight fake death

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/zulgurub/boss_thekal.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/zulgurub/boss_thekal.cpp
@@ -91,7 +91,6 @@ struct boss_thekalBaseAI : public ScriptedAI
         damage = std::min(damage, m_creature->GetHealth() - 1);
 
         m_creature->InterruptNonMeleeSpells(true);
-        m_creature->SetHealth(0);
         m_creature->StopMoving();
         m_creature->ClearComboPointHolders();
         m_creature->RemoveAllAurasOnDeath();


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Before this, Thekal and his adds would always die for real, after initiating the fakedeath. Now the fakedeath works as intended.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/2477
### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Teleport to ZG, go to Thekal, start the fight, kill him or any of his adds with regular damage (not the `.die` command)
- ???
- Profit

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
