### PR TITLE
[SD] Add OnStealthAlert Check for Klaven Mortwake 7053

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -1360,6 +1360,7 @@ UPDATE creature_template SET ScriptName='npc_tirion_fordring' WHERE entry=12126;
 /* WESTFALL */
 UPDATE creature_template SET ScriptName='npc_daphne_stilwell' WHERE entry=6182;
 UPDATE creature_template SET ScriptName='npc_defias_traitor' WHERE entry=467;
+UPDATE creature_template SET ScriptName='npc_foreman_klaven_mortwake' WHERE entry=7053;
 
 /* WETLANDS */
 UPDATE creature_template SET ScriptName='npc_tapoke_slim_jahn' WHERE entry=4962;

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/westfall.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/westfall.cpp
@@ -29,6 +29,7 @@ EndScriptData
 /* ContentData
 npc_daphne_stilwell
 npc_defias_traitor
+npc_foreman_klaven_mortwake
 EndContentData */
 
 /*######
@@ -397,6 +398,35 @@ UnitAI* GetAI_npc_defias_traitor(Creature* creature)
     return new npc_defias_traitorAI(creature);
 }
 
+/*######
+## npc_foreman_klaven_mortwake
+######*/
+
+enum KlavenMortwake
+{
+    SAY_STEALTH_ALERT_MORTWAKE = 3092
+};
+
+struct npc_foreman_klaven_mortwakeAI : public ScriptedAI
+{
+    npc_foreman_klaven_mortwakeAI(Creature* creature) : ScriptedAI(creature)
+    {
+        Reset();
+    }
+
+    void Reset() override {}
+
+    void OnStealthAlert(Unit* who) override
+    {
+        DoBroadcastText(SAY_STEALTH_ALERT_MORTWAKE, m_creature, who);
+    }
+};
+
+UnitAI* GetAI_npc_foreman_klaven_mortwake(Creature* creature)
+{
+    return new npc_foreman_klaven_mortwakeAI(creature);
+}
+
 void AddSC_westfall()
 {
     Script* pNewScript = new Script;
@@ -409,5 +439,10 @@ void AddSC_westfall()
     pNewScript->Name = "npc_defias_traitor";
     pNewScript->GetAI = &GetAI_npc_defias_traitor;
     pNewScript->pQuestAcceptNPC = &QuestAccept_npc_defias_traitor;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "npc_foreman_klaven_mortwake";
+    pNewScript->GetAI = &GetAI_npc_foreman_klaven_mortwake;
     pNewScript->RegisterSelf();
 }


### PR DESCRIPTION
## 🍰 Pullrequest
Remove ACID script which does not work as intended

https://github.com/cmangos/tbc-db/commit/f3b45ce0b04a5eeabd1fa32d8812ffe167b03973

### Proof
<!-- Link resources as proof -->
https://www.youtube.com/watch?v=d_2-8ql5pZE&t=65s

### Issues
- NA

Edit: What i found to be pretty frustrating is that detect range is pretty much the same as detect + aggro range, so maybe there is still something wrong with detection formulars.

#2 Npcs dont reset to their default orientation after a set amount of time after doing a stealth detection. (probably linked to why patrol groups dont all continue walking after they were distracted currently)

### How2Test
.go c id 7053