### PR TITLE
Prevent lost items from being returnable

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -15842,7 +15842,7 @@ void Player::_LoadInventory(QueryResult* result, uint32 timediff)
                 draft.AddItem(item);
             }
 
-            draft.SendMailTo(this, MailSender(this, MAIL_STATIONERY_GM), MAIL_CHECK_MASK_COPIED);
+            draft.SendMailTo(this, MailSender(this, MAIL_STATIONERY_GM), MAIL_CHECK_MASK_RETURNED);
         }
     }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Items that fail to equip on log in are sent through the mail with the Blizz stationary. These items have the "Return" button available which, if accidentally pressed, sends the items off into the void. Since there is no real "sender" set the mail as already returned so that the option is "Delete" instead of "Return".

![Screenshot at Jun 26 16-58-30](https://user-images.githubusercontent.com/30731/175820583-55d7a17d-5819-4cfe-b79c-61548f0fc3ab.png)


### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
