### PR TITLE
Prevent client crash when vendor wants to send too many items

### DIFF
--- a/src/game/Entities/ItemHandler.cpp
+++ b/src/game/Entities/ItemHandler.cpp
@@ -748,7 +748,7 @@ void WorldSession::SendListInventory(ObjectGuid vendorguid) const
 
     float discountMod = _player->GetReputationPriceDiscount(pCreature);
 
-    for (int i = 0; i < numitems && i < 150; ++i)
+    for (int i = 0; i < numitems && count < 150; ++i)
     {
         VendorItem const* crItem = i < customitems ? vItems->GetItem(i) : tItems->GetItem(i - customitems);
 

--- a/src/game/Entities/ItemHandler.cpp
+++ b/src/game/Entities/ItemHandler.cpp
@@ -748,7 +748,7 @@ void WorldSession::SendListInventory(ObjectGuid vendorguid) const
 
     float discountMod = _player->GetReputationPriceDiscount(pCreature);
 
-    for (int i = 0; i < numitems; ++i)
+    for (int i = 0; i < numitems && i < 150; ++i)
     {
         VendorItem const* crItem = i < customitems ? vItems->GetItem(i) : tItems->GetItem(i - customitems);
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR ensures that vendors can never send more than 150 items to the client. Sending more than 150 items to the client seems to cause out-of-bounds reads, crashing it entirely.