### PR TITLE
Add Apple Silicon support in g3dlib dependency

### DIFF
--- a/dep/g3dlite/FileSystem.cpp
+++ b/dep/g3dlite/FileSystem.cpp
@@ -43,6 +43,13 @@
 #   define _stat stat
 #endif
 
+#if defined __aarch64__ && defined __APPLE__
+#    if defined stat64
+#        undef stat64
+#    endif
+#    define stat64 stat
+#endif
+
 namespace G3D {
 
 static FileSystem* common = NULL;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR adds Apple Silicon support to the g3dlite dependency.

### How2Test
- Buy a $5000 Apple M1 MacBook Pro
- Compile CMaNGOS natively