### PR TITLE
Add SPAWN_GROUP_FORMATION_OPTION_DONT_FOLLOW_LEADER

### DIFF
--- a/src/game/Maps/SpawnGroup.cpp
+++ b/src/game/Maps/SpawnGroup.cpp
@@ -1258,6 +1258,9 @@ void FormationData::FixSlotsPositions()
         ++totalMembers;
     }
 
+    if (HaveOption(SPAWN_GROUP_FORMATION_OPTION_DONT_FOLLOW_LEADER))
+        return; 
+
     if (totalMembers <= 1)
         return;
 

--- a/src/game/Maps/SpawnGroupDefines.h
+++ b/src/game/Maps/SpawnGroupDefines.h
@@ -121,7 +121,6 @@ enum SpawnGroupFormationType : uint32
     SPAWN_GROUP_FORMATION_TYPE_FANNED_OUT_BEHIND   = 4,
     SPAWN_GROUP_FORMATION_TYPE_FANNED_OUT_IN_FRONT = 5,
     SPAWN_GROUP_FORMATION_TYPE_CIRCLE_THE_LEADER   = 6,
-
     SPAWN_GROUP_FORMATION_TYPE_COUNT               = 7
 };
 
@@ -137,6 +136,7 @@ enum SpawGroupFormationOptions : uint32
     SPAWN_GROUP_FORMATION_OPTION_NONE                                       = 0x00,
     SPAWN_GROUP_FORMATION_OPTION_FOLLOWERS_WILL_NOT_PATHFIND_TO_LOCATION    = 0x01, // NYI - need examples where used vs normal
     SPAWN_GROUP_FORMATION_OPTION_KEEP_CONPACT                               = 0x02,
+    SPAWN_GROUP_FORMATION_OPTION_DONT_FOLLOW_LEADER                         = 0x04,
 };
 
 struct FormationEntry


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This adds an simple formation option to spawn_groups preventing groups getting in SpawnGroupFormationType.

### Proof
<!-- Link resources as proof -->
![179057202-3431c521-cbda-4484-8e06-31c96631704c](https://user-images.githubusercontent.com/6261245/179090337-52a4f096-3465-465f-8c32-b0a64b5cb1ff.jpg)


https://youtu.be/l_bPZ-7Fkms?t=472

This group for example stands like this after respawning, before they start moving as SPAWN_GROUP_FORMATION_TYPE_SINGLE_FILE.

We can then use dbscript SCRIPT_COMMAND_SPAWN_GROUP (51) to change formation options before they start moving.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
