### PR TITLE
Add option for Link-Time Optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 # Minimum required cmake version to run the build
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.9)
+cmake_policy(SET CMP0069 NEW)
 
 # Will cache object files if ccache is available
 # Must be set at top of cmake outside of project header


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR adds LTO support by setting the required minimum version of CMake to 3.9 and setting the CMP0069 policy to NEW

To actually compile the project with LTO then, you will have to add the following CMAKE flag:
`-CMAKE_INTERPROCEDURAL_OPTIMIZATION=On`

This *should* work for all major platforms and all major compilers.

Because I accidentally closed my previous PR (https://github.com/cmangos/mangos-tbc/pull/503) with a force-push and am unable to re-open it, here's this new PR. Thank you @deiteris for bringing this cmake flag to my attention!
I haven't been able to test this PR on `gcc` because `gcc` is still bugged on Arch Linux and won't compile CMaNGOS at all in any case. It works flawlessly with `clang` however.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Test with MSVC
- [ ] Test with GCC
