### PR TITLE
[SD] Adjust Phasing for Venoxis in ZG & Add missing Virulent Poison Proc

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/zulgurub/boss_venoxis.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/zulgurub/boss_venoxis.cpp
@@ -43,9 +43,10 @@ enum
     SPELL_PARASITIC_SERPENT = 23867,
 
     // common spells
-    SPELL_SNAKE_FORM        = 23849,
-    SPELL_FRENZY            = 23537,
-    SPELL_TRASH             = 3391,
+    SPELL_SNAKE_FORM            = 23849,
+    SPELL_FRENZY                = 23537,
+    SPELL_VIRULENT_POISON_PROC  = 22413, // TBC+?
+    SPELL_TRASH                 = 3391,
 
     SPELL_LIST_PHASE_1 = 1450701,
     SPELL_LIST_PHASE_2 = 1450702,
@@ -92,28 +93,28 @@ struct boss_venoxisAI : public CombatAI
         switch (action)
         {
             case VENOXIS_PHASE_2:
-                if (m_creature->GetHealthPercent() > 50.f)
-                    break;
-
-                if (DoCastSpellIfCan(nullptr, SPELL_SNAKE_FORM) == CAST_OK)
+                if (m_creature->GetHealthPercent() < 50.f)
+                    if (DoCastSpellIfCan(nullptr, SPELL_SNAKE_FORM) == CAST_OK)
+                    {
+                        DoScriptText(SAY_TRANSFORM, m_creature);
+                        DoCastSpellIfCan(nullptr, SPELL_POISON_CLOUD); // an instant cloud on change
+                        DoCastSpellIfCan(nullptr, SPELL_VIRULENT_POISON_PROC, TRIGGERED_OLD_TRIGGERED);
+                        DoResetThreat();
+                        m_creature->SetSpellList(SPELL_LIST_PHASE_2);
+                        DisableCombatAction(action);
+                    }
+                break;
+            case VENOXIS_PHASE_3:
+                if (m_creature->GetHealthPercent() < 25.f)
                 {
-                    DoScriptText(SAY_TRANSFORM, m_creature);
-                    DoCastSpellIfCan(nullptr, SPELL_POISON_CLOUD); // an instant cloud on change
-                    DoResetThreat();
-                    m_creature->SetSpellList(SPELL_LIST_PHASE_2);
+                    m_creature->SetSpellList(SPELL_LIST_PHASE_3);
                     DisableCombatAction(action);
                 }
                 break;
-            case VENOXIS_PHASE_3:
-                if (m_creature->GetHealthPercent() > 25.f)
-                    break;
-                m_creature->SetSpellList(SPELL_LIST_PHASE_3);
-                break;
             case VENOXIS_FRENZY:
-                if (m_creature->GetHealthPercent() > 10.f)
-                    break;
-                if (DoCastSpellIfCan(nullptr, SPELL_FRENZY) == CAST_OK)
-                    DisableCombatAction(action);
+                if (m_creature->GetHealthPercent() < 20.f) // maybe even 25
+                    if (DoCastSpellIfCan(nullptr, SPELL_FRENZY) == CAST_OK)
+                        DisableCombatAction(action);
                 break;
         }
     }


### PR DESCRIPTION
Aura passive might be tbc(+), Phase Fix is required.

https://youtu.be/CJyeWM5QM94?t=345
https://classic.wowhead.com/guides/high-priest-venoxis-zul-gurub-strategy

Enrage and P3 might be one and the same thing.

### Proof
```
ServerToClient: SMSG_CHAT (0x0096) Length: 84 ConnIdx: 0 Time: 02/13/2009 05:26:26.000 Number: 1759931
Type: 14 (MonsterYell)
Language: 0 (Universal)
GUID: Full: 0xF1300038AB000089 Type: Creature Entry: 14507 Low: 137
Constant time: 0
Name Length: 20
Name: High Priest Venoxis
Receiver GUID: 0x0
Text Length: 30
Text: Let the coils of hate unfurl!
Chat Tag: 0 (None)

ServerToClient: SMSG_COMPRESSED_UPDATE_OBJECT (0x01F6) Length: 100 ConnIdx: 0 Time: 02/13/2009 05:26:26.000 Number: 1759998
Count: 6
[4] UpdateType: Values
[4] GUID: Full: 0xF1300038AB000089 Type: Creature Entry: 14507 Low: 137
[4] UNIT_FIELD_HEALTH: 103488
[4] UNIT_FIELD_AURASTATE: 8192/1.148E-41

ServerToClient: SMSG_AURA_UPDATE (0x0496) Length: 14 ConnIdx: 0 Time: 02/13/2009 05:26:27.000 Number: 1760025
GUID: Full: 0xF1300038AB000089 Type: Creature Entry: 14507 Low: 137
[0] Slot: 7
[0] Spell ID: 23849 (23849)
[0] Flags: 27 (EffectIndex0, EffectIndex1, NotCaster, Positive)
[0] Level: 63
[0] Charges: 0
```

### Issues
The Encounter currently somewhat does not really work due to < and >, logic was done "from behind" and in a way that it does not work.

### How2Test
.go c id 14507