### PR TITLE
Correct MMAPs for Laj .go c id 17980

### DIFF
--- a/contrib/extractor_scripts/config.json
+++ b/contrib/extractor_scripts/config.json
@@ -39,6 +39,11 @@
 		"mergeRegionArea": 10,
 		"borderSize": 5
 	},
+		"553": {
+			"_Info": "The Botanica - Laj .go c id 17980",
+			"walkableClimb": 9.0,
+			"walkableHeight": 10.0
+	},
         "554": {
                 "walkableSlopeAngle":60,
                 "minRegionArea": 30,


### PR DESCRIPTION
## 🍰 Pullrequest
Fix Pathing for Laj .go c id 17980 in Botanica

### Proof

If you Flip Start and End, Pathing is Broken.

![grafik](https://user-images.githubusercontent.com/19734826/174501448-3af29725-bf31-4c7d-9a4e-74c0f00aabfe.png)

Mob cant go down.

![grafik](https://user-images.githubusercontent.com/19734826/174501465-df64ae5e-49ba-4191-a634-b4eb0b6cdacc.png)
![grafik](https://user-images.githubusercontent.com/19734826/174501474-217ebfe3-960f-4345-a7eb-bb7b9b191854.png)

Should look more like this:

![grafik](https://user-images.githubusercontent.com/19734826/174501493-f92a11a4-abc9-489e-bc98-164b1200106a.png)

Example: https://youtu.be/ZKeK27EUd88
Example2: https://youtu.be/8Ie-omwqpKE

Based on https://youtu.be/uG_tcs82m30?t=59 as Evidence how Laj behaves around the Edges.

Edit: maybe try reducing it as much as possible, i just couldnt get any results at all without doing "stark" changes.
<https://github.com/cmangos/issues/wiki/MoveMapGen.exe> is my goto guide, which i've tryed to copypaste and implement most of <http://www.stevefsp.org/projects/rcndoc/prod/structrcConfig.html#a9b6bbabb4857e3f4bf4428af86ee7673> into.

Nothing else seems to have gotten worse by this change in the dungeon.

![grafik](https://user-images.githubusercontent.com/19734826/174501522-472288df-d3d1-4ff2-8652-856ebebef54e.png)
(3rd Boss Ramp)

### Issues
"laj in botanica is buggy. she wont move from her spot and evades if u try to pull down"

### How2Test
1. Rebuilt MMAPs with these config settings for map 553
2.  .go c id 17980
3. pull from range and see how the plant behaves