### PR TITLE
Fix issue preventing entry into rated arena. #2831

### DIFF
--- a/src/game/BattleGround/BattleGroundMgr.cpp
+++ b/src/game/BattleGround/BattleGroundMgr.cpp
@@ -1738,10 +1738,6 @@ BattleGround* BattleGroundMgr::CreateNewBattleGround(BattleGroundTypeId bgTypeId
             return nullptr;
     }
 
-    bg->SetBracketId(bracketId);
-    bg->SetArenaType(arenaType);
-    bg->SetRated(isRated);
-
     // will also set m_bgMap, instanceid
     sMapMgr.CreateBgMap(bg->GetMapId(), bg);
 
@@ -1749,6 +1745,11 @@ BattleGround* BattleGroundMgr::CreateNewBattleGround(BattleGroundTypeId bgTypeId
 
     // reset the new bg (set status to status_wait_queue from status_none)
     bg->Reset();
+
+    // set bg parameters (must occur after reset!)
+    bg->SetBracketId(bracketId);
+    bg->SetArenaType(arenaType);
+    bg->SetRated(isRated);
 
     // start the joining of the bg
     bg->SetStatus(STATUS_WAIT_JOIN);


### PR DESCRIPTION
## 🍰 Pullrequest
Reordering of some code in 66cf72be184b047e385c3c4b5ac0dcb7b57f3a57 broke rated arena queue pops since setting the BG as rated occurred before a reset call was made on the BG, always defaulting rated to false.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes [#2831](https://github.com/cmangos/issues/issues/2831)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- See linked issue for what occurs, apply this patch and see that it is resolved afterwards

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
