### PR TITLE
[Spell]Curse of Tongues now has a 12 second duration when used on PvP Targets.

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -642,7 +642,9 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (19734,'spell_devour_magic'),
 (19736,'spell_devour_magic'),
 (27276,'spell_devour_magic'),
-(27277,'spell_devour_magic');
+(27277,'spell_devour_magic'),
+(1714,'spell_curse_of_tongues'),
+(11719,'spell_curse_of_tongues');
 
 -- Pet Scaling
 INSERT INTO spell_scripts(Id, ScriptName) VALUES

--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Warlock.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Warlock.cpp
@@ -321,6 +321,28 @@ struct SoulLeech : public AuraScript
     }
 };
 
+// Curse of Tongues 
+// Spell IDs: 1714 (Rank 1), 11719 (Rank 2)
+// Patch 2.1 - "... now has a 12 second duration when used on PvP targets."
+struct CurseOfTongues : public SpellScript, public AuraScript
+{
+    void OnApply(Aura* aura, bool apply) const override
+    {
+        uint32 auraId = aura->GetId();
+        if (Unit* target = aura->GetTarget())
+        {
+            if (target->IsPlayer())
+            {
+                if (SpellAuraHolder* holder = target->GetSpellAuraHolder(auraId))
+                {
+                    holder->SetAuraDuration(12000);
+                    holder->UpdateAuraDuration();
+                }
+            }
+        }
+    }
+};
+
 void LoadWarlockScripts()
 {
     RegisterSpellScript<UnstableAffliction>("spell_unstable_affliction");
@@ -338,4 +360,5 @@ void LoadWarlockScripts()
     RegisterSpellScript<SeedOfCorruptionDamage>("spell_seed_of_corruption_damage");
     RegisterSpellScript<CurseOfDoom>("spell_curse_of_doom");
     RegisterSpellScript<CurseOfDoomEffect>("spell_curse_of_doom_effect");
+    RegisterSpellScript<CurseOfTongues>("spell_curse_of_tongues");
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Adds 12 seconds duration to Curse of Tongues when used on Players.

### Proof
<!-- Link resources as proof -->
[Patch 2.1:  ](https://wowwiki-archive.fandom.com/wiki/Patch_2.1.0#Warlocks)

> Curse of Tongues now has a 12 second duration when used on PvP targets.

https://wowwiki-archive.fandom.com/wiki/Curse_of_Tongues?oldid=1428403
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

