### PR TITLE
Port breadcrumb quest system from TrinityCore

### DIFF
--- a/sql/updates/mangos/s2444_01_mangos_quest_template.sql
+++ b/sql/updates/mangos/s2444_01_mangos_quest_template.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `quest_template` ADD COLUMN `BreadcrumbForQuestId` MEDIUMINT(9) UNSIGNED DEFAULT 0 NOT NULL AFTER `ExclusiveGroup`; 
+

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -12848,8 +12848,9 @@ bool Player::CanSeeStartQuest(Quest const* pQuest) const
 {
     if (SatisfyQuestClass(pQuest, false) && SatisfyQuestRace(pQuest, false) && SatisfyQuestSkill(pQuest, false) && SatisfyQuestCondition(pQuest, false) &&
             SatisfyQuestExclusiveGroup(pQuest, false) && SatisfyQuestReputation(pQuest, false) &&
-            SatisfyQuestPreviousQuest(pQuest, false) && SatisfyQuestNextChain(pQuest, false) &&
-            SatisfyQuestPrevChain(pQuest, false) && SatisfyQuestDay(pQuest, false) && SatisfyQuestWeek(pQuest) &&
+            SatisfyQuestPreviousQuest(pQuest, false) && SatisfyQuestBreadcrumbQuest(pQuest, false) && SatisfyQuestDependentBreadcrumbQuests(pQuest, false) &&
+            SatisfyQuestNextChain(pQuest, false) && SatisfyQuestPrevChain(pQuest, false) &&
+            SatisfyQuestDay(pQuest, false) && SatisfyQuestWeek(pQuest) &&
             SatisfyQuestMonth(pQuest) &&
             pQuest->IsActive())
     {
@@ -12869,6 +12870,7 @@ bool Player::CanTakeQuest(Quest const* pQuest, bool msg) const
            SatisfyQuestSkill(pQuest, msg) && SatisfyQuestCondition(pQuest, msg) && SatisfyQuestReputation(pQuest, msg) &&
            SatisfyQuestPreviousQuest(pQuest, msg) && SatisfyQuestTimed(pQuest, msg) &&
            SatisfyQuestNextChain(pQuest, msg) && SatisfyQuestPrevChain(pQuest, msg) &&
+           SatisfyQuestBreadcrumbQuest(pQuest, msg) && SatisfyQuestDependentBreadcrumbQuests(pQuest, msg) &&
            SatisfyQuestDay(pQuest, msg) && SatisfyQuestWeek(pQuest) && SatisfyQuestMonth(pQuest) &&
            pQuest->IsActive();
 }
@@ -13615,6 +13617,42 @@ bool Player::SatisfyQuestPreviousQuest(Quest const* qInfo, bool msg) const
         SendCanTakeQuestResponse(INVALIDREASON_DONT_HAVE_REQ);
 
     return false;
+}
+
+bool Player::SatisfyQuestBreadcrumbQuest(Quest const* qInfo, bool msg) const
+{
+    // If the target quest is not available, then we cannot accept the breadcrumb
+    uint32 breadcrumbTargetQuestId = qInfo->GetBreadcrumbForQuestId();
+    if (!breadcrumbTargetQuestId)
+        return true;
+
+    if (!CanTakeQuest(sObjectMgr.GetQuestTemplate(breadcrumbTargetQuestId), false))
+    {
+        if (msg)
+            SendCanTakeQuestResponse(INVALIDREASON_DONT_HAVE_REQ);
+
+        return false;
+    }
+
+    return true;
+}
+
+bool Player::SatisfyQuestDependentBreadcrumbQuests(Quest const* qInfo, bool msg) const
+{
+    // If we have one of the breadcrumb quests, then we can't accept the target quest
+    for (uint32 breadcrumbQuestId : qInfo->DependentBreadcrumbQuests)
+    {
+        QuestStatus status = GetQuestStatus(breadcrumbQuestId);
+        if ((status == QUEST_STATUS_INCOMPLETE || status == QUEST_STATUS_COMPLETE || status == QUEST_STATUS_FAILED) && !GetQuestRewardStatus(breadcrumbQuestId))
+        {
+            if (msg)
+                SendCanTakeQuestResponse(INVALIDREASON_DONT_HAVE_REQ);
+
+            return false;
+        }
+    }
+
+    return true;
 }
 
 bool Player::SatisfyQuestClass(Quest const* qInfo, bool msg) const

