### PR TITLE
Alterac Valley tweaks

### DIFF
--- a/src/game/BattleGround/BattleGroundAV.cpp
+++ b/src/game/BattleGround/BattleGroundAV.cpp
@@ -465,8 +465,8 @@ void BattleGroundAV::ProcessPlayerDestroyedPoint(AVNodeIds node)
     PvpTeamIndex otherTeamIdx = GetOtherTeamIndex(ownerTeamIdx);
     Team ownerTeam = GetTeamIdByTeamIndex(ownerTeamIdx);
 
-    bool isTower = m_nodes[node].graveyardId == 0;
-    uint32 newState = 0;
+    bool isTower = !m_nodes[node].graveyardId;
+    uint32 newState = ownerTeam == ALLIANCE ? avNodeWorldStates[node].worldStateAlly : avNodeWorldStates[node].worldStateHorde;
 
     // despawn banner
     DestroyNode(node);
@@ -555,7 +555,7 @@ bool BattleGroundAV::CanPlayerDoMineQuest(uint32 goEntry, Team team)
 void BattleGroundAV::PopulateNode(AVNodeIds node)
 {
     PvpTeamIndex teamIdx = m_nodes[node].owner;
-    bool isTower = m_nodes[node].graveyardId;
+    bool isTower = !m_nodes[node].graveyardId;
 
     if (!isTower && teamIdx != TEAM_INDEX_NEUTRAL)
     {
@@ -629,7 +629,7 @@ void BattleGroundAV::ProcessPlayerDefendsPoint(Player* player, AVNodeIds node)
         return;
     }
 
-    bool isTower = m_nodes[node].graveyardId;
+    bool isTower = !m_nodes[node].graveyardId;
 
     uint32 newState  = teamIdx == TEAM_INDEX_ALLIANCE ? avNodeWorldStates[node].worldStateAlly : avNodeWorldStates[node].worldStateHorde;
 
@@ -645,7 +645,7 @@ void BattleGroundAV::ProcessPlayerDefendsPoint(Player* player, AVNodeIds node)
     PlaySoundToAll(soundId);
 
     // update score
-    UpdatePlayerScore(player, SCORE_GRAVEYARDS_DEFENDED, 1);
+    UpdatePlayerScore(player, scoreType, 1);
 
     // process node events
     DefendNode(node, teamIdx);                              // set the right variables for nodeinfo
@@ -663,7 +663,7 @@ void BattleGroundAV::ProcessPlayerAssaultsPoint(Player* player, AVNodeIds node)
     if (m_nodes[node].owner == teamIdx || teamIdx == m_nodes[node].totalOwner)
         return;
 
-    bool isTower = m_nodes[node].graveyardId;
+    bool isTower = !m_nodes[node].graveyardId;
 
     uint32 newState     = teamIdx == TEAM_INDEX_ALLIANCE ? avNodeWorldStates[node].worldStateAllyGrey : avNodeWorldStates[node].worldStateHordeGrey;
     uint32 scoreType    = isTower ? SCORE_TOWERS_ASSAULTED : SCORE_GRAVEYARDS_ASSAULTED;
@@ -722,7 +722,11 @@ void BattleGroundAV::FillInitialWorldStates(WorldPacket& data, uint32& count)
 // Update node world state
 void BattleGroundAV::UpdateNodeWorldState(AVNodeIds node, uint32 newState)
 {
-    UpdateWorldState(m_nodes[node].worldState, WORLD_STATE_REMOVE);
+    if (m_nodes[node].prevOwner == TEAM_INDEX_NEUTRAL)      // currently only snowfall is supported as neutral node
+        UpdateWorldState(BG_AV_STATE_GY_SNOWFALL_N, WORLD_STATE_REMOVE);
+    else
+        UpdateWorldState(m_nodes[node].worldState, WORLD_STATE_REMOVE);
+
     m_nodes[node].worldState = newState;
     UpdateWorldState(m_nodes[node].worldState, WORLD_STATE_ADD);
 }
@@ -845,6 +849,7 @@ void BattleGroundAV::Reset()
 
         m_enemyTowersDestroyed[i] = 0;
         m_homeTowersControlled[i] = BG_AV_MAX_TOWERS_PER_TEAM;
+        m_activeEvents[BG_AV_NODE_CAPTAIN_DEAD_A + i] = BG_EVENT_NONE;
     }
 
     // initialize mine variables and active events
@@ -863,7 +868,7 @@ void BattleGroundAV::Reset()
     m_activeEvents[BG_AV_BOSS_A] = 0;
     m_activeEvents[BG_AV_BOSS_H] = 0;
 
-    for (uint8 i = 0; i < BG_AV_MAX_NODES; ++i)  // towers
+    for (uint8 i = BG_AV_NODES_DUNBALDAR_SOUTH; i < BG_AV_MAX_NODES; ++i)  // towers
         m_activeEvents[BG_AV_MARSHAL_A_SOUTH + i - BG_AV_NODES_DUNBALDAR_SOUTH] = 0;
 
     // initialize all nodes

--- a/src/game/BattleGround/BattleGroundAV.h
+++ b/src/game/BattleGround/BattleGroundAV.h
@@ -313,10 +313,10 @@ enum AVWorldStates
     BG_AV_STATE_SCORE_SHOW_A            = 3134,
 
     BG_AV_STATE_GY_SNOWFALL_N           = 1966,
-    BG_AV_STATE_GY_SNOWFALL_A           = 1343,
-    BG_AV_STATE_GY_SNOWFALL_A_GREY      = 1341,
-    BG_AV_STATE_GY_SNOWFALL_H           = 1344,
-    BG_AV_STATE_GY_SNOWFALL_H_GREY      = 1342,
+    BG_AV_STATE_GY_SNOWFALL_A           = 1341,
+    BG_AV_STATE_GY_SNOWFALL_A_GREY      = 1343,
+    BG_AV_STATE_GY_SNOWFALL_H           = 1342,
+    BG_AV_STATE_GY_SNOWFALL_H_GREY      = 1344,
 
     // mine world states
     BG_AV_STATE_IRONDEEP_MINE_A         = 1358,


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes for current Alterac Valley code to make basic functions work.
Most fixes are from vmangos.

Fixes included:
Fix GY act like towers and vice versa
Fix WorldState update for Snowfall GY (from vmangos)
Fix Alterac Valley mines being not neutral from start
Fix fires not spawning on bunker after captain kill
Fix "towers defended" not working in BG score

Note: mines fix doesn't work without DB fix, will make a PR with it.