### PR TITLE
Fix crash in mute command

### DIFF
--- a/src/game/Chat/Level2.cpp
+++ b/src/game/Chat/Level2.cpp
@@ -76,8 +76,8 @@ bool ChatHandler::HandleMuteCommand(char* args)
     if (!ExtractPlayerTarget(&nameStr, &target, &target_guid, &target_name))
         return false;
 
-    uint32 notspeaktime;
-    if (!ExtractUInt32(&args, notspeaktime))
+    uint32 mutedMinutes;
+    if (!ExtractUInt32(&args, mutedMinutes))
         return false;
 
     std::string givenReason;
@@ -97,7 +97,7 @@ bool ChatHandler::HandleMuteCommand(char* args)
     if (HasLowerSecurity(target, target_guid, true))
         return false;
 
-    time_t mutetime = time(nullptr) + notspeaktime * 60;
+    time_t mutetime = time(nullptr) + mutedMinutes * 60;
 
     if (target)
         target->GetSession()->m_muteTime = mutetime;
@@ -105,19 +105,22 @@ bool ChatHandler::HandleMuteCommand(char* args)
     LoginDatabase.PExecute("UPDATE account SET mutetime = " UI64FMTD " WHERE id = '%u'", uint64(mutetime), account_id);
 
     if (target)
-        ChatHandler(target).PSendSysMessage(LANG_YOUR_CHAT_DISABLED, notspeaktime);
+        ChatHandler(target).PSendSysMessage(LANG_YOUR_CHAT_DISABLED, mutedMinutes);
 
     std::string nameLink = playerLink(target_name);
 
-    PSendSysMessage(LANG_YOU_DISABLE_CHAT, nameLink.c_str(), notspeaktime);
+    PSendSysMessage(LANG_YOU_DISABLE_CHAT, nameLink.c_str(), mutedMinutes);
 
     // Add warning to the account
     std::string authorName = m_session ? m_session->GetPlayerName() : "Console";
     std::stringstream reason;
-    reason << target->GetName() << " muted " << notspeaktime << " minutes";
-    if (givenReason != "")
+    reason << (target ? target->GetName() : target_name) << " muted " << mutedMinutes << " minutes";
+
+    if (!givenReason.empty())
         reason << " for \"" << givenReason << "\"";
+
     sWorld.WarnAccount(account_id, authorName, reason.str(), "WARNING");
+
     return true;
 }
 


### PR DESCRIPTION
Fixes crash due to `target` being nullptr when the player is offline. Also cleans up some code and bad variable naming.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
