### PR TITLE
Adjust Out of Combat Health Regeneration for Player controlled npcs

### DIFF
--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -810,7 +810,7 @@ void Creature::RegenerateAll(uint32 update_diff)
 
     RegeneratePower(2.f);
 
-    m_regenTimer = REGEN_TIME_FULL;
+    m_regenTimer = REGEN_TIME_FULL_UNIT;
 }
 
 void Creature::RegeneratePower(float timerMultiplier)
@@ -887,7 +887,8 @@ void Creature::RegenerateHealth()
     if (curValue >= maxValue)
         return;
 
-    uint32 addvalue = maxValue / 3;
+    // regenerate 33% for npc and ~13% for player controlled npc (enslave etc) ToDo: Find Regenvalue based on Spirit, might differ due to mob types
+    uint32 addvalue = IsPlayerControlled() ? maxValue * 0.13 : maxValue / 3;
 
     ModifyHealth(addvalue);
 }

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -1028,7 +1028,8 @@ enum ReactiveType
 #define MAX_CREATURE_ATTACK_RADIUS 45.0f                    // max distance for creature aggro (use with CONFIG_FLOAT_RATE_CREATURE_AGGRO)
 
 // Regeneration defines
-#define REGEN_TIME_FULL     2000                            // For this time difference is computed regen value
+#define REGEN_TIME_FULL         2000                            // For this time difference is computed regen value
+#define REGEN_TIME_FULL_UNIT    5000                            // For npcs
 
 // Power type values defines
 enum PowerDefaults


### PR DESCRIPTION
## 🍰 Pullrequest
This targets to decrease player controlled mob health regeneration out of combat, they by default regenerate like a normal mob that is evading home in 33% ticks

This makes enslaveable mobs highly abuseable as they regenerate very fast after every drop of combat.

Searing Infernal 6073 level 29 with maxhealth 950 regens 123hp every 5secs ooc

### Proof
Based on https://mega.nz/file/CnQkxZAL#5lSze4bAZK-iJUmx4NQGb-9_ILK_vH_phnexHv3G4OI - classic ptr

![grafik](https://user-images.githubusercontent.com/19734826/155337020-3503e517-a127-46d2-b93e-d4981c417299.png)
![grafik](https://user-images.githubusercontent.com/19734826/155337105-dd6a8d61-8752-44ea-a50c-b0080a0a5ba5.png)
![grafik](https://user-images.githubusercontent.com/19734826/155337152-52f85529-fef2-47f9-89c4-200cbf5be247.png)

### Issues

- Tick Timer should 5secs, not 2secs as currently

