### PR TITLE
Improve platform labelling by adding ARM Architectures

### DIFF
--- a/src/shared/SystemConfig.h
+++ b/src/shared/SystemConfig.h
@@ -55,6 +55,10 @@
 # define ARCHITECTURE "x64"
 #elif defined(__ia64)  || defined(__IA64__)  || defined(_M_IA64)
 # define ARCHITECTURE "IA64"
+#elif defined(__aarch64__)
+# define ARCHITECTURE "AArch64"
+#elif defined(__arm__)
+# define ARCHITECTURE "ARM32"
 #else
 # define ARCHITECTURE "x32"
 #endif


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR adds ARM32 and AArch64 to the possible platforms in SystemConfig.h

This has no functional benefit, but makes our splash screen more accurate.