### PR TITLE
[Naxx] Partially move Thaddius to CombatAI

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/boss_thaddius.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/naxxramas/boss_thaddius.cpp
@@ -27,6 +27,8 @@ boss_stalagg
 boss_feugen
 EndContentData */
 
+#include "AI/ScriptDevAI/ScriptDevAIMgr.h"
+#include "AI/ScriptDevAI/base/CombatAI.h"
 #include "AI/ScriptDevAI/include/sc_common.h"
 #include "naxxramas.h"
 
@@ -82,28 +84,43 @@ enum
 ** boss_thaddius
 ************/
 
-struct boss_thaddiusAI : public ScriptedAI
+enum ThaddiusActions
 {
-    boss_thaddiusAI(Creature* creature) : ScriptedAI(creature)
+    THADDIUS_POLARITY_SHIFT,
+    THADDIUS_CHAIN_LIGHTNING,
+    THADDIUS_BALL_LIGHTNING,
+    THADDIUS_BERSERK,
+    THADDIUS_ACTION_MAX,
+};
+
+struct boss_thaddiusAI : public CombatAI
+{
+    boss_thaddiusAI(Creature* creature) : CombatAI(creature, THADDIUS_ACTION_MAX), m_instance(static_cast<ScriptedInstance*>(creature->GetInstanceData()))
     {
-        m_instance = (instance_naxxramas*)creature->GetInstanceData();
+        AddCombatAction(THADDIUS_POLARITY_SHIFT, true);
+        AddCombatAction(THADDIUS_CHAIN_LIGHTNING, true);
+        AddCombatAction(THADDIUS_BALL_LIGHTNING, true);
+        AddCombatAction(THADDIUS_BERSERK, true);
+
         Reset();
     }
 
-    instance_naxxramas* m_instance;
+    ScriptedInstance* m_instance;
 
-    uint32 m_polarityShiftTimer;
-    uint32 m_chainLightningTimer;
-    uint32 m_ballLightningTimer;
-    uint32 m_berserkTimer;
+    uint32 GetSubsequentActionTimer(uint32 id)
+    {
+        switch (id)
+        {
+            case THADDIUS_CHAIN_LIGHTNING: return 15u * IN_MILLISECONDS;
+            case THADDIUS_POLARITY_SHIFT: return 30u * IN_MILLISECONDS;
+            case THADDIUS_BALL_LIGHTNING: return 3u * IN_MILLISECONDS;
+            case THADDIUS_BERSERK: return 10u * MINUTE * IN_MILLISECONDS;
+            default: return 0;
+        }
+    }
 
     void Reset() override
     {
-        m_polarityShiftTimer = 15 * IN_MILLISECONDS;
-        m_chainLightningTimer = 8 * IN_MILLISECONDS;
-        m_ballLightningTimer = 3 * IN_MILLISECONDS;
-        m_berserkTimer = 6 * MINUTE * IN_MILLISECONDS;
-
         m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
         m_creature->SetImmuneToPlayer(true);
         DoCastSpellIfCan(m_creature, SPELL_THADIUS_SPAWN, CAST_TRIGGERED | CAST_AURA_NOT_PRESENT);
@@ -117,6 +134,11 @@ struct boss_thaddiusAI : public ScriptedAI
             case 1: DoScriptText(SAY_AGGRO_2, m_creature); break;
             case 2: DoScriptText(SAY_AGGRO_3, m_creature); break;
         }
+
+        ResetCombatAction(THADDIUS_CHAIN_LIGHTNING, 8u * IN_MILLISECONDS);
+        ResetCombatAction(THADDIUS_POLARITY_SHIFT, 15u * IN_MILLISECONDS);
+        ResetCombatAction(THADDIUS_BERSERK, 6u * MINUTE * IN_MILLISECONDS);
+        ResetCombatAction(THADDIUS_BALL_LIGHTNING, 3u * IN_MILLISECONDS);
 
         // Make Attackable
         m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
@@ -158,66 +180,48 @@ struct boss_thaddiusAI : public ScriptedAI
         }
     }
 