--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -1318,6 +1318,8 @@ class Player : public Unit
         bool SatisfyQuestLevel(Quest const* qInfo, bool msg) const;
         bool SatisfyQuestLog(bool msg) const;
         bool SatisfyQuestPreviousQuest(Quest const* qInfo, bool msg) const;
+        bool SatisfyQuestBreadcrumbQuest(Quest const* qInfo, bool msg) const;
+        bool SatisfyQuestDependentBreadcrumbQuests(Quest const* qInfo, bool msg) const;
         bool SatisfyQuestClass(Quest const* qInfo, bool msg) const;
         bool SatisfyQuestRace(Quest const* qInfo, bool msg) const;
         bool SatisfyQuestReputation(Quest const* qInfo, bool msg) const;

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -4349,37 +4349,37 @@ void ObjectMgr::LoadQuests()
 
     //                                                0      1       2           3         4           5     6                7              8              9
     QueryResult* result = WorldDatabase.Query("SELECT entry, Method, ZoneOrSort, MinLevel, QuestLevel, Type, RequiredClasses, RequiredRaces, RequiredSkill, RequiredSkillValue,"
-                          //   10                   11                 12                     13                   14                     15                   16                17
+                          // 10                 11                 12                     13                   14                     15                   16                17
                           "RepObjectiveFaction, RepObjectiveValue, RequiredMinRepFaction, RequiredMinRepValue, RequiredMaxRepFaction, RequiredMaxRepValue, SuggestedPlayers, LimitTime,"
-                          //   18          19            20           21           22           23              24                25         26            27
-                          "QuestFlags, SpecialFlags, CharTitleId, PrevQuestId, NextQuestId, ExclusiveGroup, NextQuestInChain, SrcItemId, SrcItemCount, SrcSpell,"
-                          //   28     29       30          31               32                33       34              35              36              37
+                          // 18        19            20           21           22           23              24                    25                26         27            28
+                          "QuestFlags, SpecialFlags, CharTitleId, PrevQuestId, NextQuestId, ExclusiveGroup, BreadcrumbForQuestId, NextQuestInChain, SrcItemId, SrcItemCount, SrcSpell,"
+                          // 29   30       31          32               33                34       35              36              37              38
                           "Title, Details, Objectives, OfferRewardText, RequestItemsText, EndText, ObjectiveText1, ObjectiveText2, ObjectiveText3, ObjectiveText4,"
-                          //   38          39          40          41          42             43             44             45
+                          // 39        40          41          42          43             44             45             46
                           "ReqItemId1, ReqItemId2, ReqItemId3, ReqItemId4, ReqItemCount1, ReqItemCount2, ReqItemCount3, ReqItemCount4,"
-                          //   46            47            48            49            50               51               52               53
+                          // 47          48            49            50            51               52               53               54
                           "ReqSourceId1, ReqSourceId2, ReqSourceId3, ReqSourceId4, ReqSourceCount1, ReqSourceCount2, ReqSourceCount3, ReqSourceCount4,"
-                          //   54                  55                  56                  57                  58                     59                     60                     61
+                          // 55                56                  57                  58                  59                     60                     61                     62
                           "ReqCreatureOrGOId1, ReqCreatureOrGOId2, ReqCreatureOrGOId3, ReqCreatureOrGOId4, ReqCreatureOrGOCount1, ReqCreatureOrGOCount2, ReqCreatureOrGOCount3, ReqCreatureOrGOCount4,"
-                          //   62             63             64             65
+                          // 63           64             65             66
                           "ReqSpellCast1, ReqSpellCast2, ReqSpellCast3, ReqSpellCast4,"
-                          //   66                67                68                69                70                71
+                          // 67              68                69                70                71                72
                           "RewChoiceItemId1, RewChoiceItemId2, RewChoiceItemId3, RewChoiceItemId4, RewChoiceItemId5, RewChoiceItemId6,"
-                          //   72                   73                   74                   75                   76                   77
+                          // 73                 74                   75                   76                   77                   78
                           "RewChoiceItemCount1, RewChoiceItemCount2, RewChoiceItemCount3, RewChoiceItemCount4, RewChoiceItemCount5, RewChoiceItemCount6,"
-                          //   78          79          80          81          82             83             84             85
+                          // 79        80          81          82          83             84             85             86
                           "RewItemId1, RewItemId2, RewItemId3, RewItemId4, RewItemCount1, RewItemCount2, RewItemCount3, RewItemCount4,"
-                          //   86              87              88              89              90              91            92            93            94            95
+                          // 87            88              89              90              91              92            93            94            95            96
                           "RewRepFaction1, RewRepFaction2, RewRepFaction3, RewRepFaction4, RewRepFaction5, RewRepValue1, RewRepValue2, RewRepValue3, RewRepValue4, RewRepValue5,"
-                          //   96                 97             98                99        100           101                102               103         104     105     106
+                          // 97               98             99                100       101           102                103               104         105     106     107
                           "RewHonorableKills, RewOrReqMoney, RewMoneyMaxLevel, RewSpell, RewSpellCast, RewMailTemplateId, RewMailDelaySecs, PointMapId, PointX, PointY, PointOpt,"
-                          //   107            108            109            110            111                 112                 113                 114
+                          // 108          109            110            111            112                 113                 114                 115
                           "DetailsEmote1, DetailsEmote2, DetailsEmote3, DetailsEmote4, DetailsEmoteDelay1, DetailsEmoteDelay2, DetailsEmoteDelay3, DetailsEmoteDelay4,"
-                          //   115          116                   117                118                119                120             121                 122          
+                          // 116            117                   118            119                 120                121                122                123          
                           "IncompleteEmote, IncompleteEmoteDelay, CompleteEmote, CompleteEmoteDelay, OfferRewardEmote1, OfferRewardEmote2, OfferRewardEmote3, OfferRewardEmote4,"
-                          //   123                     124                     125                     126
+                          // 124                   125                     126                     127
                           "OfferRewardEmoteDelay1, OfferRewardEmoteDelay2, OfferRewardEmoteDelay3, OfferRewardEmoteDelay4,"
-                          //   127          128            129              130             131               132             133               134
+                          // 128        129             130              131              132              133              134              135
                           "StartScript, CompleteScript, RewMaxRepValue1, RewMaxRepValue2, RewMaxRepValue3, RewMaxRepValue4, RewMaxRepValue5, RequiredCondition"
 
                           " FROM quest_template");
