### PR TITLE
Fix Devour Magic self cast on debuffs

### DIFF
--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Warlock.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Warlock.cpp
@@ -244,7 +244,7 @@ struct DevourMagic : public SpellScript
             for (auto itr : auras)
             {
                 SpellEntry const* spell = itr.second->GetSpellProto();
-                if (itr.second->GetTarget()->GetObjectGuid() != caster->GetObjectGuid() && spell->Dispel == DISPEL_MAGIC && caster->IsFriend(target) ? !IsPositiveSpell(spell) : IsPositiveSpell(spell) && !IsPassiveSpell(spell))
+                if (itr.second->GetTarget()->GetObjectGuid() != caster->GetObjectGuid() && spell->Dispel == DISPEL_MAGIC && caster->CanAssist(target) ? !IsPositiveSpell(spell) : IsPositiveSpell(spell) && !IsPassiveSpell(spell))
                     return SPELL_CAST_OK;
             }
         }

--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Warlock.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Warlock.cpp
@@ -244,7 +244,7 @@ struct DevourMagic : public SpellScript
             for (auto itr : auras)
             {
                 SpellEntry const* spell = itr.second->GetSpellProto();
-                if (itr.second->GetTarget()->GetObjectGuid() != caster->GetObjectGuid() && spell->Dispel == DISPEL_MAGIC && IsPositiveSpell(spell) && !IsPassiveSpell(spell))
+                if (itr.second->GetTarget()->GetObjectGuid() != caster->GetObjectGuid() && spell->Dispel == DISPEL_MAGIC && caster->IsFriend(target) ? !IsPositiveSpell(spell) : IsPositiveSpell(spell) && !IsPassiveSpell(spell))
                     return SPELL_CAST_OK;
             }
         }


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes https://github.com/cmangos/issues/issues/3064.

tl;dr: Devour Magic not possible to self-cast or on friendly ally, but is supposed to be. Check was wrong.

### Proof
<!-- Link resources as proof -->
- See [spell tooltip](https://tbc.wowhead.com/spell=27277/devour-magic)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [3064](https://github.com/cmangos/issues/issues/3064)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Reproduction steps in issue linked above.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
