### PR TITLE
Update min/max values of SKILL_RANGE_MONO skills on character levelup

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -5783,7 +5783,8 @@ void Player::UpdateSkillsForLevel(bool maximize/* = false*/)
         if (!pSkill)
             continue;
 
-        if (GetSkillRangeType(pSkill, false) != SKILL_RANGE_LEVEL)
+        SkillRangeType skillType = GetSkillRangeType(pSkill, false);
+        if (skillType != SKILL_RANGE_LEVEL && skillType != SKILL_RANGE_MONO)
             continue;
 
         bool maxed = maximize;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Currently, SKILL_RANGE_MONO have their min/max values updated when a character logs in. This is correct. However, they are not updated when the character levels up, which is incorrect.

Valid for Vanilla, TBC and WotLK.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create a Draenei.
- Check the tooltip for Gift of the Naaru, see that it mentions 50 health points.
- .levelup 10
- Check the tooltip, see that it still mentions 50 health points.
- This is fixed when logging out and back in, but it should be updated on levelup too.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
