### PR TITLE
Fix large GOs visibility override map visibility

### DIFF
--- a/src/game/Entities/GameObject.cpp
+++ b/src/game/Entities/GameObject.cpp
@@ -292,8 +292,8 @@ bool GameObject::Create(uint32 dbGuid, uint32 guidlow, uint32 name_id, Map* map,
     if (InstanceData* iData = map->GetInstanceData())
         iData->OnObjectCreate(this);
 
-    // Check if GameObject is Large
-    if (GetGOInfo()->IsLargeGameObject())
+    // Check if GameObject is Large, skip if map has same or better visibility (e.g. Battleground)
+    if (GetGOInfo()->IsLargeGameObject() && GetVisibilityData().GetVisibilityDistance() < VISIBILITY_DISTANCE_LARGE)
         GetVisibilityData().SetVisibilityDistanceOverride(VisibilityDistanceType::Large);
 
     if (GetEntry() == 187039) // Smuggled Mana Cell - only GO in phase in TBC


### PR DESCRIPTION
## 🍰 Pullrequest
Fix "Large" Gameobjects visibility set to Large (200y) on maps with higher visibility, e.g. Battlegrounds

### Issues
- "Large" Gameobjects in Battleground (e.g. Flagstands) are set to 200y and ignore that map visibility is higher

### How2Test
- Go away from flag in BG to >200y, it disappears. Everything else, e.g. players, is still visible from 500+y
