### PR TITLE
[SD] Sunken Temple: Remove UNIT_FLAG_IMMUNE_TO_PLAYER from Jammalan & Ogom when Atalai Defenders (5712-5717) are defeated

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/searing_gorge.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/searing_gorge.cpp
@@ -47,7 +47,11 @@ struct npc_dorius_stonetenderAI : public npc_escortAI
 {
     npc_dorius_stonetenderAI(Creature* pCreature) : npc_escortAI(pCreature) { Reset(); }
 
-    void Reset() override { }
+    void Reset() override
+    {
+        if (!HasEscortState(STATE_ESCORT_ESCORTING))
+            m_creature->SetStandState(UNIT_STAND_STATE_DEAD);
+    }
 
     void Aggro(Unit* pWho) override
     {

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/sunken_temple/sunken_temple.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/sunken_temple/sunken_temple.cpp
@@ -87,6 +87,11 @@ void instance_sunken_temple::OnCreatureCreate(Creature* pCreature)
             ++m_uiProtectorsRemaining;
             break;
         case NPC_JAMMALAN:
+        case NPC_OGOM:
+            if (GetData(TYPE_PROTECTORS) == DONE)
+                pCreature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
+            m_npcEntryGuidStore[pCreature->GetEntry()] = pCreature->GetObjectGuid();
+            break;
         case NPC_ATALARION:
             m_npcEntryGuidStore[pCreature->GetEntry()] = pCreature->GetObjectGuid();
             break;
@@ -110,7 +115,9 @@ void instance_sunken_temple::OnCreatureEvade(Creature* pCreature)
         case NPC_AVATAR_OF_HAKKAR:
             SetData(TYPE_AVATAR, FAIL);
             break;
-        // Shade of Eranikus: prevent it to become unattackable after a wipe
+        // Prevent it to become unattackable after a wipe
+        case NPC_JAMMALAN:
+        case NPC_OGOM:
         case NPC_SHADE_OF_ERANIKUS:
             pCreature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
             break;
@@ -160,6 +167,12 @@ void instance_sunken_temple::SetData(uint32 uiType, uint32 uiData)
                     DoUseDoorOrButton(GO_JAMMALAN_BARRIER);
                     // Intro yell
                     DoOrSimulateScriptTextForThisInstance(SAY_JAMMALAN_INTRO, NPC_JAMMALAN);
+
+                    if (Creature* jammalan = GetSingleCreatureFromStorage(NPC_JAMMALAN))
+                        jammalan->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
+
+                    if (Creature* ogom = GetSingleCreatureFromStorage(NPC_OGOM))
+                        ogom->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
                 }
             }
             break;

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/sunken_temple/sunken_temple.h
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/sunken_temple/sunken_temple.h
@@ -21,6 +21,7 @@ enum
     NPC_DREAMSCYTH        = 5721,
     NPC_WEAVER            = 5720,
     NPC_JAMMALAN          = 5710,
+    NPC_OGOM              = 5711,
     NPC_AVATAR_OF_HAKKAR  = 8443,
     NPC_SHADE_OF_ERANIKUS = 5709,
 


### PR DESCRIPTION
### Proof
```
ServerToClient: SMSG_COMPRESSED_UPDATE_OBJECT (0x01F6) Length: 1693 ConnIdx: 0 Time: 03/18/2009 23:53:41.000 Number: 653093
[3] GUID: Full: 0xF13000164E001953 Type: Creature Entry: 5710 Low: 6483
[3] UNIT_FIELD_FLAGS: 320

ServerToClient: SMSG_COMPRESSED_UPDATE_OBJECT (0x01F6) Length: 596 ConnIdx: 0 Time: 03/18/2009 23:53:50.000 Number: 653651
[10] GUID: Full: 0xF13000164F001954 Type: Creature Entry: 5711 Low: 6484
[10] UNIT_FIELD_FLAGS: 33088
```