### PR TITLE
Prevent relearning of profession specializations on login

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -19688,46 +19688,10 @@ void Player::learnQuestRewardedSpells(Quest const* quest)
     if (!found)
         return;
 
-    // prevent learn non first rank unknown profession and second specialization for same profession)
+    // Prevent learning profession specializations, because unlearning and re-learning a profession doesn't automatically re-add the specialization
     uint32 learned_0 = spellInfo->EffectTriggerSpell[EFFECT_INDEX_0];
-    if (sSpellMgr.GetSpellRank(learned_0) > 1 && !HasSpell(learned_0))
-    {
-        // not have first rank learned (unlearned prof?)
-        uint32 first_spell = sSpellMgr.GetFirstSpellInChain(learned_0);
-        if (!HasSpell(first_spell))
-            return;
-
-        SpellEntry const* learnedInfo = sSpellTemplate.LookupEntry<SpellEntry>(learned_0);
-        if (!learnedInfo)
-            return;
-
-        // specialization
-        if (learnedInfo->Effect[EFFECT_INDEX_0] == SPELL_EFFECT_TRADE_SKILL && learnedInfo->Effect[EFFECT_INDEX_1] == 0)
-        {
-            // search other specialization for same prof
-            for (PlayerSpellMap::const_iterator itr = m_spells.begin(); itr != m_spells.end(); ++itr)
-            {
-                if (itr->second.state == PLAYERSPELL_REMOVED || itr->first == learned_0)
-                    continue;
-
-                SpellEntry const* itrInfo = sSpellTemplate.LookupEntry<SpellEntry>(itr->first);
-                if (!itrInfo)
-                    return;
-
-                // compare only specializations
-                if (itrInfo->Effect[EFFECT_INDEX_0] != SPELL_EFFECT_TRADE_SKILL || itrInfo->Effect[EFFECT_INDEX_1] != 0)
-                    continue;
-
-                // compare same chain spells
-                if (sSpellMgr.GetFirstSpellInChain(itr->first) != first_spell)
-                    continue;
-
-                // now we have 2 specialization, learn possible only if found is lesser specialization rank
-                if (!sSpellMgr.IsSpellHigherRankOfSpell(learned_0, itr->first))
-                    return;
-            }
-        }
-    }
+    if (sSpellMgr.GetSpellRank(learned_0) > 1)
+        return;
 
     CastSpell(this, spell_id, TRIGGERED_OLD_TRIGGERED);
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Right now, when you unlearn a profession specialization (like Gnomish Engineer) and relog, the profession is relearned when the character's quest status is loaded.

This is wrong. If you're a Gnomish Engineer and drop and relearn Engineering (for the sake of changing specialization in TBC, because that was the only way to do it until WotLK), you don't get Gnomish Engineer back on relog.

Relearning of specializations is handled elsewhere (NPCs or that Soothsaying for Dummies book in Tanaris), it doesn't need this handling too.

### Proof
<!-- Link resources as proof -->

https://user-images.githubusercontent.com/99603810/158232416-00214db0-2261-4abb-b383-fb9fc57bc4e2.mp4


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create an Alliance character.
- .learn 30350
- .set 202 375
- .quest add 3641
- .quest complete 3641
- .go creature id 7944
- Turn that quest in. Now you have Gnomish Engineering.
- .unlearn 20219 and now you don't.
- Relog.
- Gnomish Engineering will reappear without this PR. It shouldn't.
