### PR TITLE
Fix crash that can happen by crossing vector bounds

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/world/npcs_special.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/npcs_special.cpp
@@ -1722,7 +1722,7 @@ struct npc_shaman_fire_elementalAI : public npc_shaman_elementalAI
 
 struct npc_shaman_earth_elementalAI : public npc_shaman_elementalAI
 {
-    npc_shaman_earth_elementalAI(Creature* creature) : npc_shaman_elementalAI(creature, 1)
+    npc_shaman_earth_elementalAI(Creature* creature) : npc_shaman_elementalAI(creature, 2)
     {
         m_angeredEarthParams.range.minRange = 0;
         m_angeredEarthParams.range.maxRange = 15;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
I have been getting reports from the user Frede, that his server would crash whenever an earth elemental totem is placed. The stack trace shows this happening in the function `AddCombatAction()` and from then somewhere in std::vector
I have not been able to reproduce this issue on Linux, and nobody has been willing to try to reproduce it on Windows, so I'm creating this PR regardless.

### Proof
<!-- Link resources as proof -->
![image](https://user-images.githubusercontent.com/3718129/131623198-e6e73400-f517-49a7-baa8-a156fa085e5b.png)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Summon Earth Elemental Totem on a Server running on Windows
- Expect Crash maybe
- Summon Earth Elemental Totem after applying PR
- Don't expect a crash

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Reproduce crash on Windows
- [ ] Check if this change fixes it in all cases.
