### PR TITLE
Hotfix failing builds by initializing WorldSession with dummy values

### DIFF
--- a/src/game/Entities/CharacterHandler.cpp
+++ b/src/game/Entities/CharacterHandler.cpp
@@ -147,7 +147,7 @@ class CharacterHandler
 
             // The bot's WorldSession is owned by the bot's Player object
             // The bot's WorldSession is deleted by PlayerbotMgr::LogoutPlayerBot
-            WorldSession* botSession = new WorldSession(lqh->GetAccountId(), nullptr, SEC_PLAYER, masterSession->GetExpansion(), 0, DEFAULT_LOCALE);
+            WorldSession* botSession = new WorldSession(lqh->GetAccountId(), nullptr, SEC_PLAYER, masterSession->GetExpansion(), 0, DEFAULT_LOCALE, 0, false);
             botSession->HandlePlayerLogin(lqh); // will delete lqh
             masterSession->GetPlayer()->GetPlayerbotMgr()->OnBotLogin(botSession->GetPlayer());
         }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Builds were failing because WorldSession behind the playerbot ifdef was still using the incorrect WorldSession constructor
The pullrequest fills this WorldSession initialization with two dummy values (0 for referrer id, and false for isRecruiter)
The actual values can probably be pulled from the database, but I'm not 100% sure if `lqh->GetAccountId()` is the correct id so I am erring on the side of caution here.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
