### PR TITLE
Add GameobjectCallForHelpOnUsage spell_script

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -152,7 +152,39 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (30132,'spell_sapphiron_iceblock'),
 (28091,'spell_despawner_self'),
 (28345,'spell_communique_trigger'),
-(31315,'spell_summon_boss');
+(31315,'spell_summon_boss'),
+(491,'spell_gameobject_call_for_help_on_usage'), -- Khadgar's Unlocking
+(857,'spell_gameobject_call_for_help_on_usage'), -- Khadgar's Unlocking
+(1804,'spell_gameobject_call_for_help_on_usage'), -- Pick Lock
+(2366,'spell_gameobject_call_for_help_on_usage'), -- Herb Gathering
+(2368,'spell_gameobject_call_for_help_on_usage'), -- Herb Gathering
+(2369,'spell_gameobject_call_for_help_on_usage'), -- Herb Gathering
+(2371,'spell_gameobject_call_for_help_on_usage'), -- Herb Gathering
+(2575,'spell_gameobject_call_for_help_on_usage'), -- Mining
+(2576,'spell_gameobject_call_for_help_on_usage'), -- Mining
+(3365,'spell_gameobject_call_for_help_on_usage'), -- Opening (Standard)
+(3564,'spell_gameobject_call_for_help_on_usage'), -- Mining
+(3570,'spell_gameobject_call_for_help_on_usage'), -- Herb Gathering
+(4056,'spell_gameobject_call_for_help_on_usage'), -- Small Seaforium Charge
+(4075,'spell_gameobject_call_for_help_on_usage'), -- Large Seaforium Charge
+(6247,'spell_gameobject_call_for_help_on_usage'), -- Opening
+-- (6461,'spell_gameobject_call_for_help_on_usage'), -- Pick Lock (classic)
+-- (6463,'spell_gameobject_call_for_help_on_usage'), -- Pick Lock (classic)
+(6477,'spell_gameobject_call_for_help_on_usage'), -- Opening
+(6478,'spell_gameobject_call_for_help_on_usage'), -- Opening
+(8917,'spell_gameobject_call_for_help_on_usage'), -- Opening
+(10165,'spell_gameobject_call_for_help_on_usage'), -- Khadgar's Unlocking
+(10166,'spell_gameobject_call_for_help_on_usage'), -- Khadgar's Unlocking
+(10248,'spell_gameobject_call_for_help_on_usage'), -- Mining
+(11993,'spell_gameobject_call_for_help_on_usage'), -- Herb Gathering
+(19646,'spell_gameobject_call_for_help_on_usage'), -- Silver Skeleton Key
+(19649,'spell_gameobject_call_for_help_on_usage'), -- Golden Skeleton Key
+(19651,'spell_gameobject_call_for_help_on_usage'), -- Truesilver Skeleton Key
+(19657,'spell_gameobject_call_for_help_on_usage'), -- Arcanite Skeleton Key
+(20709,'spell_gameobject_call_for_help_on_usage'), -- Arcanite Skeleton Key
+(22810,'spell_gameobject_call_for_help_on_usage'), -- Opening - No Text
+(23008,'spell_gameobject_call_for_help_on_usage'), -- Powerful Seaforium Charge
+(26868,'spell_gameobject_call_for_help_on_usage'); -- Opening
 
 -- TBC
 INSERT INTO spell_scripts(Id, ScriptName) VALUES
@@ -549,7 +581,10 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (49858,'spell_make_bunny_summon_mole_machine'),
 (47514,'spell_summon_mole_machine'),
 (46649,'spell_maximize_pet_loyalty_and_happiness'),
-(42919,'spell_tricky_treat');
+(42919,'spell_tricky_treat'),
+(28695,'spell_gameobject_call_for_help_on_usage'), -- Herb Gathering (Master)
+(29354,'spell_gameobject_call_for_help_on_usage'), -- Mining (Master)
+(30434,'spell_gameobject_call_for_help_on_usage'); -- Elemental Seaforium Charge
 
 -- Wotlk
 

--- a/src/game/AI/ScriptDevAI/scripts/world/spell_scripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/spell_scripts.cpp
@@ -38,9 +38,10 @@ EndContentData */
 
 #include "AI/ScriptDevAI/include/sc_common.h"
 #include "Spells/Scripts/SpellScript.h"
+#include "Grids/Cell.h"
+#include "Grids/CellImpl.h"
 #include "Grids/GridNotifiers.h"
 #include "Grids/GridNotifiersImpl.h"
-#include "Grids/CellImpl.h"
 
 /* When you make a spell effect:
 - always check spell id and effect index
@@ -1007,6 +1008,20 @@ struct MaximizePetLoyalty : public SpellScript
     }
 };
 
+struct GameobjectCallForHelpOnUsage : public SpellScript
+{
+    void OnSuccessfulStart(Spell* spell) const
+    {
+        UnitList targets;
+        MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck check(spell->GetCaster(), 12.f);
+        MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(targets, check);
+        Cell::VisitAllObjects(spell->GetCaster(), searcher, 12.f);
+        for (Unit* attacker : targets)
+            if (attacker->AI())
+                attacker->AI()->AttackStart(spell->GetCaster());
+    }
+};
+
 void AddSC_spell_scripts()
 {
     Script* pNewScript = new Script;
@@ -1053,4 +1068,5 @@ void AddSC_spell_scripts()
     RegisterSpellScript<SleepVisualFlavor>("spell_sleep_visual_flavor");
     RegisterSpellScript<CallOfTheFalcon>("spell_call_of_the_falcon");
     RegisterSpellScript<MaximizePetLoyalty>("spell_maximize_pet_loyalty_and_happiness");
+    RegisterSpellScript<GameobjectCallForHelpOnUsage>("spell_gameobject_call_for_help_on_usage");
 }

--- a/src/game/Entities/GameObject.cpp
+++ b/src/game/Entities/GameObject.cpp
@@ -1472,14 +1472,6 @@ void GameObject::Use(Unit* user, SpellEntry const* spellInfo)
             if (!GetGOInfo()->chest.lockId)
                 SetLootState(GO_JUST_DEACTIVATED);
 
-            UnitList targets;
-            MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck check(user, 5.f);
-            MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(targets, check);
-            Cell::VisitAllObjects(this, searcher, 5.f);
-            for (Unit* attacker : targets)
-                if (attacker->IsCreature() && !static_cast<Creature*>(attacker)->IsCritter() && attacker->AI())
-                    attacker->AI()->AttackStart(user);
-
             return;
         }
         case GAMEOBJECT_TYPE_GENERIC:                       // 5


### PR DESCRIPTION
https://youtu.be/GuTdSBVzWTM?t=1320 - shows a possible min and max radius, which were used to get the radius value thx @ cloudbells

Used for Chests, Ore Nodes, Herbs and more triggered by player trying to use the gameobject in proximity of unfriendly npcs

Followup to

https://github.com/cmangos/mangos-tbc/commit/340c1ee23122a22bd297eb149b4ba4fed5ba1e96
https://github.com/cmangos/mangos-tbc/commit/cbc945f0e1c8b94a0119f4df2cd23d82fb88e483
https://github.com/cmangos/mangos-tbc/commit/e3f1b605c39506ba97500b9322a6b66fa63eb717

### Proof
https://youtu.be/GuTdSBVzWTM?t=1320

### Issues
current implementation does not work

### How2Test
.go o 300022 open chest if spawned
.go any herb/ore in proximity of hostile mobs and use it

