### PR TITLE
Add capability to reference broadcast_text directly in SD2

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -112,6 +112,7 @@ UPDATE gameobject_template SET ScriptName='go_dragon_head' WHERE entry IN(179556
 UPDATE gameobject_template SET ScriptName='go_unadorned_spike' WHERE entry IN(175787);
 UPDATE gameobject_template SET ScriptName='go_containment_coffer' WHERE entry=122088;
 UPDATE gameobject_template SET ScriptName='go_large_jack_o_lantern' WHERE entry=186887;
+UPDATE gameobject_template SET ScriptName='go_imp_in_a_ball' WHERE entry=185898;
 
 /* GUARD */
 UPDATE creature_template SET ScriptName='guard_azuremyst' WHERE entry=18038;
@@ -171,6 +172,7 @@ UPDATE creature_template SET ScriptName='npc_orphan' WHERE entry IN (23712,23971
 UPDATE creature_template SET ScriptName='npc_shade_of_the_horseman' WHERE entry=23543;
 UPDATE creature_template SET ScriptName='npc_headless_horseman_fire' WHERE entry=23537;
 UPDATE creature_template SET ScriptName='npc_child_tbc' WHERE entry IN(22817,22818);
+UPDATE creature_template SET ScriptName='npc_imp_in_a_ball' WHERE entry IN (23224,23229);
 
 /*Quest (quest scripts which are not in one zone)*/
 UPDATE creature_template SET ScriptName='npc_quest_attunement' WHERE entry IN(22421,18528,19935);

--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -432,7 +432,8 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (45907,'spell_torch_target_picker'),
 (46747,'spell_fling_torch'),
 (45671,'spell_juggle_torch_catch_quest'),
-(45693,'spell_torches_caught');
+(45693,'spell_torches_caught'),
+(40526,'spell_imp_in_a_bottle_say');
 
 -- Wotlk
 

--- a/src/game/AI/ScriptDevAI/ScriptDevAIMgr.cpp
+++ b/src/game/AI/ScriptDevAI/ScriptDevAIMgr.cpp
@@ -41,7 +41,7 @@ void LoadDatabase()
 * @param pSource Source of the text
 * @param pTarget Can be nullptr (depending on CHAT_TYPE of iTextEntry). Possible target for the text
 */
-void DoScriptText(int32 iTextEntry, WorldObject* pSource, Unit* pTarget)
+void DoScriptText(int32 iTextEntry, WorldObject* pSource, Unit* pTarget, uint32 chatTypeOverride)
 {
     if (!pSource)
     {
@@ -53,12 +53,35 @@ void DoScriptText(int32 iTextEntry, WorldObject* pSource, Unit* pTarget)
     {
         script_error_log("DoScriptText with source entry %u (TypeId=%u, guid=%u) attempts to process text entry %i, but text entry must be negative.",
                          pSource->GetEntry(), pSource->GetTypeId(), pSource->GetGUIDLow(), iTextEntry);
-
         return;
     }
 
-    DoDisplayText(pSource, iTextEntry, pTarget);
-    // TODO - maybe add some call-stack like error output if above function returns false
+    DoDisplayText(pSource, iTextEntry, pTarget, chatTypeOverride);
+}
+
+/**
+* Function that does broadcast text
+*
+* @param iTextEntry Entry of the text
+* @param pSource Source of the text
+* @param pTarget Can be nullptr (depending on CHAT_TYPE of iTextEntry). Possible target for the text
+*/
+void DoBroadcastText(int32 iTextEntry, WorldObject* pSource, Unit* pTarget, uint32 chatTypeOverride)
+{
+    if (!pSource)
+    {
+        script_error_log("DoScriptText entry %i, invalid Source pointer.", iTextEntry);
+        return;
+    }
+
+    if (iTextEntry <= 0)
+    {
+        script_error_log("DoBroadcastText with source entry %u (TypeId=%u, guid=%u) attempts to process text entry %i, but text entry must be positive.",
+                         pSource->GetEntry(), pSource->GetTypeId(), pSource->GetGUIDLow(), iTextEntry);
+        return;
+    }
+
+    DoDisplayText(pSource, iTextEntry, pTarget, chatTypeOverride);
 }
 
 /**

--- a/src/game/AI/ScriptDevAI/ScriptDevAIMgr.h
+++ b/src/game/AI/ScriptDevAI/ScriptDevAIMgr.h
@@ -195,7 +195,8 @@ class ScriptDevAIMgr
 // ************* Some functions used globally **************
 
 // Generic scripting text function
-void DoScriptText(int32 iTextEntry, WorldObject* pSource, Unit* pTarget = nullptr);
+void DoScriptText(int32 iTextEntry, WorldObject* pSource, Unit* pTarget = nullptr, uint32 chatTypeOverride = 0);
+void DoBroadcastText(int32 iTextEntry, WorldObject* pSource, Unit* pTarget = nullptr, uint32 chatTypeOverride = 0);
 void DoOrSimulateScriptTextForMap(int32 iTextEntry, uint32 uiCreatureEntry, Map* pMap, Creature* pCreatureSource = nullptr, Unit* pTarget = nullptr);
 
 #define sScriptDevAIMgr MaNGOS::Singleton<ScriptDevAIMgr>::Instance()

--- a/src/game/AI/ScriptDevAI/scripts/world/npcs_special.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/npcs_special.cpp
@@ -2212,6 +2212,96 @@ struct mob_phoenix_tkAI : public CombatAI
     }
 };
 
+enum
+{
+    SPELL_IMP_IN_A_BOTTLE_SAY                       = 40526,
+    SPELL_IMP_IN_A_BOTTLE_OBJECT                    = 40527,
+    SPELL_IMP_IN_A_BOTTLE_CREATURE                  = 40528,
+    SPELL_IMP_IN_A_BOTTLE_SPECIAL_CASE_NOT          = 40533, // purpose unk
+    SPELL_IMP_IN_A_BOTTLE_SPECIAL_CASE_ROGUE        = 40537, // purpose unk
+    SPELL_IMP_IN_A_BOTTLE_SPECIAL_CASE_ROGUE_SOUND  = 40539, // purpose unk - summons npc 23229
+    SPELL_CREATE_IMP_IN_A_BALL                      = 40552, // unused
+
+    SOUND_ID_IMP_1                                  = 766,
+    SOUND_ID_IMP_2                                  = 770,
+};
+
+// broadcast texts (used in either whisper or party chat)
+// 21197 may have something to do with SPELL_IMP_IN_A_BOTTLE_SPECIAL_CASE_ROGUE?
+// 21244 is possibly associated with 21243
+std::vector<uint32> impInABallTexts = { 21157,21158,21159,21160,21161,21162,21163,21164,21165,21169,21170,21171,21172,21173,21174,21175,21176,21177,21178,21179,21180,21181,21182,21183,21184,21185,21186,21187,21188,21189,21190,21191,21192,21193,21194,21195,21196,21197,21198,21200,21205,21208,21209,21210,21211,21212,21213,21214,21215,21216,21217,21218,21219,21220,21221,21222,21223,21224,21225,21226,21227,21228,21229,21230,21231,21232,21233,21234,21235,21236,21237,21238,21239,21240,21241,21242,21243,21244,21245,21246,21247 };
+
+struct go_imp_in_a_ball : public GameObjectAI
+{
+    go_imp_in_a_ball(GameObject* go) : GameObjectAI(go), m_animTimer(2000) {}
+
+    uint32 m_animTimer;
+
+    void JustSpawned() override
+    {
+        if (ObjectGuid spawnerGuid = m_go->GetSpawnerGuid())
+            if (Player* player = m_go->GetMap()->GetPlayer(spawnerGuid))
+                player->CastSpell(player, SPELL_IMP_IN_A_BOTTLE_CREATURE, TRIGGERED_OLD_TRIGGERED);
+    }
+
+    void UpdateAI(const uint32 diff) override
+    {
+        if (m_animTimer)
+        {
+            if (m_animTimer < diff)
+            {
+                m_go->SendGameObjectCustomAnim(m_go->GetObjectGuid());
+                m_animTimer = 0;
+            }
+            else
+                m_animTimer -= diff;
+        }
+    }
+};
+
+struct npc_imp_in_a_ball : public ScriptedAI
+{
+    npc_imp_in_a_ball(Creature* pCreature) : ScriptedAI(pCreature), m_toldFortune(false), m_startTimer(2000) { Reset(); }
+
+    bool m_toldFortune;
+    uint32 m_startTimer;
+
+    void Reset() override {}
+
+    void JustRespawned() override
+    {
+        m_creature->PlayDistanceSound(SOUND_ID_IMP_1);
+    }
+
+    void UpdateAI(const uint32 diff) override
+    {
+        if (!m_toldFortune)
+        {
+            if (m_startTimer < diff)
+            {
+                m_creature->PlayDistanceSound(SOUND_ID_IMP_2);
+                m_creature->CastSpell(m_creature, SPELL_IMP_IN_A_BOTTLE_SAY, TRIGGERED_OLD_TRIGGERED);
+                m_toldFortune = true;
+                m_startTimer = 0;
+            }
+            else
+                m_startTimer -= diff;
+        }
+    }
+};
+
+struct ImpInABottleSay : public SpellScript
+{
+    void OnEffectExecute(Spell* spell, SpellEffectIndex effIdx) const override
+    {
+        if (Unit* caster = spell->GetCaster())
+            if (Unit* spawner = caster->GetSpawner())
+                if (spawner->IsPlayer())
+                    if (Player* player = (Player*)spawner)
+                        DoBroadcastText(impInABallTexts[urand(0, impInABallTexts.size() - 1)], caster, player, player->GetGroup() != nullptr ? CHAT_TYPE_PARTY : CHAT_TYPE_WHISPER);
+    }
+};
+
 void AddSC_npcs_special()
 {
     Script* pNewScript = new Script;
@@ -2311,4 +2401,16 @@ void AddSC_npcs_special()
     pNewScript->Name = "mob_phoenix";
     pNewScript->GetAI = &GetNewAIInstance<mob_phoenix_tkAI>;
     pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "go_imp_in_a_ball";
+    pNewScript->GetGameObjectAI = &GetNewAIInstance<go_imp_in_a_ball>;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "npc_imp_in_a_ball";
+    pNewScript->GetAI = &GetNewAIInstance<npc_imp_in_a_ball>;
+    pNewScript->RegisterSelf();
+
+    RegisterSpellScript<ImpInABottleSay>("spell_imp_in_a_bottle_say");
 }

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -376,6 +376,7 @@ enum ChatType
     CHAT_TYPE_BOSS_WHISPER      = 5,
     CHAT_TYPE_ZONE_YELL         = 6,
     CHAT_TYPE_ZONE_EMOTE        = 7,
+    CHAT_TYPE_PARTY             = 8,
     CHAT_TYPE_MAX
 };
 

--- a/src/game/Entities/Object.cpp
+++ b/src/game/Entities/Object.cpp
@@ -1734,20 +1734,15 @@ namespace MaNGOS
     class MonsterChatBuilder
     {
         public:
-            MonsterChatBuilder(WorldObject const& obj, ChatMsg msgtype, MangosStringLocale const* textData, Language language, Unit const* target)
-                : i_object(obj), i_msgtype(msgtype), i_textData(textData), i_language(language), i_target(target), m_gender(obj.IsUnit() ? Gender(static_cast<Unit const&>(obj).getGender()) : GENDER_MALE) {}
+            MonsterChatBuilder(WorldObject const& obj, ChatMsg msgtype, std::vector<std::string> content, Language language, Unit const* target)
+                : i_object(obj), i_msgtype(msgtype), i_content(content), i_language(language), i_target(target) {}
             void operator()(WorldPacket& data, int32 loc_idx)
             {
                 char const* text = nullptr;
-                if (BroadcastText const* bct = i_textData->broadcastText)
-                    text = bct->GetText(loc_idx, m_gender).data();
+                if ((int32)i_content.size() > loc_idx + 1 && !i_content[loc_idx + 1].empty())
+                    text = i_content[loc_idx + 1].c_str();
                 else
-                {
-                    if ((int32)i_textData->Content.size() > loc_idx + 1 && !i_textData->Content[loc_idx + 1].empty())
-                        text = i_textData->Content[loc_idx + 1].c_str();
-                    else
-                        text = i_textData->Content[0].c_str();
-                }
+                    text = i_content[0].c_str();
 
                 ChatHandler::BuildChatPacket(data, i_msgtype, text, i_language, CHAT_TAG_NONE, i_object.GetObjectGuid(), i_object.GetNameForLocaleIdx(loc_idx),
                                              i_target ? i_target->GetObjectGuid() : ObjectGuid(), i_target ? i_target->GetNameForLocaleIdx(loc_idx) : "");
@@ -1756,48 +1751,43 @@ namespace MaNGOS
         private:
             WorldObject const& i_object;
             ChatMsg i_msgtype;
-            MangosStringLocale const* i_textData;
+            std::vector<std::string> i_content;
             Language i_language;
             Unit const* i_target;
-            Gender m_gender;
     };
 }                                                           // namespace MaNGOS
 
 /// Helper function to create localized around a source
-void _DoLocalizedTextAround(WorldObject const* source, MangosStringLocale const* textData, ChatMsg msgtype, Language language, Unit const* target, float range)
+void _DoLocalizedTextAround(WorldObject const* source, std::vector<std::string> content, ChatMsg msgtype, Language language, Unit const* target, float range)
 {
-    MaNGOS::MonsterChatBuilder say_build(*source, msgtype, textData, language, target);
+    MaNGOS::MonsterChatBuilder say_build(*source, msgtype, content, language, target);
     MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
     MaNGOS::CameraDistWorker<MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> > say_worker(source, range, say_do);
     Cell::VisitWorldObjects(source, say_worker, range);
 }
 
-/// Function that sends a text associated to a MangosString
-void WorldObject::MonsterText(MangosStringLocale const* textData, Unit const* target) const
+/// Function that sends a text associated to a MangosString or BroadcastText
+void WorldObject::MonsterText(std::vector<std::string> content, uint32 type, Language lang, Unit const* target) const
 {
-    MANGOS_ASSERT(textData);
-
-    Language languageId = textData->broadcastText ? textData->broadcastText->languageId : textData->LanguageId;
-
-    switch (textData->Type)
+    switch (type)
     {
         case CHAT_TYPE_SAY:
-            _DoLocalizedTextAround(this, textData, CHAT_MSG_MONSTER_SAY, languageId, target, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_SAY));
+            _DoLocalizedTextAround(this, content, CHAT_MSG_MONSTER_SAY, lang, target, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_SAY));
             break;
         case CHAT_TYPE_YELL:
-            _DoLocalizedTextAround(this, textData, CHAT_MSG_MONSTER_YELL, languageId, target, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_YELL));
+            _DoLocalizedTextAround(this, content, CHAT_MSG_MONSTER_YELL, lang, target, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_YELL));
             break;
         case CHAT_TYPE_TEXT_EMOTE:
-            _DoLocalizedTextAround(this, textData, CHAT_MSG_MONSTER_EMOTE, LANG_UNIVERSAL, target, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_TEXTEMOTE));
+            _DoLocalizedTextAround(this, content, CHAT_MSG_MONSTER_EMOTE, LANG_UNIVERSAL, target, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_TEXTEMOTE));
             break;
         case CHAT_TYPE_BOSS_EMOTE:
-            _DoLocalizedTextAround(this, textData, CHAT_MSG_RAID_BOSS_EMOTE, LANG_UNIVERSAL, target, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_YELL));
+            _DoLocalizedTextAround(this, content, CHAT_MSG_RAID_BOSS_EMOTE, LANG_UNIVERSAL, target, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_YELL));
             break;
         case CHAT_TYPE_WHISPER:
         {
             if (!target || target->GetTypeId() != TYPEID_PLAYER)
                 return;
-            MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_MONSTER_WHISPER, textData, LANG_UNIVERSAL, target);
+            MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_MONSTER_WHISPER, content, LANG_UNIVERSAL, target);
             MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
             say_do((Player*)target);
             break;
@@ -1806,14 +1796,14 @@ void WorldObject::MonsterText(MangosStringLocale const* textData, Unit const* ta
         {
             if (!target || target->GetTypeId() != TYPEID_PLAYER)
                 return;
-            MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_RAID_BOSS_WHISPER, textData, LANG_UNIVERSAL, target);
+            MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_RAID_BOSS_WHISPER, content, LANG_UNIVERSAL, target);
             MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
             say_do((Player*)target);
             break;
         }
         case CHAT_TYPE_ZONE_YELL:
         {
-            MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_MONSTER_YELL, textData, languageId, target);
+            MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_MONSTER_YELL, content, lang, target);
             MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
             uint32 zoneId = GetZoneId();
             GetMap()->ExecuteMapWorkerZone(zoneId, std::bind(&MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder>::operator(), &say_do, std::placeholders::_1));
@@ -1821,10 +1811,31 @@ void WorldObject::MonsterText(MangosStringLocale const* textData, Unit const* ta
         }
         case CHAT_TYPE_ZONE_EMOTE:
         {
-            MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_MONSTER_EMOTE, textData, languageId, target);
+            MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_MONSTER_EMOTE, content, lang, target);
             MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
             uint32 zoneId = GetZoneId();
             GetMap()->ExecuteMapWorkerZone(zoneId, std::bind(&MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder>::operator(), &say_do, std::placeholders::_1));
+            break;
+        }
+        case CHAT_TYPE_PARTY:
+        {
+            if (!target || target->GetTypeId() != TYPEID_PLAYER)
+                return;
+
+            if (Group* group = ((Player*)target)->GetGroup())
+            {
+                for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+                {
+                    Player* groupMember = itr->getSource();
+
+                    if (!groupMember)
+                        continue;
+
+                    MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_MONSTER_PARTY, content, LANG_UNIVERSAL, groupMember);
+                    MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
+                    say_do(groupMember);
+                }
+            }
             break;
         }
     }

--- a/src/game/Entities/Object.h
+++ b/src/game/Entities/Object.h
@@ -1040,7 +1040,7 @@ class WorldObject : public Object
         void MonsterYell(const char* text, uint32 language, Unit const* target = nullptr) const;
         void MonsterTextEmote(const char* text, Unit const* target, bool IsBossEmote = false) const;
         void MonsterWhisper(const char* text, Unit const* target, bool IsBossWhisper = false) const;
-        void MonsterText(MangosStringLocale const* textData, Unit const* target) const;
+        void MonsterText(std::vector<std::string> content, uint32 type, Language lang, Unit const* target) const;
 
         void PlayDistanceSound(uint32 sound_id, PlayPacketParameters parameters = PlayPacketParameters(PLAY_SET)) const;
         void PlayDirectSound(uint32 sound_id, PlayPacketParameters parameters = PlayPacketParameters(PLAY_SET)) const;

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -7400,7 +7400,7 @@ void ObjectMgr::LoadBroadcastText()
 {
     uint32 count = 0;
 
-    std::unique_ptr<QueryResult> result(WorldDatabase.Query("SELECT Id, Text, Text1, LanguageID, EmoteID1, EmoteID2, EmoteID3, EmoteDelay1, EmoteDelay2, EmoteDelay3 FROM broadcast_text"));
+    std::unique_ptr<QueryResult> result(WorldDatabase.Query("SELECT Id, Text, Text1, ChatTypeID, LanguageID, SoundEntriesID1, EmoteID1, EmoteID2, EmoteID3, EmoteDelay1, EmoteDelay2, EmoteDelay3 FROM broadcast_text"));
 
     if (!result)
     {
@@ -7427,13 +7427,15 @@ void ObjectMgr::LoadBroadcastText()
 
         bct.maleText[DEFAULT_LOCALE] = fields[1].GetCppString();
         bct.femaleText[DEFAULT_LOCALE] = fields[2].GetCppString();
-        bct.languageId = Language(fields[3].GetUInt32());
-        bct.emoteIds[0] = fields[4].GetUInt32();
-        bct.emoteIds[1] = fields[5].GetUInt32();
-        bct.emoteIds[2] = fields[6].GetUInt32();
-        bct.emoteDelays[0] = fields[7].GetUInt32();
-        bct.emoteDelays[1] = fields[8].GetUInt32();
-        bct.emoteDelays[2] = fields[9].GetUInt32();
+        bct.chatTypeId = ChatType(fields[3].GetUInt32());
+        bct.languageId = Language(fields[4].GetUInt32());
+        bct.soundId1 = fields[5].GetUInt32();
+        bct.emoteIds[0] = fields[6].GetUInt32();
+        bct.emoteIds[1] = fields[7].GetUInt32();
+        bct.emoteIds[2] = fields[8].GetUInt32();
+        bct.emoteDelays[0] = fields[9].GetUInt32();
+        bct.emoteDelays[1] = fields[10].GetUInt32();
+        bct.emoteDelays[2] = fields[11].GetUInt32();
 
         ++count;
     } while (result->NextRow());
@@ -9643,41 +9645,80 @@ GameObjectDataPair const* FindGOData::GetResult() const
     return i_anyData;
 }
 
-bool DoDisplayText(WorldObject* source, int32 entry, Unit const* target /*=nullptr*/)
+bool DoDisplayText(WorldObject* source, int32 entry, Unit const* target, uint32 chatTypeOverride)
 {
-    MangosStringLocale const* data = sObjectMgr.GetMangosStringLocale(entry);
+    uint32 sound, emote, type = 0;
+    Language lang = LANG_UNIVERSAL;
+    std::vector<std::string> content;
+    Gender sourceGender = source->IsUnit() ? (Gender)((Unit*)source)->getGender() : GENDER_NONE;
 
-    if (!data)
+    if (BroadcastText const* bct = sObjectMgr.GetBroadcastText(entry))
+    {
+        lang = bct->languageId;
+        type = bct->chatTypeId;
+        sound = bct->soundId1;
+        emote = bct->emoteIds[0];
+        content = bct->maleText;
+
+        if ((sourceGender == GENDER_FEMALE || sourceGender == GENDER_NONE) && !bct->femaleText[DEFAULT_LOCALE].empty() && bct->femaleText.size() > 0)
+            content = bct->femaleText;
+
+        if (bct->maleText.size() > 0 && !bct->maleText[DEFAULT_LOCALE].empty())
+            content = bct->maleText;
+    }
+    else
+    {
+        MangosStringLocale const* data = sObjectMgr.GetMangosStringLocale(entry);
+        lang = data->LanguageId;
+        type = data->Type;
+        sound = data->SoundId;
+        emote = data->Emote;
+        if (BroadcastText const* bct = data->broadcastText)
+        {
+            if ((sourceGender == GENDER_FEMALE || sourceGender == GENDER_NONE) && !bct->femaleText[DEFAULT_LOCALE].empty() && bct->femaleText.size() > 0)
+                content = bct->femaleText;
+
+            if (bct->maleText.size() > 0 && !bct->maleText[DEFAULT_LOCALE].empty())
+                content = bct->maleText;
+        }
+        else
+            content = data->Content;
+    }
+
+    if (chatTypeOverride > 0)
+        type = chatTypeOverride;
+
+    if (content.empty())
     {
         _DoStringError(entry, "DoScriptText with source %s could not find text entry %i.", source->GetGuidStr().c_str(), entry);
         return false;
     }
 
-    if (data->SoundId)
+    if (sound)
     {
-        switch (data->Type)
+        switch (type)
         {
             case CHAT_TYPE_ZONE_YELL:
             case CHAT_TYPE_ZONE_EMOTE:
-                source->PlayDirectSound(data->SoundId, PlayPacketParameters(PLAY_ZONE, source->GetZoneId()));
+                source->PlayDirectSound(sound, PlayPacketParameters(PLAY_ZONE, source->GetZoneId()));
                 break;
             case CHAT_TYPE_WHISPER:
             case CHAT_TYPE_BOSS_WHISPER:
                 // An error will be displayed for the text
                 if (target && target->GetTypeId() == TYPEID_PLAYER)
-                    source->PlayDirectSound(data->SoundId, PlayPacketParameters(PLAY_TARGET, (Player const*)target));
+                    source->PlayDirectSound(sound, PlayPacketParameters(PLAY_TARGET, (Player const*)target));
                 break;
             default:
-                source->PlayDirectSound(data->SoundId);
+                source->PlayDirectSound(sound);
                 break;
         }
     }
 
-    if (data->Emote)
+    if (emote)
     {
         if (source->GetTypeId() == TYPEID_UNIT || source->GetTypeId() == TYPEID_PLAYER)
         {
-            ((Unit*)source)->HandleEmote(data->Emote);
+            ((Unit*)source)->HandleEmote(emote);
         }
         else
         {
@@ -9686,12 +9727,12 @@ bool DoDisplayText(WorldObject* source, int32 entry, Unit const* target /*=nullp
         }
     }
 
-    if ((data->Type == CHAT_TYPE_WHISPER || data->Type == CHAT_TYPE_BOSS_WHISPER) && (!target || target->GetTypeId() != TYPEID_PLAYER))
+    if ((type == CHAT_TYPE_WHISPER || type == CHAT_TYPE_BOSS_WHISPER || type == CHAT_TYPE_PARTY) && (!target || target->GetTypeId() != TYPEID_PLAYER))
     {
-        _DoStringError(entry, "DoDisplayText entry %i cannot whisper without target unit (TYPEID_PLAYER).", entry);
+        _DoStringError(entry, "DoDisplayText entry %i cannot whisper/party chat without target unit (TYPEID_PLAYER).", entry);
         return false;
     }
 
-    source->MonsterText(data, target);
+    source->MonsterText(content, type, lang, target);
     return true;
 }

--- a/src/game/Globals/ObjectMgr.h
+++ b/src/game/Globals/ObjectMgr.h
@@ -94,11 +94,12 @@ struct BroadcastText
     uint32 Id;
     std::vector<std::string> maleText;
     std::vector<std::string> femaleText;
+    ChatType chatTypeId; // not contained in SMSG_DB_REPLY, but added here for ease of use
     Language languageId;
     // uint32 conditionId;
     // uint32 emotesId;
     // uint32 flags;
-    // uint32 soundId1;
+    uint32 soundId1;
     // uint32 soundId2;
     uint32 emoteIds[3];
     uint32 emoteDelays[3];
@@ -1337,7 +1338,7 @@ class ObjectMgr
 #define sObjectMgr MaNGOS::Singleton<ObjectMgr>::Instance()
 
 /// generic text function
-bool DoDisplayText(WorldObject* source, int32 entry, Unit const* target = nullptr);
+bool DoDisplayText(WorldObject* source, int32 entry, Unit const* target = nullptr, uint32 chatTypeOverride = 0);
 
 // scripting access functions
 bool LoadMangosStrings(DatabaseType& db, char const* table, int32 start_value = MAX_CREATURE_AI_TEXT_STRING_ID, int32 end_value = std::numeric_limits<int32>::min(), bool extra_content = false);


### PR DESCRIPTION
Plus script Imp in a Ball for proof of concept

The addition of the function DoBroadcastText along with adding chatTypeID to the broadcast_text table is part of the text makeover process described in https://github.com/cmangos/issues/issues/2331