### PR TITLE
Fixes summon eye of Kilrogg crash

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -10066,6 +10066,10 @@ void CharmInfo::InitPossessCreateSpells()
         return;
 
     std::vector<uint32> spells = m_unit->GetCharmSpells();
+ 
+    if (spells.empty())
+        return;
+ 
     for (uint32 x = 0; x < CREATURE_MAX_SPELLS; ++x)
     {
         if (spells[x] == 2 || (spells[x] == 0 && m_unit->hasUnitState(UNIT_STAT_MELEE_ATTACKING)))


### PR DESCRIPTION
## 🍰 Pullrequest
Add empty check for spell list

### Proof
<!-- Link resources as proof -->
When summon an eye of Kilrogg, spells is empty, and in the for loop, it will visit the index zero.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
Create a warlock character, and summon eye of Kilrogg

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
