### PR TITLE
fix clang compiler warnings and minor logical error

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/world/scourge_invasion.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/scourge_invasion.cpp
@@ -146,7 +146,7 @@ void DespawnEventDoodads(Creature* shard)
         pDoodad->ForcedDespawn();
 
     std::list<Creature*> finderList;
-    GetCreatureListWithEntryInGrid(finderList, shard, { NPC_SCOURGE_INVASION_MINION_FINDER }, 60.0f);
+    GetCreatureListWithEntryInGrid(finderList, shard, NPC_SCOURGE_INVASION_MINION_FINDER, 60.0f);
     for (const auto pFinder : finderList)
         pFinder->ForcedDespawn();
 }
@@ -168,7 +168,7 @@ void SummonCultists(Unit* shard)
         return;
 
     std::list<GameObject*> summonerShieldList;
-    GetGameObjectListWithEntryInGrid(summonerShieldList, shard, { GOBJ_SUMMONER_SHIELD }, INSPECT_DISTANCE);
+    GetGameObjectListWithEntryInGrid(summonerShieldList, shard, GOBJ_SUMMONER_SHIELD, INSPECT_DISTANCE);
     for (const auto pSummonerShield : summonerShieldList)
         pSummonerShield->ForcedDespawn();
 
@@ -194,7 +194,7 @@ void DespawnCultists(Unit* despawner)
         return;
 
     std::list<Creature*> cultistList;
-    GetCreatureListWithEntryInGrid(cultistList, despawner, { NPC_CULTIST_ENGINEER }, INSPECT_DISTANCE);
+    GetCreatureListWithEntryInGrid(cultistList, despawner, NPC_CULTIST_ENGINEER, INSPECT_DISTANCE);
     for (const auto pCultist : cultistList)
         if (pCultist)
             pCultist->ForcedDespawn();
@@ -206,7 +206,7 @@ void DespawnShadowsOfDoom(Unit* despawner)
         return;
 
     std::list<Creature*> shadowList;
-    GetCreatureListWithEntryInGrid(shadowList, despawner, { NPC_SHADOW_OF_DOOM }, 200.0f);
+    GetCreatureListWithEntryInGrid(shadowList, despawner, NPC_SHADOW_OF_DOOM, 200.0f);
     for (const auto pShadow : shadowList)
         if (pShadow && pShadow->IsAlive() && !pShadow->IsInCombat())
             pShadow->ForcedDespawn();
@@ -253,7 +253,7 @@ uint32 GetFindersAmount(Creature* shard)
 {
     uint32 finderCounter = 0;
     std::list<Creature*> finderList;
-    GetCreatureListWithEntryInGrid(finderList, shard, { NPC_SCOURGE_INVASION_MINION_FINDER }, 60.0f);
+    GetCreatureListWithEntryInGrid(finderList, shard, NPC_SCOURGE_INVASION_MINION_FINDER, 60.0f);
     for (const auto pFinder : finderList)
         if (pFinder)
             finderCounter++;
@@ -677,7 +677,7 @@ struct NecroticShard : public ScriptedAI
         int finderAmount = urand(1, 3); // Up to 3 spawns.
 
         std::list<Creature*> finderList;
-        GetCreatureListWithEntryInGrid(finderList, m_creature, { NPC_SCOURGE_INVASION_MINION_FINDER }, 60.0f);
+        GetCreatureListWithEntryInGrid(finderList, m_creature, NPC_SCOURGE_INVASION_MINION_FINDER, 60.0f);
         if (finderList.empty())
             return;
 
@@ -774,7 +774,7 @@ struct npc_cultist_engineer : public ScriptedAI
             gameObject->Delete();
     }
 
-    void ReceiveAIEvent(AIEventType eventType, Unit* /*sender*/, Unit* invoker, uint32 miscValue) override
+    void ReceiveAIEvent(uint32 eventType, Unit* /*sender*/, Unit* invoker, uint32 miscValue)
     {
         if (eventType == 7166 && miscValue == 0)
         {

--- a/src/game/World/WorldState.cpp
+++ b/src/game/World/WorldState.cpp
@@ -726,7 +726,7 @@ Map* WorldState::GetMap(uint32 mapId, Position const& invZone)
 {
     Map* map = sMapMgr.FindMap(mapId);
     if (!map)
-        sLog.outError("ScourgeInvasionEvent::GetMap found no map with mapId %d, x: %d, y: %d.", mapId, invZone.x, invZone.y);
+        sLog.outError("ScourgeInvasionEvent::GetMap found no map with mapId %d, x: %f, y: %f.", mapId, invZone.x, invZone.y);
     return map;
 }
 
@@ -1884,7 +1884,7 @@ void WorldState::HandleActiveZone(uint32 attackTimeVar, uint32 zoneId, uint32 re
                 if (mouth)
                     mouth->AI()->SendAIEvent(AI_EVENT_CUSTOM_A, mouth, mouth, EVENT_MOUTH_OF_KELTHUZAD_ZONE_STOP);
                 else
-                    sLog.outError("ScourgeInvasionEvent::HandleActiveZone ObjectGuid %d not found.", zone.mouthGuid);
+                    sLog.outError("ScourgeInvasionEvent::HandleActiveZone ObjectGuid %d not found.", zone.mouthGuid.GetCounter());
             }
         });
     }
@@ -2626,7 +2626,7 @@ void WorldState::StartExpansionEvent()
 
 void WorldState::FillInitialWorldStates(ByteBuffer& data, uint32& count, uint32 zoneId, uint32 /*areaId*/)
 {
-    if (m_siData.m_state != PHASE_0_DISABLED) // scourge invasion active - need to send all worldstates
+    if (m_siData.m_state != STATE_0_DISABLED) // scourge invasion active - need to send all worldstates
     {
         uint32 victories = GetBattlesWon();
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Fixing clang compiler warnings such as braces used as initializer. I understand why it was used in this case, because the surrounding code uses lists of enums to pass on, but since these function calls here are only for single creatures I think it makes sense to use the correct function call for single creatures

ReceiveAIEvent() usually takes an enum as function parameter, but that enum cannot contain 7166 as EventType, because that isn't defined in the AIEventType enum. Clang thus sees this comparison as always false, since the enum does not contain that value 7166 and so the parameter can also never be 7166 because it must be of type AIEventType, so clang would optimize that if statement out because at compiletime it always evaluates to false.

Minor datatype fixes.

Corrected typo in the PHASE/STATE enum used. (The original referred to an Ahn'Qiraji event and while it *could* have evaluated to the same uint32 it might also not, so I changed it to the explicit ScourgeInvasion State.