### PR TITLE
Update auras when applying temporary enchantments

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -11817,6 +11817,9 @@ void Player::ApplyEnchantment(Item* item, EnchantmentSlot slot, bool apply, bool
                         }
                         else
                             RemoveAurasDueToItemSpell(item, enchant_spell_id);
+
+                        if (SpellAuraHolder* holder = GetSpellAuraHolder(enchant_spell_id))
+                            holder->UpdateAuraDuration();
                     }
                     break;
                 }

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -5267,6 +5267,7 @@ void Spell::EffectEnchantItemTmp(SpellEffectIndex eff_idx)
 
     // add new enchanting if equipped
     item_owner->ApplyEnchantment(itemTarget, TEMP_ENCHANTMENT_SLOT, true);
+    item_owner->UpdateClientAuras();
 }
 
 void Spell::EffectTameCreature(SpellEffectIndex /*eff_idx*/)

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -5267,7 +5267,6 @@ void Spell::EffectEnchantItemTmp(SpellEffectIndex eff_idx)
 
     // add new enchanting if equipped
     item_owner->ApplyEnchantment(itemTarget, TEMP_ENCHANTMENT_SLOT, true);
-    item_owner->UpdateClientAuras();
 }
 
 void Spell::EffectTameCreature(SpellEffectIndex /*eff_idx*/)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR updates the status of all Auras for the client when a temporary enchantment occurs.
This will cause the `UNIT_AURA` API-Event to fire on the client, notifying all Addons that a change has taken place and that there are values that can be updated.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Cast `Windfury Weapon` repeatedly
- use `/etrace start`
- Cast `Windfury Weapon` repeatedly, again
- Notice that the `UNIT_AURA` API-Event fires.