@@ -4947,14 +4947,13 @@ void ObjectMgr::LoadQuests()
         // fill additional data stores
         if (qinfo->PrevQuestId)
         {
-            if (mQuestTemplates.find(abs(qinfo->GetPrevQuestId())) == mQuestTemplates.end())
-            {
+            QuestMap::iterator qPrevItr = mQuestTemplates.find(abs(qinfo->GetPrevQuestId()));
+            if (qPrevItr == mQuestTemplates.end())
                 sLog.outErrorDb("Quest %d has PrevQuestId %i, but no such quest", qinfo->GetQuestId(), qinfo->GetPrevQuestId());
-            }
+            else if (qPrevItr->second->BreadcrumbForQuestId)
+                sLog.outErrorDb("Quest %d should not be unlocked by breadcrumb quest %u", qinfo->GetQuestId(), qinfo->GetPrevQuestId());
             else
-            {
                 qinfo->prevQuests.push_back(qinfo->PrevQuestId);
-            }
         }
 
         if (qinfo->NextQuestId)
@@ -4976,6 +4975,50 @@ void ObjectMgr::LoadQuests()
 
         if (qinfo->LimitTime)
             qinfo->SetSpecialFlag(QUEST_SPECIAL_FLAG_TIMED);
+
+        if (uint32 breadcrumbQuestId = qinfo->BreadcrumbForQuestId)
+        {
+            QuestMap::iterator qBreadcrumbQuestItr = mQuestTemplates.find(breadcrumbQuestId);
+            if (qBreadcrumbQuestItr == mQuestTemplates.end())
+            {
+                sLog.outErrorDb("Quest %u has BreadcrumbForQuestId %u, but there is no such quest", qinfo->GetQuestId(), breadcrumbQuestId);
+                qinfo->BreadcrumbForQuestId = 0;
+            }
+            else
+            {
+                if (qinfo->NextQuestId)
+                    sLog.outErrorDb("Quest %u is a breadcrumb, it should not unlock quest %d", qinfo->GetQuestId(), qinfo->NextQuestId);
+                if (qinfo->ExclusiveGroup)
+                    sLog.outErrorDb("Quest %u is a breadcrumb, it should not be in exclusive group %d", qinfo->GetQuestId(), qinfo->ExclusiveGroup);
+            }
+        }
+    }
+
+    // Prevent any breadcrumb loops, and inform target quests of their breadcrumbs
+    for (auto& mQuestTemplate : mQuestTemplates)
+    {
+        Quest* qinfo = mQuestTemplate.second;
+        uint32   qid = qinfo->GetQuestId();
+        uint32 breadcrumbForQuestId = qinfo->BreadcrumbForQuestId;
+        std::set<uint32> questSet;
+
+        while (breadcrumbForQuestId)
+        {
+            // If the insertion fails, then we already processed this breadcrumb quest in this iteration. This means that two breadcrumb quests have each other set as targets
+            if (!questSet.insert(qinfo->QuestId).second)
+            {
+                sLog.outErrorDb("Breadcrumb quests %u and %u are in a loop!", qid, breadcrumbForQuestId);
+                qinfo->BreadcrumbForQuestId = 0;
+                break;
+            }
+
+            qinfo = const_cast<Quest*>(sObjectMgr.GetQuestTemplate(breadcrumbForQuestId));
+
+            // Every quest has a list of breadcrumb quests that point toward it
+            qinfo->DependentBreadcrumbQuests.push_back(qid);
+
+            breadcrumbForQuestId = qinfo->GetBreadcrumbForQuestId();
+        }
     }
 
     sLog.outString(">> Loaded " SIZEFMTD " quests definitions", mQuestTemplates.size());

