### PR TITLE
Further simplify item set effect management and fix crash.

### DIFF
--- a/src/game/Entities/Item.cpp
+++ b/src/game/Entities/Item.cpp
@@ -45,13 +45,7 @@ void AddItemsSetItem(Player* player, Item* item)
     ItemSetEffect* eff = player->GetItemSetEffect(setid);
 
     if (!eff)
-    {
-        eff = new ItemSetEffect;
-        memset(eff, 0, sizeof(ItemSetEffect));
-        eff->setid = setid;
-
-        player->SetItemSetEffect(setid, eff);
-    }
+        eff = player->AddItemSetEffect(setid);
 
     ++eff->item_count;
 
@@ -134,10 +128,7 @@ void RemoveItemsSetItem(Player* player, ItemPrototype const* proto)
     }
 
     if (!eff->item_count)                                   // all items of a set were removed
-    {
-        delete eff;
-        player->SetItemSetEffect(setid, nullptr);
-    }
+        player->RemoveItemSetEffect(setid);
 }
 
 bool ItemCanGoIntoBag(ItemPrototype const* pProto, ItemPrototype const* pBagProto)

--- a/src/game/Entities/Item.h
+++ b/src/game/Entities/Item.h
@@ -33,9 +33,8 @@ struct SpellModifier;
 
 struct ItemSetEffect
 {
-    uint32 setid;
-    uint32 item_count;
-    SpellEntry const* spells[8];
+    uint32 item_count = 0;
+    SpellEntry const* spells[8] = {};
 };
 
 enum InventoryResult

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -681,9 +681,6 @@ Player::~Player()
         m_transport->RemovePassenger(this);
     }
 
-    for (auto& x : m_itemSetEffects)
-        delete x.second;
-
     // clean up player-instance binds, may unload some instance saves
     for (auto& m_boundInstance : m_boundInstances)
         for (BoundInstancesMap::iterator itr = m_boundInstance.begin(); itr != m_boundInstance.end(); ++itr)
@@ -6362,8 +6359,7 @@ void Player::CheckAreaExploreAndOutdoor()
         }
         for (auto& setData : m_itemSetEffects)
         {
-            ItemSetEffect* itemSet = setData.second;
-            for (auto spellInfo : itemSet->spells)
+            for (auto spellInfo : setData.second.spells)
             {
                 if (!spellInfo || !IsNeedCastSpellAtOutdoor(spellInfo) || HasAura(spellInfo->Id))
                     continue;
@@ -7592,11 +7588,7 @@ void Player::UpdateEquipSpellsAtFormChange()
     // item set bonuses not dependent from item broken state
     for (auto& setData : m_itemSetEffects)
     {
-        ItemSetEffect* eff = setData.second;
-        if (!eff)
-            continue;
-
-        for (auto spellInfo : eff->spells)
+        for (auto spellInfo : setData.second.spells)
         {
             if (!spellInfo)
                 continue;
@@ -19823,23 +19815,23 @@ void Player::SendAuraDurationsOnLogin(bool visible)
     }
 }
 
-ItemSetEffect* Player::GetItemSetEffect(uint32 setId) const
+ItemSetEffect* Player::GetItemSetEffect(uint32 setId)
 {
     auto itr = m_itemSetEffects.find(setId);
     if (itr == m_itemSetEffects.end())
         return nullptr;
 
-    return itr->second;
+    return &itr->second;
 }
 
-void Player::SetItemSetEffect(uint32 setId, ItemSetEffect* itemSetEffect)
+ItemSetEffect* Player::AddItemSetEffect(uint32 setId)
 {
-    if (itemSetEffect == nullptr)
-    {
-        m_itemSetEffects.erase(setId);
-    }
+    return &m_itemSetEffects.insert({ setId, ItemSetEffect() }).first->second;
+}
 
-    m_itemSetEffects[setId] = itemSetEffect;
+void Player::RemoveItemSetEffect(uint32 setId)
+{
+    m_itemSetEffects.erase(setId);
 }
 
 void Player::SetDailyQuestStatus(uint32 quest_id)

--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -1942,8 +1942,9 @@ class Player : public Unit
 
         PlayerMenu* GetPlayerMenu() const { return m_playerMenu.get(); }
 
-        ItemSetEffect* GetItemSetEffect(uint32 setId) const;
-        void SetItemSetEffect(uint32 setId, ItemSetEffect* itemSetEffect);
+        ItemSetEffect* GetItemSetEffect(uint32 setId);
+        ItemSetEffect* AddItemSetEffect(uint32 setId);
+        void RemoveItemSetEffect(uint32 setId);
 
         /*********************************************************/
         /***               BATTLEGROUND SYSTEM                 ***/
@@ -2633,7 +2634,7 @@ class Player : public Unit
 
         uint8 m_fishingSteps;
 
-        std::map<uint32, ItemSetEffect*> m_itemSetEffects;
+        std::map<uint32, ItemSetEffect> m_itemSetEffects;
 };
 
 void AddItemsSetItem(Player* player, Item* item);


### PR DESCRIPTION
## 🍰 Pullrequest
- Fixes crash on unequipping item set because of nullptr that gets inserted into the map.
- Removes not needed manual memory management with new/delete now that we are using std::map.
- Replaces C style memset initialization of ItemSetEffect structure with modern C++ approach.
- Removes no longer needed setid member of the ItemSetEffect structure.
