### PR TITLE
[SD] Remove faulty script for Burning Abyssal 17454

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -793,7 +793,6 @@ UPDATE instance_template SET ScriptName='instance_shattered_halls' WHERE map=540
 UPDATE instance_template SET ScriptName='instance_magtheridons_lair' WHERE map=544;
 UPDATE gameobject_template SET ScriptName='go_manticron_cube' WHERE entry=181713;
 UPDATE creature_template SET ScriptName='boss_magtheridon' WHERE entry=17257;
-UPDATE creature_template SET ScriptName='mob_abyssal' WHERE entry=17454;
 UPDATE creature_template SET ScriptName='mob_hellfire_channeler' WHERE entry=17256;
 
 /* HELLFIRE PENINSULA */

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/magtheridons_lair/boss_magtheridon.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/magtheridons_lair/boss_magtheridon.cpp
@@ -75,12 +75,9 @@ enum
     SPELL_BURNING_ABYSSAL       = 30511,
     SPELL_SOUL_TRANSFER         = 30531,
 
-    // Abyss spells
-    SPELL_FIRE_BLAST            = 37110,
-
     // summons
-    // NPC_MAGS_ROOM             = 17516,
-    NPC_BURNING_ABYSS           = 17454,
+    // NPC_MAGS_ROOM               = 17516,
+    // NPC_BURNING_ABYSSAL         = 17454,
     NPC_RAID_TRIGGER            = 17376,
 
     MAX_QUAKE_COUNT             = 7,
@@ -360,12 +357,6 @@ struct mob_hellfire_channelerAI : public CombatAI
             m_instance->SetData(TYPE_CHANNELER_EVENT, FAIL);
     }
 
-    void JustSummoned(Creature* summoned) override
-    {
-        if (m_creature->GetVictim())
-            summoned->AI()->AttackStart(m_creature->GetVictim());
-    }
-
     void ExecuteAction(uint32 action) override
     {
         switch (action)
@@ -442,45 +433,6 @@ bool GOUse_go_manticron_cube(Player* player, GameObject* go)
 
     return true;
 }
-
-// ToDo: move this script to eventAI
-struct mob_abyssalAI : public ScriptedAI
-{
-    mob_abyssalAI(Creature* creature) : ScriptedAI(creature) { Reset(); }
-
-    uint32 m_uiFireBlastTimer;
-    uint32 m_uiDespawnTimer;
-
-    void Reset() override
-    {
-        m_uiDespawnTimer   = 60000;
-        m_uiFireBlastTimer = 6000;
-    }
-
-    void UpdateAI(const uint32 uiDiff) override
-    {
-        if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
-            return;
-
-        if (m_uiDespawnTimer < uiDiff)
-        {
-            m_creature->ForcedDespawn();
-            m_uiDespawnTimer = 10000;
-        }
-        else
-            m_uiDespawnTimer -= uiDiff;
-
-        if (m_uiFireBlastTimer < uiDiff)
-        {
-            if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_FIRE_BLAST) == CAST_OK)
-                m_uiFireBlastTimer = urand(5000, 15000);
-        }
-        else
-            m_uiFireBlastTimer -= uiDiff;
-
-        DoMeleeAttackIfReady();
-    }
-};
 
 struct ShadowGraspCube : public AuraScript
 {
@@ -566,11 +518,6 @@ void AddSC_boss_magtheridon()
     pNewScript->Name = "go_manticron_cube";
     pNewScript->pGOUse = &GOUse_go_manticron_cube;
     pNewScript->GetGameObjectAI = &GetNewAIInstance<go_manticron_cubeAI>;
-    pNewScript->RegisterSelf();
-
-    pNewScript = new Script;
-    pNewScript->Name = "mob_abyssal";
-    pNewScript->GetAI = &GetNewAIInstance<mob_abyssalAI>;
     pNewScript->RegisterSelf();
 
     RegisterSpellScript<ShadowGraspCube>("spell_shadow_grasp_cube");


### PR DESCRIPTION
Will be handled and improved in ACID/EAI File

https://github.com/cmangos/tbc-db/commit/8bd633b3d1271a24fcc7f2292f070f476a7a2b41

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
```
ServerToClient: SMSG_UPDATE_OBJECT (0x280D) Length: 1324 ConnIdx: 1 Time: 08/27/2017 21:55:20.100 Number: 3612
[1] UpdateType: CreateObject2
[1] Object Guid: Full: 0x2016F44400110B800028F000002323A5 Creature/0 R1469/S10480 Map: 544 Entry: 17454 Low: 2302885

ServerToClient: SMSG_AURA_UPDATE (0x2C22) Length: 51 ConnIdx: 1 Time: 08/27/2017 21:55:20.100 Number: 3613
[0] SpellID: 30516 (30516)
UnitGUID: Full: 0x2016F44400110B800028F000002323A5 Creature/0 R1469/S10480 Map: 544 Entry: 17454 Low: 2302885

ServerToClient: SMSG_AI_REACTION (0x26E1) Length: 18 ConnIdx: 1 Time: 08/27/2017 21:55:21.335 Number: 3620
UnitGUID: Full: 0x2016F44400110B800028F000002323A5 Creature/0 R1469/S10480 Map: 544 Entry: 17454 Low: 2302885
Reaction: 2 (Hostile)
```

### Issues
Currently uses wrong Fire Blast Spell, doesnt have Attack Delay

### How2Test
.go c id 17257