### PR TITLE
Fix Compiler Warnings for Extractors

### DIFF
--- a/contrib/vmap_extractor/vmapextract/model.cpp
+++ b/contrib/vmap_extractor/vmapextract/model.cpp
@@ -165,7 +165,7 @@ ModelInstance::ModelInstance(MPQFile& f, const char* ModelInstName, uint32 mapID
     // scale factor - divide by 1024. game devs must be on crack, why not just use a float?
     sc = scale / 1024.0f;
 
-    char tempname[512];
+    char tempname[512 + (sizeof(szWorkDirWmo) / sizeof(szWorkDirWmo[0]))];
     sprintf(tempname, "%s/%s", szWorkDirWmo, ModelInstName);
 
     FILE* input = fopen(tempname, "r+b");
@@ -237,7 +237,7 @@ void Doodad::ExtractSet(WMODoodadData const& doodadData, ADT::MODF const& wmo, u
             }
         }
 
-        char tempname[1036];
+        char tempname[1036 + (sizeof(szWorkDirWmo) / sizeof(szWorkDirWmo[0]))];
         sprintf(tempname, "%s/%s", szWorkDirWmo, ModelInstName);
         FILE* input = fopen(tempname, "r+b");
         if (!input)

--- a/contrib/vmap_extractor/vmapextract/vmapexport.cpp
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.cpp
@@ -157,7 +157,7 @@ bool ExtractSingleWmo(std::string& fname)
 {
     // Copy files from archive
 
-    char szLocalFile[path_l + 512];
+    char szLocalFile[(sizeof(szWorkDirWmo) / sizeof(szWorkDirWmo[0])) + 512];
     char* plain_name = GetPlainName(&fname[0]);
     fixnamen(plain_name, strlen(plain_name));
     fixname2(plain_name, strlen(plain_name));

--- a/contrib/vmap_extractor/vmapextract/wmo.cpp
+++ b/contrib/vmap_extractor/vmapextract/wmo.cpp
@@ -572,7 +572,7 @@ WMOInstance::WMOInstance(MPQFile& f, const char* WmoInstName, uint32 mapID, uint
 
     //-----------add_in _dir_file----------------
 
-    char tempname[512];
+    char tempname[512 + (sizeof(szWorkDirWmo) / sizeof(szWorkDirWmo[0]))];
     sprintf(tempname, "%s/%s", szWorkDirWmo, WmoInstName);
     FILE* input;
     input = fopen(tempname, "r+b");


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR ensures that the strings for the custom path changes all have adequate lengths.

*this PR is valid for all 3 cores*

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/2679

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Compile CMaNGOS with `-DBUILD_EXTRACTORS=1`