### PR TITLE
Fix AI-Bot "pet state" command

### DIFF
--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -10347,8 +10347,10 @@ void PlayerbotAI::_HandleCommandPet(std::string& text, Player& fromPlayer)
             return;
         }
 
-        std::string state;
-        switch (pet->GetCharmInfo()->GetAI()->GetReactState())
+        if(!pet || !pet->AI())
+            return;
+            
+        switch (pet->AI()->GetReactState())
         {
             case REACT_AGGRESSIVE:
                 SendWhisper("My pet is aggressive.", fromPlayer);
@@ -10367,6 +10369,9 @@ void PlayerbotAI::_HandleCommandPet(std::string& text, Player& fromPlayer)
             _HandleCommandHelp("pet cast", fromPlayer);
             return;
         }
+
+        if(!pet)
+            return;
 
         uint32 spellId = (uint32) atol(text.c_str());
 
@@ -10397,6 +10402,9 @@ void PlayerbotAI::_HandleCommandPet(std::string& text, Player& fromPlayer)
             _HandleCommandHelp("pet toggle", fromPlayer);
             return;
         }
+
+        if(!pet)
+            return;
 
         uint32 spellId = (uint32) atol(text.c_str());
 
@@ -10430,6 +10438,9 @@ void PlayerbotAI::_HandleCommandPet(std::string& text, Player& fromPlayer)
             SendWhisper("'pet spells' does not support subcommands.", fromPlayer);
             return;
         }
+
+        if(!pet)
+            return;
 
         int loc = GetMaster()->GetSession()->GetSessionDbcLocale();
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes the `pet state` command for playerbots.

It also adds some nullptr guards to make sure a pet object actually exists before trying to invoke it.
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Summon a Hunter/Warlock with a pet as playerbot
- Whisper `pet state` to them

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
