### PR TITLE
Allow to change a specific creature spawn's npcflags via creature_spawn_data_template

### DIFF
--- a/sql/updates/mangos/s9999_01_mangos_creature_spawn_data_template.sql
+++ b/sql/updates/mangos/s9999_01_mangos_creature_spawn_data_template.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `creature_spawn_data_template` ADD COLUMN `NpcFlags` INT(10) DEFAULT -1 NOT NULL AFTER `Entry`, DROP PRIMARY KEY, ADD PRIMARY KEY (`Entry`, `NpcFlags`, `UnitFlags`, `ModelId`, `EquipmentId`, `CurHealth`, `CurMana`, `SpawnFlags`);
+

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -547,7 +547,11 @@ bool Creature::UpdateEntry(uint32 Entry, const CreatureData* data /*=nullptr*/, 
     setFaction(faction);
 
     SetDefaultGossipMenuId(GetCreatureInfo()->GossipMenuId);
-    SetUInt32Value(UNIT_NPC_FLAGS, GetCreatureInfo()->NpcFlags);
+
+    uint32 npcFlags = GetCreatureInfo()->NpcFlags;
+    if (data && data->spawnTemplate->npcFlags != -1)
+        npcFlags = uint32(data->spawnTemplate->npcFlags);
+    SetUInt32Value(UNIT_NPC_FLAGS, npcFlags);
 
     uint32 attackTimer = GetCreatureInfo()->MeleeBaseAttackTime;
 

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -221,6 +221,7 @@ enum SpawnFlags
 struct CreatureSpawnTemplate
 {
     uint32 entry;
+    int32 npcFlags;
     int64 unitFlags;
     uint32 faction;
     uint32 modelId;

--- a/src/game/Entities/Object.cpp
+++ b/src/game/Entities/Object.cpp
@@ -2098,6 +2098,8 @@ Creature* WorldObject::SummonCreature(TempSpawnSettings settings, Map* map)
     {
         if (CreatureSpawnTemplate const* templateData = sObjectMgr.GetCreatureSpawnTemplate(settings.spawnDataEntry))
         {
+            if (templateData->npcFlags != -1)
+                creature->SetUInt32Value(UNIT_NPC_FLAGS, uint32(templateData->npcFlags));
             if (templateData->unitFlags != -1)
                 creature->SetUInt32Value(UNIT_FIELD_FLAGS, uint32(templateData->unitFlags));
             if (templateData->faction > 0)

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -1767,7 +1767,7 @@ void ObjectMgr::LoadCreatureSpawnDataTemplates()
 {
     m_creatureSpawnTemplateMap.clear();
 
-    std::unique_ptr<QueryResult> result(WorldDatabase.Query("SELECT Entry, UnitFlags, Faction, ModelId, EquipmentId, CurHealth, CurMana, SpawnFlags, RelayId FROM creature_spawn_data_template"));
+    std::unique_ptr<QueryResult> result(WorldDatabase.Query("SELECT Entry, NpcFlags, UnitFlags, Faction, ModelId, EquipmentId, CurHealth, CurMana, SpawnFlags, RelayId FROM creature_spawn_data_template"));
     if (!result)
     {
         BarGoLink bar(1);
@@ -1788,18 +1788,20 @@ void ObjectMgr::LoadCreatureSpawnDataTemplates()
         Field* fields = result->Fetch();
 
         uint32 entry =      fields[0].GetUInt32();
-        int64 unitFlags =   int64(fields[1].GetUInt64());
-        uint32 faction =    fields[2].GetUInt32();
-        uint32 modelId =    fields[3].GetUInt32();
-        int32 equipmentId = fields[4].GetInt32();
-        uint32 curHealth =  fields[5].GetUInt32();
-        uint32 curMana =    fields[6].GetUInt32();
-        uint32 spawnFlags = fields[7].GetUInt32();
-        uint32 relayId = fields[8].GetUInt32();
+        int32 npcFlags =    int32(fields[1].GetUInt32());
+        int64 unitFlags =   int64(fields[2].GetUInt64());
+        uint32 faction =    fields[3].GetUInt32();
+        uint32 modelId =    fields[4].GetUInt32();
+        int32 equipmentId = fields[5].GetInt32();
+        uint32 curHealth =  fields[6].GetUInt32();
+        uint32 curMana =    fields[7].GetUInt32();
+        uint32 spawnFlags = fields[8].GetUInt32();
+        uint32 relayId = fields[9].GetUInt32();
 
         // leave room for invalidation in future
 
         auto& data = m_creatureSpawnTemplateMap[entry];
+        data.npcFlags = npcFlags;
         data.unitFlags = unitFlags;
         data.faction = faction;
         data.modelId = modelId;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Allow to change npcflags on a per-spawn basis via creature_spawn_data_template.

### Proof
<!-- Link resources as proof -->
I only have one example for this behavior, but the [Gadgetzan Bruisers](https://tbc.wowhead.com/npc=9460/gadgetzan-bruiser) in Gadgetzan don't have the gossip npc flag (currently they use a Cataclysm gossip text), while the two in Un'Goro have it. They have the same creature entry, verified in sniffs (and there's only one of this creature in template, too).

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
Run the following queries:

```sql
UPDATE `creature_template` SET `NpcFlags`=`NpcFlags`&~1 WHERE `Entry`=9460;

DELETE FROM `creature_spawn_data_template` WHERE Entry=4;
INSERT INTO `creature_spawn_data_template` (Entry, NpcFlags) VALUES
(4, 1);

DELETE FROM `creature_spawn_data` WHERE `Guid` IN (24664, 24665);
INSERT INTO `creature_spawn_data` (`Guid`, `Id`) VALUES
(24664, 4),
(24665, 4);
```

- .go creature 24664
- Check that this and the other Bruiser have gossip flag.
- .tele gadgetzan
- Check that the Bruisers there don't have gossip flag.
