### PR TITLE
Fix crash due to typo in 7dc176d

### DIFF
--- a/src/game/BattleGround/BattleGroundHandler.cpp
+++ b/src/game/BattleGround/BattleGroundHandler.cpp
@@ -246,7 +246,7 @@ void WorldSession::HandleBattleGroundPlayerPositionsOpcode(WorldPacket& /*recv_d
             Player* flagCarrierHorde = sObjectMgr.GetPlayer(static_cast<BattleGroundWS*>(bg)->GetFlagCarrierGuid(TEAM_INDEX_HORDE));
             if (flagCarrierHorde)
             {
-                if (flagCarrierHorde->GetTeam() == _player->GetTeam() || static_cast<BattleGroundWS*>(bg)->IsFlagHeldFor45Seconds(flagCarrierAlliance->GetTeam()))
+                if (flagCarrierHorde->GetTeam() == _player->GetTeam() || static_cast<BattleGroundWS*>(bg)->IsFlagHeldFor45Seconds(flagCarrierHorde->GetTeam()))
                     ++flagCarrierCount;
             }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes small typo which results in a crash if an Alliance character picks up the flag while a single Horde character is present in WSG.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Before applying fix, queue as Alliance and Horde into WSG
- Pick up flag as Alliance (not Horde), server will crash
- Apply fix, repeat steps
- Success!

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
