### PR TITLE
Add explicit default parameter to fix compilation

### DIFF
--- a/contrib/mmap/src/TerrainBuilder.h
+++ b/contrib/mmap/src/TerrainBuilder.h
@@ -82,7 +82,7 @@ namespace MMAP
     class TerrainBuilder
     {
         public:
-            TerrainBuilder(bool skipLiquid, const char* workdir);
+            TerrainBuilder(bool skipLiquid, const char* workdir = nullptr);
             ~TerrainBuilder();
 
             void loadMap(uint32 mapID, uint32 tileX, uint32 tileY, MeshData& meshData);


### PR DESCRIPTION
necessary when trying to build recast+extractors on windows

This fixes compilation errors on my windows machine.

New TerrainBuilder constructor doesnt fit the call in GeomData.cpp:149 anymore

![image](https://user-images.githubusercontent.com/9959527/151176901-5df61841-478a-43ed-9b1f-44e6e797563f.png)

calls https://github.com/cmangos/mangos-tbc/blob/ce65ebca5c17cb0087ace7638907910b175a0955/contrib/recastdemomod/Source/GeomData.cpp#L149
https://github.com/cmangos/mangos-tbc/blob/ce65ebca5c17cb0087ace7638907910b175a0955/contrib/recastdemomod/Source/GeomData.cpp#L200

callee https://github.com/cmangos/mangos-tbc/blob/ce65ebca5c17cb0087ace7638907910b175a0955/contrib/mmap/src/TerrainBuilder.h#L85

adding the explicit default argument to the constructor fixes the compilation for windows.