### PR TITLE
Remove obsolete setting for ignoring spell LoS.

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -4815,7 +4815,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                     }
                 }
 
-                if (!IsIgnoreLosSpellCast(m_spellInfo) && !m_IsTriggeredSpell && VMAP::VMapFactory::checkSpellForLoS(m_spellInfo->Id) && !m_trueCaster->IsWithinLOSInMap(target, true))
+                if (!IsIgnoreLosSpellCast(m_spellInfo) && !m_IsTriggeredSpell && !m_trueCaster->IsWithinLOSInMap(target, true))
                     return SPELL_FAILED_LINE_OF_SIGHT;
 
                 if (m_trueCaster->IsPlayer())

--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -808,14 +808,12 @@ void World::LoadConfigSettings(bool reload)
     setConfig(CONFIG_BOOL_VMAP_INDOOR_CHECK, "vmap.enableIndoorCheck", true);
     bool enableLOS = sConfig.GetBoolDefault("vmap.enableLOS", false);
     bool enableHeight = sConfig.GetBoolDefault("vmap.enableHeight", false);
-    std::string ignoreSpellIds = sConfig.GetStringDefault("vmap.ignoreSpellIds");
 
     if (!enableHeight)
         sLog.outError("VMAP height use disabled! Creatures movements and other things will be in broken state.");
 
     VMAP::VMapFactory::createOrGetVMapManager()->setEnableLineOfSightCalc(enableLOS);
     VMAP::VMapFactory::createOrGetVMapManager()->setEnableHeightCalc(enableHeight);
-    VMAP::VMapFactory::preventSpellsFromBeingTestedForLoS(ignoreSpellIds.c_str());
     sLog.outString("WORLD: VMap support included. LineOfSight:%i, getHeight:%i, indoorCheck:%i",
                    enableLOS, enableHeight, getConfig(CONFIG_BOOL_VMAP_INDOOR_CHECK) ? 1 : 0);
     sLog.outString("WORLD: VMap data directory is: %svmaps", m_dataPath.c_str());

--- a/src/game/vmap/VMapFactory.cpp
+++ b/src/game/vmap/VMapFactory.cpp
@@ -53,7 +53,6 @@ namespace VMAP
 
     std::mutex m_vmapMutex;
     IVMapManager* gVMapManager = nullptr;
-    Table<unsigned int, bool>* iIgnoreSpellIds = nullptr;
 
     //===============================================
     // result false, if no more id are found
@@ -81,35 +80,6 @@ namespace VMAP
     }
 
     //===============================================
-    /**
-    parameter: String of map ids. Delimiter = ","
-    */
-
-    void VMapFactory::preventSpellsFromBeingTestedForLoS(const char* pSpellIdString)
-    {
-        if (!iIgnoreSpellIds)
-            iIgnoreSpellIds = new Table<unsigned int, bool>();
-        if (pSpellIdString != nullptr)
-        {
-            unsigned int pos = 0;
-            unsigned int id;
-            std::string confString(pSpellIdString);
-            chompAndTrim(confString);
-            while (getNextId(confString, pos, id))
-            {
-                iIgnoreSpellIds->set(id, true);
-            }
-        }
-    }
-
-    //===============================================
-
-    bool VMapFactory::checkSpellForLoS(unsigned int pSpellId)
-    {
-        return !iIgnoreSpellIds->containsKey(pSpellId);
-    }
-
-    //===============================================
     // just return the instance
     IVMapManager* VMapFactory::createOrGetVMapManager()
     {
@@ -127,10 +97,8 @@ namespace VMAP
     void VMapFactory::clear()
     {
         std::lock_guard<std::mutex> lock(m_vmapMutex);
-        delete iIgnoreSpellIds;
-        delete gVMapManager;
 
-        iIgnoreSpellIds = nullptr;
+        delete gVMapManager;
         gVMapManager = nullptr;
     }
 }

--- a/src/game/vmap/VMapFactory.h
+++ b/src/game/vmap/VMapFactory.h
@@ -35,9 +35,6 @@ namespace VMAP
             static IVMapManager* createOrGetVMapManager();
             static void clear();
 
-            static void preventSpellsFromBeingTestedForLoS(const char* pSpellIdString);
-            static bool checkSpellForLoS(unsigned int pSpellId);
-
             static void chompAndTrim(std::string& str);
             static bool getNextId(const std::string& pString, unsigned int& pStartPos, unsigned int& pId);
     };

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -164,10 +164,6 @@ SD2ErrorLogFile = "SD2Errors.log"
 #        Default: 1 (enable)
 #                 0 (disable)
 #
-#    vmap.ignoreSpellIds
-#        These spells are ignored for LoS calculation
-#        List of ids with delimiter ','
-#
 #    vmap.enableIndoorCheck
 #        Enable/Disable VMap based indoor check to remove outdoor-only auras (mounts etc.).
 #        Requires VMaps enabled to work.
@@ -251,7 +247,6 @@ PlayerSave.Stats.MinLevel = 0
 PlayerSave.Stats.SaveOnlyOnLogout = 1
 vmap.enableLOS = 1
 vmap.enableHeight = 1
-vmap.ignoreSpellIds = "7720"
 vmap.enableIndoorCheck = 1
 DetectPosCollision = 1
 mmap.enabled = 1


### PR DESCRIPTION
## 🍰 Pullrequest
This removes the obsolete vmap.ignoreSpellIds setting from the config. Whether a spell ignores LoS or not is defined in the spell attributes, so this functionality is redundant, and it isn't really even being used right now, with only 1 spell id included in the config. It is also bad design to define things that are specific to individual spell entries in the config, it should have been a DB table instead. This setting was already removed from [Trinity](https://github.com/TrinityCore/TrinityCore/commit/22896bd7a46ade453e72ad09138b3c6d62efe4e7) way back in 2012.

### Issues
Cleans up the vmap code by removing obsolete functionality.
