### PR TITLE
Fix crash when SaveRespawnTimeImmediately config option is set to 0

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -909,16 +909,18 @@ void Map::Remove(T* obj, bool remove)
 
     m_objRemoveList.insert(obj->GetObjectGuid());
 
-    obj->ResetMap();
     if (remove)
     {
         // if option set then object already saved at this moment
         if (!sWorld.getConfig(CONFIG_BOOL_SAVE_RESPAWN_TIME_IMMEDIATELY))
             obj->SaveRespawnTime();
 
+        obj->ResetMap();
         // Note: In case resurrectable corpse and pet its removed from global lists in own destructor
         delete obj;
     }
+    else
+        obj->ResetMap();
 }
 
 void Map::PlayerRelocation(Player* player, float x, float y, float z, float orientation)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes a crash that occurs when `SaveRespawnTimeImmediately` is set to 0

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Compile this PR
- Set `SaveRespawnTimeImmediately` to 0 in `mangosd.conf`
- Observe that it does no longer crash