### PR TITLE
Send message on areatrigger teleport fail

### DIFF
--- a/src/game/Entities/MiscHandler.cpp
+++ b/src/game/Entities/MiscHandler.cpp
@@ -783,7 +783,12 @@ void WorldSession::HandleAreaTriggerOpcode(WorldPacket& recv_data)
 
     if (at->conditionId && !sObjectMgr.IsConditionSatisfied(at->conditionId, player, player->GetMap(), nullptr, CONDITION_FROM_AREATRIGGER_TELEPORT))
     {
-        /*TODO player->GetSession()->SendAreaTriggerMessage("%s", "YOU SHALL NOT PASS!");*/
+        if (!at->status_failed_text.empty())
+        {
+            std::string message = at->status_failed_text;
+            sObjectMgr.GetAreaTriggerLocales(at->entry, GetSessionDbLocaleIndex(), &message);
+            SendAreaTriggerMessage(message.data());
+        }
         return;
     }
 


### PR DESCRIPTION
Message can be localised

## 🍰 Pullrequest
Send localised message if condition is failed on teleport. E.g. if you have no attunement or level is too low. Those messages are already in DB