### PR TITLE
[SD] Make ChoRush friendly and Sit on Dungeon Create & King Gordok done

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/dire_maul/dire_maul.h
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/dire_maul/dire_maul.h
@@ -97,7 +97,7 @@ enum
     NPC_GUARD_FENGUS            = 14321,
     NPC_GUARD_SLIPKIK           = 14323,
     NPC_CAPTAIN_KROMCRUSH       = 14325,
-    NPC_CHORUSH                 = 14324,
+    NPC_CHO_RUSH_THE_OBSERVER   = 14324,
     NPC_KING_GORDOK             = 11501,
     NPC_MIZZLE_THE_CRAFTY       = 14353,
 

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/dire_maul/instance_dire_maul.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/dire_maul/instance_dire_maul.cpp
@@ -96,7 +96,10 @@ void instance_dire_maul::OnCreatureCreate(Creature* pCreature)
             return;
 
         // North
-        case NPC_CHORUSH:
+        case NPC_CHO_RUSH_THE_OBSERVER:
+            if (m_auiEncounter[TYPE_KING_GORDOK] == DONE)
+                pCreature->SetStandState(UNIT_STAND_STATE_SIT);
+            break;
         case NPC_KING_GORDOK:
         case NPC_CAPTAIN_KROMCRUSH:
         case NPC_GUARD_SLIPKIK:
@@ -322,7 +325,7 @@ void instance_dire_maul::SetData(uint32 uiType, uint32 uiData)
                     }
                 }
 
-                if (Creature* pOgre = GetSingleCreatureFromStorage(NPC_CHORUSH))
+                if (Creature* pOgre = GetSingleCreatureFromStorage(NPC_CHO_RUSH_THE_OBSERVER))
                 {
                     // Chorush evades and yells on king death (if alive)
                     if (pOgre->IsAlive())
@@ -445,7 +448,7 @@ void instance_dire_maul::OnCreatureDeath(Creature* pCreature)
         case NPC_CAPTAIN_KROMCRUSH:
             SetData(TYPE_KROMCRUSH, DONE);
             break;
-        case NPC_CHORUSH:
+        case NPC_CHO_RUSH_THE_OBSERVER:
             SetData(TYPE_CHORUSH, DONE);
             break;
         case NPC_STOMPER_KREEG:


### PR DESCRIPTION
## 🍰 Pullrequest
Make ChoRush Sit on Dungeon Create when King Gordok event is done

### Proof
https://youtu.be/RnQ7BEswhts?t=1262

### Issues
Else you can run out and back in, and he will be attackable again, eventhough only King Gordok was killed that "id"

### How2Test
.go c id 14324
kill King Gordok
leave dungeon
.go c id 14324
he is attackable again and does not sit