### PR TITLE
[Naxx] Make Thaddius properly enter combat

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/boss_thaddius.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/boss_thaddius.cpp
@@ -244,7 +244,7 @@ bool EffectDummyNPC_spell_thaddius_encounter(Unit* /*caster*/, uint32 spellId, S
             return true;
         case SPELL_THADIUS_LIGHTNING_VISUAL:
             if (effIndex == EFFECT_INDEX_0 && creatureTarget->GetEntry() == NPC_THADDIUS)
-                creatureTarget->SetInCombatWithZone();
+                creatureTarget->SetInCombatWithZone(false);
             return true;
     }
     return false;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Thaddius now enters combat after Stalag and Feugen are defeated. Before this PR he would be unfrozen, but because he has Unselectable Unitflags which are only removed upon aggro, `SetInCombatWithZone()` fails, because it checks for attackability.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/2486

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- As described in the issue.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] Tested and working on my TBC Core/Client
