### PR TITLE
Implement ITEM_EXTRA_IGNORE_QUEST_STATUS to allow items that start a quest to drop for players even if they have the related quest already accepted/completed/rewarded

### DIFF
--- a/src/game/Entities/ItemPrototype.h
+++ b/src/game/Entities/ItemPrototype.h
@@ -448,8 +448,9 @@ inline uint8 ItemSubClassToDurabilityMultiplierId(uint32 ItemClass, uint32 ItemS
 
 enum ItemExtraFlags
 {
-    ITEM_EXTRA_REAL_TIME_DURATION = 0x01,                   // if set and have Duration time, then offline time included in counting, if not set then counted only in game time
-    ITEM_EXTRA_ALL                = 0x01                    // all used flags, used for check DB data (mask all above flags)
+    ITEM_EXTRA_REAL_TIME_DURATION  = 0x01, // if set and have Duration time, then offline time included in counting, if not set then counted only in game time
+    ITEM_EXTRA_IGNORE_QUEST_STATUS = 0x02, // if set, queststarter item will drop for player regardless of the related quest's status
+    ITEM_EXTRA_ALL                 = 0x03  // all used flags, used for check DB data (mask all above flags)
 };
 
 // GCC have alternative #pragma pack(N) syntax and old gcc version not support pack(push,N), also any gcc version not support it at some platform

--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -421,9 +421,12 @@ bool LootItem::AllowedForPlayer(Player const* player, WorldObject const* lootTar
             break;
     }
 
-    // Not quest only drop (check quest starting items for already accepted non-repeatable quests)
-    if (player != masterLooter && itemProto->StartQuest && player->GetQuestStatus(itemProto->StartQuest) != QUEST_STATUS_NONE && !player->HasQuestForItem(itemId))
-        return false;
+    // If the item starts a quest and the player has that quest accepted/completed/rewarded, it can't be looted (unless the player is the master looter, or the item has ITEM_EXTRA_IGNORE_QUEST_STATUS)
+    if (itemProto->StartQuest)
+    {
+        if (!(itemProto->ExtraFlags & ITEM_EXTRA_IGNORE_QUEST_STATUS) && player != masterLooter && player->GetQuestStatus(itemProto->StartQuest) != QUEST_STATUS_NONE)
+            return false;
+    }
 
     return true;
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

This is my attempt to fix [Arena Master](https://tbc.wowhead.com/item=18706/arena-master) and items like that (although the number of items with this behavior I know of, other than this, is 0) without having to add a specific case for this item directly in core.

Items that start a quest, and have ITEM_EXTRA_IGNORE_QUEST_STATUS, will be lootable regardless of the related quest's status.

I had a hard time trying to find alternative ways to fix this, because this item is special in that, as long as you "win" the event (by opening the chest) you can obtain as many of this trinket as you want. But there's also a quest (the next step of the quest started by the trinket) that requires 12 of those.

I removed the ```!player->HasQuestForItem(itemId)``` part because it only affects this item (git blame bought me to the SVN import, but I'm 99% sure this was only added with this item in mind), but it's not relevant for this change so I can put it back if anyone wants it.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .gobj add 179697
- Loot the Arena Master trinket.
- Right-click it, accept the quest.
- .gobj add 179697
- Open the chest, notice that there's no Arena Master trinket in the new chest.

Execute this query:
```sql
UPDATE `item_template` SET `ExtraFlags`=`ExtraFlags`|2 WHERE `entry`=18706;

```

Repeat above steps, notice how now you're able to loot the trinket again.