### PR TITLE
[Karazhan] Spotlight spawns in front of Barnes

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/karazhanScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/karazhanScripts.cpp
@@ -149,7 +149,7 @@ struct npc_barnesAI : public npc_escortAI, private DialogueHelper
                         break;
                 }
                 SetEscortPaused(true);
-                m_creature->SummonCreature(NPC_SPOTLIGHT, 0, 0, 0, 0, TEMPSPAWN_DEAD_DESPAWN, 0);
+                m_creature->SummonCreature(NPC_SPOTLIGHT, 0, 0, 0, 0, TEMPSPAWN_DEAD_DESPAWN, 0, false, false, 0, 0, 0, false, true);
                 break;
             case 9:
                 m_pInstance->DoUseDoorOrButton(GO_STAGE_DOOR_LEFT);

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/karazhanScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/karazhanScripts.cpp
@@ -149,7 +149,7 @@ struct npc_barnesAI : public npc_escortAI, private DialogueHelper
                         break;
                 }
                 SetEscortPaused(true);
-                m_creature->SummonCreature(NPC_SPOTLIGHT, 0, 0, 0, 0, TEMPSPAWN_DEAD_DESPAWN, 0, false, false, 0, 0, 0, false, true);
+                m_creature->SummonCreature(NPC_SPOTLIGHT, -10895.27, -1782.626, 90.55984, 3.769911, TEMPSPAWN_DEAD_DESPAWN, 0);
                 break;
             case 9:
                 m_pInstance->DoUseDoorOrButton(GO_STAGE_DOOR_LEFT);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
With this PR the spotlight spawns in/on top of barnes, instead of in front of him (see screenshot for the previous, wrong behavior)


![image](https://user-images.githubusercontent.com/3718129/132886703-1cd6a60d-d576-48e9-876f-22b052620a41.png)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- `.gm on`
- `.go cr Barnes`
