### PR TITLE
Port fix from wotlk for BG flag proc & move aura handling to spell script

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -867,6 +867,9 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 
 -- Battleground and Outdoor PvP
 INSERT INTO spell_scripts(Id, ScriptName) VALUES
+(23333,'spell_flag_aura_bg'),
+(23335,'spell_flag_aura_bg'),
+(34976,'spell_flag_aura_bg'),
 -- Arathi basin
 (23936,'spell_battleground_banner_trigger'),
 (23932,'spell_battleground_banner_trigger'),

--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -869,6 +869,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (23333,'spell_flag_aura_bg'),
 (23335,'spell_flag_aura_bg'),
+(29519,'spell_flag_aura_bg'),
 (34976,'spell_flag_aura_bg'),
 -- Arathi basin
 (23936,'spell_battleground_banner_trigger'),

--- a/src/game/AI/ScriptDevAI/scripts/battlegrounds/battlegrounds.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/battlegrounds/battlegrounds.cpp
@@ -130,6 +130,17 @@ struct InactiveBattleground : public SpellScript
     }
 };
 
+struct FlagAuraBg : public AuraScript
+{
+    SpellAuraProcResult OnProc(Aura* aura, ProcExecutionData& procData) const override
+    {
+        // procs on taken spell - if acquired immune flag, remove it - maybe other conditions too
+        if (procData.victim && procData.victim->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE))
+            aura->GetTarget()->RemoveSpellAuraHolder(aura->GetHolder());
+        return SPELL_AURA_PROC_OK;
+    }
+};
+
 struct ArenaPreparation : public AuraScript
 {
     void OnApply(Aura* aura, bool apply) const override
@@ -220,6 +231,7 @@ void AddSC_battleground()
     pNewScript->RegisterSelf();
 
     RegisterSpellScript<OpeningCapping>("spell_opening_capping");
+    RegisterSpellScript<FlagAuraBg>("spell_flag_aura_bg");
     RegisterSpellScript<InactiveBattleground>("spell_inactive");
     RegisterSpellScript<ArenaPreparation>("spell_arena_preparation");
     RegisterSpellScript<spell_battleground_banner_trigger>("spell_battleground_banner_trigger");

--- a/src/game/AI/ScriptDevAI/scripts/battlegrounds/battlegrounds.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/battlegrounds/battlegrounds.cpp
@@ -139,6 +139,27 @@ struct FlagAuraBg : public AuraScript
             aura->GetTarget()->RemoveSpellAuraHolder(aura->GetHolder());
         return SPELL_AURA_PROC_OK;
     }
+
+    void OnApply(Aura* aura, bool apply) const
+    {
+        Unit* unitTarget = aura->GetTarget();
+        if (!unitTarget || !unitTarget->IsPlayer())
+            return;
+
+        Player *player = static_cast<Player*>(unitTarget);
+
+        if (apply)
+            player->pvpInfo.isPvPFlagCarrier = true;
+        else
+        {
+            player->pvpInfo.isPvPFlagCarrier = false;
+
+            if (BattleGround* bg = player->GetBattleGround())
+                bg->HandlePlayerDroppedFlag(player);
+            else if (OutdoorPvP* outdoorPvP = sOutdoorPvPMgr.GetScript(player->GetCachedZoneId()))
+                outdoorPvP->HandleDropFlag(player, aura->GetSpellProto()->Id);
+        }
+    }
 };
 
 struct ArenaPreparation : public AuraScript

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -4761,24 +4761,6 @@ void Aura::HandleAuraModEffectImmunity(bool apply, bool /*Real*/)
 {
     Unit* target = GetTarget();
 
-    // when removing flag aura, handle flag drop
-    if (target->GetTypeId() == TYPEID_PLAYER && (GetSpellProto()->AuraInterruptFlags & AURA_INTERRUPT_FLAG_INVULNERABILITY_BUFF_CANCELS))
-    {
-        Player* player = static_cast<Player*>(target);
-
-        if (apply)
-            player->pvpInfo.isPvPFlagCarrier = true;
-        else
-        {
-            player->pvpInfo.isPvPFlagCarrier = false;
-
-            if (BattleGround* bg = player->GetBattleGround())
-                bg->HandlePlayerDroppedFlag(player);
-            else if (OutdoorPvP* outdoorPvP = sOutdoorPvPMgr.GetScript(player->GetCachedZoneId()))
-                outdoorPvP->HandleDropFlag(player, GetSpellProto()->Id);
-        }
-    }
-
     target->ApplySpellImmune(this, IMMUNITY_EFFECT, m_modifier.m_miscvalue, apply);
 
     if (apply && IsPositive())


### PR DESCRIPTION
## 🍰 Pullrequest
Ports wotlk commit: https://github.com/cmangos/mangos-wotlk/commit/d781711a667d39a46630b6d793e0543b41b0c79c

And includes fix for https://github.com/cmangos/issues/issues/3026 where flags were not properly remove from players if the buff was lost due to that block of code not running. Instead, logic is moved into the new spell script.

Also includes case for Silithus outdoor PvP spell.

Relies on tbc-db PR: https://github.com/cmangos/tbc-db/pull/1087

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3026

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
