### PR TITLE
[Command] Remove extra dbguid readout from .npc info command

### DIFF
--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -3746,7 +3746,6 @@ bool ChatHandler::HandleNpcInfoCommand(char* /*args*/)
     else
         PSendSysMessage(LANG_NPCINFO_CHAR, target->GetGuidStr().c_str(), faction, npcflags, Entry, displayid, nativeid);
 
-    PSendSysMessage("DbGuid: %u", target->GetDbGuid());
     PSendSysMessage(LANG_NPCINFO_LEVEL, target->GetLevel());
     PSendSysMessage(LANG_NPCINFO_HEALTH, target->GetCreateHealth(), target->GetMaxHealth(), target->GetHealth());
     PSendSysMessage(LANG_NPCINFO_FLAGS, target->GetUInt32Value(UNIT_FIELD_FLAGS), target->GetUInt32Value(UNIT_DYNAMIC_FLAGS), target->GetCreatureInfo()->ExtraFlags);


### PR DESCRIPTION
### Proof
![grafik](https://user-images.githubusercontent.com/19734826/180425720-67e2a095-980c-4dd1-ab89-3379b3aa3108.png)

![grafik](https://user-images.githubusercontent.com/19734826/180425792-a1acfc08-aaee-498b-9af6-9f4343be73d4.png)

### Issues
More rows then needed.