### PR TITLE
[Spell] Add script for s.8555 Left for Dead -> s.8359

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -27,6 +27,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (4132,'spell_banish_exile'),
 (6467,'spell_unarmed_woodcutter'),
 (7054,'spell_forsaken_skill'),
+(8555,'spell_left_for_dead'),
 (8603,'spell_tribal_death'),
 (8655,'spell_tribal_death'),
 (8894,'spell_tribal_death'),

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/razorfen_kraul/razorfen_kraul.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/razorfen_kraul/razorfen_kraul.cpp
@@ -252,6 +252,18 @@ bool EffectDummyCreature_npc_snufflenose_gopher(Unit* /*pCaster*/, uint32 uiSpel
     return false;
 }
 
+struct LeftForDead : public SpellScript // s.8555
+{
+    void OnEffectExecute(Spell* spell, SpellEffectIndex /*effIdx*/) const override
+    {
+        Unit* target = spell->GetUnitTarget();
+        if (!target)
+            return;
+
+        target->CastSpell(nullptr, 8359, TRIGGERED_OLD_TRIGGERED);
+    }
+};
+
 void AddSC_razorfen_kraul()
 {
     Script* pNewScript = new Script;
@@ -265,4 +277,6 @@ void AddSC_razorfen_kraul()
     pNewScript->GetAI = &GetAI_npc_snufflenose_gopher;
     pNewScript->pEffectDummyNPC = &EffectDummyCreature_npc_snufflenose_gopher;
     pNewScript->RegisterSelf();
+
+    RegisterSpellScript<LeftForDead>("spell_left_for_dead");
 }


### PR DESCRIPTION
Add support for smartest spell ever. https://tbc.wowhead.com/npc=4422/agathelos-the-raging#abilities;mode:normal

## 🍰 Pullrequest
Adds SPELL_ATTR_TRIGGERS_A_SPELL component of the spell 8555

### Proof
https://www.wowhead.com/npc=4422/agathelos-the-raging#comments:id=1071607
https://wowwiki-archive.fandom.com/wiki/Agathelos_the_Raging

### How2Test
.go c id 4422 with two clients, watch one getting feign deathed, its seemingly not even a debuff so you can just break it, but not by pushing normal spells/abilities.