--- a/src/game/Quests/QuestDef.cpp
+++ b/src/game/Quests/QuestDef.cpp
@@ -46,100 +46,101 @@ Quest::Quest(Field* questRecord)
     PrevQuestId = questRecord[21].GetInt32();
     NextQuestId = questRecord[22].GetInt32();
     ExclusiveGroup = questRecord[23].GetInt32();
-    NextQuestInChain = questRecord[24].GetUInt32();
-    SrcItemId = questRecord[25].GetUInt32();
-    SrcItemCount = questRecord[26].GetUInt32();
-    SrcSpell = questRecord[27].GetUInt32();
-    Title = questRecord[28].GetCppString();
-    Details = questRecord[29].GetCppString();
-    Objectives = questRecord[30].GetCppString();
-    OfferRewardText = questRecord[31].GetCppString();
-    RequestItemsText = questRecord[32].GetCppString();
-    EndText = questRecord[33].GetCppString();
+    BreadcrumbForQuestId = questRecord[24].GetInt32();
+    NextQuestInChain = questRecord[25].GetUInt32();
+    SrcItemId = questRecord[26].GetUInt32();
+    SrcItemCount = questRecord[27].GetUInt32();
+    SrcSpell = questRecord[28].GetUInt32();
+    Title = questRecord[29].GetCppString();
+    Details = questRecord[30].GetCppString();
+    Objectives = questRecord[31].GetCppString();
+    OfferRewardText = questRecord[32].GetCppString();
+    RequestItemsText = questRecord[33].GetCppString();
+    EndText = questRecord[34].GetCppString();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ObjectiveText[i] = questRecord[34 + i].GetCppString();
+        ObjectiveText[i] = questRecord[35 + i].GetCppString();
 
     for (int i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
-        ReqItemId[i] = questRecord[38 + i].GetUInt32();
+        ReqItemId[i] = questRecord[39 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ReqItemCount[i] = questRecord[42 + i].GetUInt32();
+        ReqItemCount[i] = questRecord[43 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
-        ReqSourceId[i] = questRecord[46 + i].GetUInt32();
+        ReqSourceId[i] = questRecord[47 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
-        ReqSourceCount[i] = questRecord[50 + i].GetUInt32();
+        ReqSourceCount[i] = questRecord[51 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ReqCreatureOrGOId[i] = questRecord[54 + i].GetInt32();
+        ReqCreatureOrGOId[i] = questRecord[55 + i].GetInt32();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ReqCreatureOrGOCount[i] = questRecord[58 + i].GetUInt32();
+        ReqCreatureOrGOCount[i] = questRecord[59 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ReqSpell[i] = questRecord[62 + i].GetUInt32();
+        ReqSpell[i] = questRecord[63 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REWARD_CHOICES_COUNT; ++i)
-        RewChoiceItemId[i] = questRecord[66 + i].GetUInt32();
+        RewChoiceItemId[i] = questRecord[67 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REWARD_CHOICES_COUNT; ++i)
-        RewChoiceItemCount[i] = questRecord[72 + i].GetUInt32();
+        RewChoiceItemCount[i] = questRecord[73 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REWARDS_COUNT; ++i)
-        RewItemId[i] = questRecord[78 + i].GetUInt32();
+        RewItemId[i] = questRecord[79 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REWARDS_COUNT; ++i)
-        RewItemCount[i] = questRecord[82 + i].GetUInt32();
+        RewItemCount[i] = questRecord[83 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
-        RewRepFaction[i] = questRecord[86 + i].GetUInt32();
+        RewRepFaction[i] = questRecord[87 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
-        RewRepValue[i] = questRecord[91 + i].GetInt32();
+        RewRepValue[i] = questRecord[92 + i].GetInt32();
 
-    RewHonorableKills = questRecord[96].GetUInt32();
-    RewOrReqMoney = questRecord[97].GetInt32();
-    RewMoneyMaxLevel = questRecord[98].GetUInt32();
-    RewSpell = questRecord[99].GetUInt32();
-    RewSpellCast = questRecord[100].GetUInt32();
-    RewMailTemplateId = questRecord[101].GetUInt32();
-    RewMailDelaySecs = questRecord[102].GetUInt32();
-    PointMapId = questRecord[103].GetUInt32();
-    PointX = questRecord[104].GetFloat();
-    PointY = questRecord[105].GetFloat();
-    PointOpt = questRecord[106].GetUInt32();
+    RewHonorableKills = questRecord[97].GetUInt32();
+    RewOrReqMoney = questRecord[98].GetInt32();
+    RewMoneyMaxLevel = questRecord[99].GetUInt32();
+    RewSpell = questRecord[100].GetUInt32();
+    RewSpellCast = questRecord[101].GetUInt32();
+    RewMailTemplateId = questRecord[102].GetUInt32();
+    RewMailDelaySecs = questRecord[103].GetUInt32();
+    PointMapId = questRecord[104].GetUInt32();
+    PointX = questRecord[105].GetFloat();
+    PointY = questRecord[106].GetFloat();
+    PointOpt = questRecord[107].GetUInt32();
 
     m_detailsemotecount = 0;
     for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
     {
-        DetailsEmote[i] = questRecord[107 + i].GetUInt32();
+        DetailsEmote[i] = questRecord[108 + i].GetUInt32();
         if (DetailsEmote[i] != 0)
             m_detailsemotecount = i + 1;
     }
 
     for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
-        DetailsEmoteDelay[i] = questRecord[111 + i].GetUInt32();
+        DetailsEmoteDelay[i] = questRecord[112 + i].GetUInt32();
 
-    IncompleteEmote = questRecord[115].GetUInt32();
-    IncompleteEmoteDelay = questRecord[116].GetUInt32();
-    CompleteEmote = questRecord[117].GetUInt32();
-    CompleteEmoteDelay = questRecord[118].GetUInt32();
-
-    for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
-        OfferRewardEmote[i] = questRecord[119 + i].GetInt32();
+    IncompleteEmote = questRecord[116].GetUInt32();
+    IncompleteEmoteDelay = questRecord[117].GetUInt32();
+    CompleteEmote = questRecord[118].GetUInt32();
+    CompleteEmoteDelay = questRecord[119].GetUInt32();
 
     for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
-        OfferRewardEmoteDelay[i] = questRecord[123 + i].GetInt32();
+        OfferRewardEmote[i] = questRecord[120 + i].GetInt32();
 
-    QuestStartScript = questRecord[127].GetUInt32();
-    QuestCompleteScript = questRecord[128].GetUInt32();
+    for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
+        OfferRewardEmoteDelay[i] = questRecord[124 + i].GetInt32();
+
+    QuestStartScript = questRecord[128].GetUInt32();
+    QuestCompleteScript = questRecord[129].GetUInt32();
 
     for (int i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
-        RewMaxRepValue[i] = questRecord[129 + i].GetInt32();
+        RewMaxRepValue[i] = questRecord[130 + i].GetInt32();
 
-    RequiredCondition = questRecord[134].GetUInt32();
+    RequiredCondition = questRecord[135].GetUInt32();
 
     m_isActive = true;
 

--- a/src/game/Quests/QuestDef.h
+++ b/src/game/Quests/QuestDef.h
@@ -217,6 +217,7 @@ class Quest
         int32  GetPrevQuestId() const { return PrevQuestId; }
         int32  GetNextQuestId() const { return NextQuestId; }
         int32  GetExclusiveGroup() const { return ExclusiveGroup; }
+        uint32 GetBreadcrumbForQuestId() const { return BreadcrumbForQuestId; }
         uint32 GetNextQuestInChain() const { return NextQuestInChain; }
         uint32 GetCharTitleId() const { return CharTitleId; }
         uint32 GetCharTitleBitIndex() const;                // in 2.x in different from 3.x in some quest packets used bit index insed id
@@ -291,6 +292,7 @@ class Quest
         PrevQuests prevQuests;
         typedef std::vector<uint32> PrevChainQuests;
         PrevChainQuests prevChainQuests;
+        std::vector<uint32> DependentBreadcrumbQuests;
 
         // cached data
     private:
@@ -329,6 +331,7 @@ class Quest
         int32  PrevQuestId;
         int32  NextQuestId;
         int32  ExclusiveGroup;
+        uint32 BreadcrumbForQuestId;
         uint32 NextQuestInChain;
         uint32 SrcItemId;
         uint32 SrcItemCount;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Port of the core-side part of https://github.com/TrinityCore/TrinityCore/commit/5ed77113b637c49e99a610b00f385c51da67c3bf. The DB side will take a bit longer, but the functionality itself works.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
https://github.com/cmangos/issues/issues/2745 (does not close it yet)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
```sql
-- Rude Awakening (363) -> The Mindless Ones (364)
UPDATE `quest_template` SET `BreadcrumbForQuestId`=364 WHERE `entry`=363;
UPDATE `quest_template` SET `PrevQuestId`=0 WHERE `entry`=364;

```

Create an Undead.
- .go creature id 1569
- Spawn creature 1568 nearby, for ease of access.
- Accept quest from Shadow Priest Sarvis, see that you can't take Undertaker Mordo's quest. Do the opposite thing and see you can't accept the other's quest. Notice that Undertaker Mordo's quest is entirely optional. They behave as a breadcrumb and target quest should do.