-    void UpdateAI(const uint32 diff) override
+    void ExecuteAction(uint32 action) override
     {
         if (!m_instance)
             return;
 
-        if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
-            return;
-
-        // Berserk
-        if (m_berserkTimer < diff)
+        switch (action)
         {
-            if (DoCastSpellIfCan(m_creature, SPELL_BESERK) == CAST_OK)                  // allow combat movement?
-                m_berserkTimer = 10 * MINUTE * IN_MILLISECONDS;
-        }
-        else
-            m_berserkTimer -= diff;
-
-        // Polarity Shift
-        if (m_polarityShiftTimer < diff)
-        {
-            if (DoCastSpellIfCan(m_creature, SPELL_POLARITY_SHIFT, CAST_INTERRUPT_PREVIOUS) == CAST_OK)
+            case THADDIUS_CHAIN_LIGHTNING:
             {
-                DoScriptText(SAY_ELECT, m_creature);
-                m_polarityShiftTimer = 30 * IN_MILLISECONDS;
+                Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0);
+                if (target && DoCastSpellIfCan(target, SPELL_CHAIN_LIGHTNING) == CAST_OK)
+                    ResetCombatAction(action, GetSubsequentActionTimer(action));
+                return;
+            }
+            case THADDIUS_POLARITY_SHIFT:
+            {
+                if (DoCastSpellIfCan(m_creature, SPELL_POLARITY_SHIFT, CAST_INTERRUPT_PREVIOUS) == CAST_OK)
+                {
+                    DoScriptText(SAY_ELECT, m_creature);
+                    ResetCombatAction(action, GetSubsequentActionTimer(action));
+                }
+                return;
+            }
+            case THADDIUS_BALL_LIGHTNING:
+            {
+                Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, uint32(0), SELECT_FLAG_IN_MELEE_RANGE);
+                if (!target)
+                {
+                    if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_BALL_LIGHTNING) == CAST_OK)
+                        ResetCombatAction(action, GetSubsequentActionTimer(action));
+                }
+                return;
+            }
+            case THADDIUS_BERSERK:
+            {
+                if (DoCastSpellIfCan(m_creature, SPELL_BESERK) == CAST_OK)                  // allow combat movement?
+                    ResetCombatAction(action, GetSubsequentActionTimer(action));
+                return;
             }
         }
-        else
-            m_polarityShiftTimer -= diff;
-
-        // Chain Lightning
-        if (m_chainLightningTimer < diff)
-        {
-            Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0);
-            if (target && DoCastSpellIfCan(target, SPELL_CHAIN_LIGHTNING) == CAST_OK)
-                m_chainLightningTimer = 15 * IN_MILLISECONDS;
-        }
-        else
-            m_chainLightningTimer -= diff;
-
-        // Ball Lightning if no target in melee range
-        Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, uint32(0), SELECT_FLAG_IN_MELEE_RANGE);
-        if (!target)
-        {
-            if (m_ballLightningTimer < diff)
-            {
-                if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_BALL_LIGHTNING) == CAST_OK)
-                    m_ballLightningTimer = 3 * IN_MILLISECONDS;
-            }
-            else
-                m_ballLightningTimer -= diff;
-        }
-        else
-            DoMeleeAttackIfReady();
     }
 };
-
-UnitAI* GetAI_boss_thaddius(Creature* creature)
-{
-    return new boss_thaddiusAI(creature);
-}
 
 bool EffectDummyNPC_spell_thaddius_encounter(Unit* /*caster*/, uint32 spellId, SpellEffectIndex effIndex, Creature* creatureTarget, ObjectGuid /*originalCasterGuid*/)
 {
@@ -601,7 +605,7 @@ void AddSC_boss_thaddius()
 {
     Script* newScript = new Script;
     newScript->Name = "boss_thaddius";
-    newScript->GetAI = &GetAI_boss_thaddius;
+    newScript->GetAI = &GetNewAIInstance<boss_thaddiusAI>;
     newScript->pEffectDummyNPC = &EffectDummyNPC_spell_thaddius_encounter;
     newScript->RegisterSelf();
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR moves the Thaddius part of the encounter to CombatAI. Stalagg and Feugen remain ScriptedAI because they're a pretty complicated beast and I'll need more time and patience to convert them, too.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Move into the Thaddius room with `.gm on`
- Stand next to one of the adds and do `.gm off`
- Use a damage macro that deals 300k damage to the add on the other platform (needs to be pressed twice)
- Use the same damage macro to "kill" the add that stands next to you
- Stay on top of the current platform and wait until Thaddius activates.
- Thaddius should:
   - Cast Ball Lightning every 3 seconds
   - When you jump down move to you and start melee attacking you and stop casting Ball Lightnings
   - Start using Chain Lightning and Polarity Shift

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Test the Thaddius encounter
