### PR TITLE
[Spell] Prevent Orientation during s.34664 Sleep Visual - Flavor

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -373,6 +373,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (38858,'spell_queldanas_shoot'),
 (34800,'spell_getting_sleepy_aura'),
 (43364,'spell_getting_sleepy_aura'),
+(34664,'spell_sleep_visual_flavor'),
 (37156,'spell_tk_dive'),
 (41951,'spell_supremus_random_target'),
 (41925,'spell_hateful_strike_primer'),

--- a/src/game/AI/ScriptDevAI/scripts/world/spell_scripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/spell_scripts.cpp
@@ -946,6 +946,24 @@ struct BirthNoVisualInstantSpawn : public SpellScript
     }
 };
 
+struct SleepVisualFlavor : public AuraScript
+{
+    void OnApply(Aura* aura, bool apply) const override
+    {
+        Unit* target = aura->GetTarget();
+        if (apply)
+        {
+            target->addUnitState(UNIT_STAT_ROOT);
+            target->SetStandState(UNIT_STAND_STATE_SLEEP);
+        }
+        else
+        {
+            target->clearUnitState(UNIT_STAT_ROOT);
+            target->SetStandState(UNIT_STAND_STATE_STAND);
+        }
+    }
+};
+
 void AddSC_spell_scripts()
 {
     Script* pNewScript = new Script;
@@ -988,4 +1006,5 @@ void AddSC_spell_scripts()
     RegisterSpellScript<HateToZero>("spell_hate_to_zero");
     RegisterSpellScript<Stoned>("spell_stoned");
     RegisterSpellScript<BirthNoVisualInstantSpawn>("spell_birth_no_visual_instant_spawn");
+    RegisterSpellScript<SleepVisualFlavor>("spell_sleep_visual_flavor");
 }


### PR DESCRIPTION
Mob seemingly does not remove npcflags during this, emote played at the
end needs to be scripted with delay to get actually played - EMOTE_ONESHOT_CHEER_NOSHEATHE

Resolves https://github.com/cmangos/issues/issues/2837