### PR TITLE
[Spell] Shadow Word: Death - workaround for absorb backfire

### DIFF
--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Priest.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Priest.cpp
@@ -19,7 +19,6 @@
 #include "Spells/Scripts/SpellScript.h"
 #include "Spells/SpellAuras.h"
 #include "Spells/SpellMgr.h"
-#include<iostream>
 
 struct SpiritOfRedemptionHeal : public SpellScript
 {

--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Priest.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Priest.cpp
@@ -19,6 +19,7 @@
 #include "Spells/Scripts/SpellScript.h"
 #include "Spells/SpellAuras.h"
 #include "Spells/SpellMgr.h"
+#include<iostream>
 
 struct SpiritOfRedemptionHeal : public SpellScript
 {
@@ -86,7 +87,7 @@ struct ShadowWordDeath : public SpellScript
 {
     void OnHit(Spell* spell, SpellMissInfo /*missInfo*/) const override
     {
-        int32 swdDamage = spell->GetTotalTargetDamage();
+        int32 swdDamage = spell->GetTargetDamageBeforeAbsorb();
         spell->GetCaster()->CastCustomSpell(nullptr, 32409, &swdDamage, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED);
     }
 };

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -1267,13 +1267,13 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
                 if (m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL)
                     spellDamageInfo.damage = Unit::CalcArmorReducedDamage(affectiveCaster ? affectiveCaster : m_trueCaster, unitTarget, spellDamageInfo.damage);
             }
-        }
-
-        m_damgeBeforeAbsorb = spellDamageInfo.damage;
+        }              
 
         unitTarget->CalculateAbsorbResistBlock(affectiveCaster, &spellDamageInfo, m_spellInfo);
 
         Unit::DealDamageMods(affectiveCaster, spellDamageInfo.target, spellDamageInfo.damage, &spellDamageInfo.absorb, SPELL_DIRECT_DAMAGE, m_spellInfo);
+
+        m_damgeBeforeAbsorb = spellDamageInfo.damage + spellDamageInfo.absorb;
 
         m_damage = spellDamageInfo.damage; // update value so that script handler has access
         OnHit(missInfo); // TODO: After spell damage calc is moved to proper handler - move this before the first if

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -1269,6 +1269,8 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
             }
         }
 
+        m_damgeBeforeAbsorb = spellDamageInfo.damage;
+
         unitTarget->CalculateAbsorbResistBlock(affectiveCaster, &spellDamageInfo, m_spellInfo);
 
         Unit::DealDamageMods(affectiveCaster, spellDamageInfo.target, spellDamageInfo.damage, &spellDamageInfo.absorb, SPELL_DIRECT_DAMAGE, m_spellInfo);

--- a/src/game/Spells/Spell.h
+++ b/src/game/Spells/Spell.h
@@ -724,6 +724,7 @@ class Spell
         SpellSchoolMask GetSchoolMask() { return m_spellSchoolMask; }
         // OnHit use only
         uint32 GetTotalTargetDamage() { return m_damage; }
+        uint32 GetTargetDamageBeforeAbsorb() { return m_damgeBeforeAbsorb; }
         void SetTotalTargetValueModifier(float modifier);
         // script initialization hook only setters - use only if dynamic - else use appropriate helper
         void SetMaxAffectedTargets(uint32 newValue) { m_affectedTargetCount = newValue; }
@@ -806,6 +807,7 @@ class Spell
 
         // Damage and healing in effects need just calculate
         int32 m_damage;                                     // Damage in effects count here
+        int32 m_damgeBeforeAbsorb;                          // Work around
         int32 damagePerEffect[MAX_EFFECT_INDEX];            // Workaround for multiple weapon damage effects
         int32 m_damagePerEffect[MAX_EFFECT_INDEX];
         int32 m_healing;                                    // Healing in effects count here

--- a/src/game/Spells/Spell.h
+++ b/src/game/Spells/Spell.h
@@ -724,7 +724,7 @@ class Spell
         SpellSchoolMask GetSchoolMask() { return m_spellSchoolMask; }
         // OnHit use only
         uint32 GetTotalTargetDamage() { return m_damage; }
-        uint32 GetTargetDamageBeforeAbsorb() { return m_damgeBeforeAbsorb; }
+        uint32 GetTargetDamageBeforeAbsorb() { return m_damgeWithAbsorb; }
         void SetTotalTargetValueModifier(float modifier);
         // script initialization hook only setters - use only if dynamic - else use appropriate helper
         void SetMaxAffectedTargets(uint32 newValue) { m_affectedTargetCount = newValue; }
@@ -807,7 +807,7 @@ class Spell
 
         // Damage and healing in effects need just calculate
         int32 m_damage;                                     // Damage in effects count here
-        int32 m_damgeBeforeAbsorb;                          // Work around
+        int32 m_damgeWithAbsorb;                          // Work around
         int32 damagePerEffect[MAX_EFFECT_INDEX];            // Workaround for multiple weapon damage effects
         int32 m_damagePerEffect[MAX_EFFECT_INDEX];
         int32 m_healing;                                    // Healing in effects count here


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This adds a workaround for Shadow Word: Death backfire damage, when target damage gets fully absorbed.

![Wow_G4zYHDf8Ka](https://user-images.githubusercontent.com/6261245/187426059-ad78ee2d-9268-4b29-995d-1549de3732a6.png)

### Proof
<!-- Link resources as proof -->
[- None](https://youtu.be/PVRZKW4jwQo?t=330)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
https://github.com/cmangos/issues/issues/3119
### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
Let 2 priests duel 1 with shield 1 uses sw:d, see result.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
