### PR TITLE
[AQ40] Make bug trio boss unlootable when being consumed

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/temple_of_ahnqiraj/boss_bug_trio.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/temple_of_ahnqiraj/boss_bug_trio.cpp
@@ -136,6 +136,7 @@ struct boss_silithidRoyaltyAI : public CombatAI
 
     void DoDummyConsume()
     {
+        m_creature->SetNoLoot(true);
         DoScriptText(EMOTE_CONSUMED, m_creature);
         m_creature->SetStandState(UNIT_STAND_STATE_DEAD);
         DoSpecialAbility();


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
as the title says, while being consumed, the bosses are lootable for 3 seconds before they despawn, this shouldn't happen.

### Proof
<!-- Link resources as proof -->
- https://www.youtube.com/watch?v=uor-DHA0elE

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/2475

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- As described in the bug

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Actually test this. Can't compile and run a server right now, so that'd be appreciated

PS: please excuse the misleading branch name, I wanted to fix something else first and noticed that it can't be done in SD2
