### PR TITLE
Remove GM aura if not GM on log in

### DIFF
--- a/src/game/Entities/CharacterHandler.cpp
+++ b/src/game/Entities/CharacterHandler.cpp
@@ -830,6 +830,8 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
         if (invisibleAuraInfo && IsSpellAppliesAura(invisibleAuraInfo))
             pCurrChar->CastSpell(pCurrChar, invisibleAuraInfo, TRIGGERED_OLD_TRIGGERED);
     }
+    else if (pCurrChar->HasAura(sWorld.getConfig(CONFIG_UINT32_GM_INVISIBLE_AURA)))
+        pCurrChar->RemoveAurasDueToSpell(sWorld.getConfig(CONFIG_UINT32_GM_INVISIBLE_AURA));
 
     std::string IP_str = GetRemoteAddress();
     sLog.outChar("Account: %d (IP: %s) Login Character:[%s] (guid: %u)",

--- a/src/game/Entities/CharacterHandler.cpp
+++ b/src/game/Entities/CharacterHandler.cpp
@@ -830,8 +830,6 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
         if (invisibleAuraInfo && IsSpellAppliesAura(invisibleAuraInfo))
             pCurrChar->CastSpell(pCurrChar, invisibleAuraInfo, TRIGGERED_OLD_TRIGGERED);
     }
-    else if (pCurrChar->HasAura(sWorld.getConfig(CONFIG_UINT32_GM_INVISIBLE_AURA)))
-        pCurrChar->RemoveAurasDueToSpell(sWorld.getConfig(CONFIG_UINT32_GM_INVISIBLE_AURA));
 
     std::string IP_str = GetRemoteAddress();
     sLog.outChar("Account: %d (IP: %s) Login Character:[%s] (guid: %u)",

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -8635,6 +8635,7 @@ bool SpellAuraHolder::IsSaveToDbHolder() const
             case 33377: // blessing of auchindoun
             case 33779: // twin spire blessing
             case 33795: // halaani strength
+            case 37800: // 50% Transparency (GM aura)
             case 39911: // nazgrels command
             case 39913: // trollbanes command
             case 39953: // adals song of battle


### PR DESCRIPTION
## 🍰 Pullrequest
Discovered an issue where if a player is no longer a GM and logs in, they will have the permanent transparency debuff. This checks, on log in, if they're supposed to still have it or not.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Log in as GM, get transparency debuff
- Logout and remove GM access
- Log in again, and notice you still have the debuff

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
