### PR TITLE
Disable MANGOS_ASSERT when defining NDEBUG

### DIFF
--- a/src/game/AI/ScriptDevAI/system/ScriptLoader.cpp
+++ b/src/game/AI/ScriptDevAI/system/ScriptLoader.cpp
@@ -371,7 +371,7 @@ void AddScripts()
     AddSC_battleground();
 
     // custom
-
+MANGOS_ASSERT(false);
     // examples
     AddSC_example_creature();
     AddSC_example_escort();

--- a/src/game/AI/ScriptDevAI/system/ScriptLoader.cpp
+++ b/src/game/AI/ScriptDevAI/system/ScriptLoader.cpp
@@ -371,7 +371,7 @@ void AddScripts()
     AddSC_battleground();
 
     // custom
-MANGOS_ASSERT(false);
+
     // examples
     AddSC_example_creature();
     AddSC_example_escort();

--- a/src/shared/Errors.h
+++ b/src/shared/Errors.h
@@ -21,27 +21,23 @@
 
 #include "Common.h"
 
-#ifndef NDEBUG
 // Normal assert.
 #  define WPError(CONDITION) \
 if (!(CONDITION)) \
 { \
-    printf("%s:%i: Error: Assertion in %s failed: %s\n", \
-        __FILE__, __LINE__, __FUNCTION__, STRINGIZE(CONDITION)); \
-    fflush(stdout); \
     assert(STRINGIZE(CONDITION) && 0); \
+    std::abort(); \
 }
-#else
-#  define WPError(CONDITION)
-#endif
 
+#if false // Disable unused warning
 // Just warn.
-/*#define WPWarning(CONDITION) \
+#define WPWarning(CONDITION) \
 if (!(CONDITION)) \
 { \
     printf("%s:%i: Warning: Assertion in %s failed: %s",\
         __FILE__, __LINE__, __FUNCTION__, STRINGIZE(CONDITION)); \
-}*/
+}
+#endif
 
 #ifdef MANGOS_DEBUG
 #  define MANGOS_ASSERT WPError

--- a/src/shared/Errors.h
+++ b/src/shared/Errors.h
@@ -26,8 +26,9 @@
 #  define WPError(CONDITION) \
 if (!(CONDITION)) \
 { \
-    printf("%s:%i: Error: Assertion in %s failed: %s", \
+    printf("%s:%i: Error: Assertion in %s failed: %s\n", \
         __FILE__, __LINE__, __FUNCTION__, STRINGIZE(CONDITION)); \
+    fflush(stdout); \
     assert(STRINGIZE(CONDITION) && 0); \
 }
 #else
@@ -35,12 +36,12 @@ if (!(CONDITION)) \
 #endif
 
 // Just warn.
-#define WPWarning(CONDITION) \
+/*#define WPWarning(CONDITION) \
 if (!(CONDITION)) \
 { \
     printf("%s:%i: Warning: Assertion in %s failed: %s",\
         __FILE__, __LINE__, __FUNCTION__, STRINGIZE(CONDITION)); \
-}
+}*/
 
 #ifdef MANGOS_DEBUG
 #  define MANGOS_ASSERT WPError

--- a/src/shared/Errors.h
+++ b/src/shared/Errors.h
@@ -26,6 +26,9 @@
 if (!(CONDITION)) \
 { \
     assert(STRINGIZE(CONDITION) && 0); \
+    fprintf(stderr, "Critical Error: A condition which must never be false was found to be false. \
+Server was shut down to protect data integrity.\nIf this error is occurring frequently, please \
+recompile the software in debug mode to get more details.\n\n%s(): %s\n", __FUNCTION__, STRINGIZE(CONDITION)); \
     std::abort(); \
 }
 

--- a/src/shared/Errors.h
+++ b/src/shared/Errors.h
@@ -32,7 +32,6 @@ recompile the software in debug mode to get more details.\n\n%s(): %s\n", __FUNC
     std::abort(); \
 }
 
-#if false // Disable unused warning
 // Just warn.
 #define WPWarning(CONDITION) \
 if (!(CONDITION)) \
@@ -40,7 +39,6 @@ if (!(CONDITION)) \
     printf("%s:%i: Warning: Assertion in %s failed: %s",\
         __FILE__, __LINE__, __FUNCTION__, STRINGIZE(CONDITION)); \
 }
-#endif
 
 #ifdef MANGOS_DEBUG
 #  define MANGOS_ASSERT WPError

--- a/src/shared/Errors.h
+++ b/src/shared/Errors.h
@@ -21,14 +21,18 @@
 
 #include "Common.h"
 
+#ifndef NDEBUG
 // Normal assert.
-#define WPError(CONDITION) \
+#  define WPError(CONDITION) \
 if (!(CONDITION)) \
 { \
     printf("%s:%i: Error: Assertion in %s failed: %s", \
         __FILE__, __LINE__, __FUNCTION__, STRINGIZE(CONDITION)); \
     assert(STRINGIZE(CONDITION) && 0); \
 }
+#else
+#  define WPError(CONDITION)
+#endif
 
 // Just warn.
 #define WPWarning(CONDITION) \

--- a/src/shared/Errors.h
+++ b/src/shared/Errors.h
@@ -22,7 +22,7 @@
 #include "Common.h"
 
 // Normal assert.
-#  define WPError(CONDITION) \
+#define WPError(CONDITION) \
 if (!(CONDITION)) \
 { \
     assert(STRINGIZE(CONDITION) && 0); \


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR disables the MANGOS_ASSERT macro when a release build is selected and `NDEBUG` is defined.

Asserts are a debugging tool and have no place in release builds https://en.wikipedia.org/wiki/Assertion_(software_development)#Assertions_in_production_environment

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/1966

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- use `cmake .. -DCMAKE_BUILD_TYPE=Release -DNDEBUG` when building
