### PR TITLE
[Naxx] Fix Gothik's central door

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/boss_gothik.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/boss_gothik.cpp
@@ -286,7 +286,7 @@ struct boss_gothikAI : public ScriptedAI
                     m_teleportTimer -= diff;
 
                 // Second time that Gothik teleports back from dead side to living side: open the central gate
-                if (m_teleportCount >= 4)
+                if (m_teleportCount >= 4 || m_creature->GetHealthPercent() <= 30)
                 {
                     m_phase = PHASE_STOP_TELEPORTING;
                     m_instance->SetData(TYPE_GOTHIK, SPECIAL);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Gothik's door now opens when he has either teleported 4 times, or has reached less than 30% HP. I can't be 100% sure if it's 30% or 25%, because in every WoW Classic Video I find of Gothik kills he just dies so fast that the door barely has a chance to open before he goes from 40% to 0%, but I'm mostly confident that 30% is correct.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/2488

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Same as described in the issue:
-   create hero level 60
    go to naxxramas
    go to boss .go 2701.14 -3389.06 267.68
    start boss (kill all mobs)
    when the boss arrives, damage him to 30%.
    see


### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Testing haven't tested this change yet, but it doesn't seem like it could do much wrong? Sanity check at least would be appreciated!