### PR TITLE
Improve ByteBuffer API.

### DIFF
--- a/src/game/Entities/UpdateData.cpp
+++ b/src/game/Entities/UpdateData.cpp
@@ -28,9 +28,8 @@
 #include "Entities/ObjectGuid.h"
 #include "Server/WorldSession.h"
 
-UpdateData::UpdateData() : m_data(1), m_currentIndex(0)
+UpdateData::UpdateData() : m_data(1, {ByteBuffer(0), 0}), m_currentIndex(0)
 {
-    m_data[0].m_buffer = 0;
 }
 
 void UpdateData::AddOutOfRangeGUID(GuidSet& guids)

--- a/src/shared/ByteBuffer.h
+++ b/src/shared/ByteBuffer.h
@@ -49,22 +49,38 @@ struct Unused
 class ByteBuffer
 {
     public:
-        const static size_t DEFAULT_SIZE = 0x1000;
 
-        // constructor
-        ByteBuffer(): _rpos(0), _wpos(0)
+        explicit ByteBuffer(size_t reservedSize = s_defaultSize): _rpos(0), _wpos(0)
         {
-            _storage.reserve(DEFAULT_SIZE);
+            _storage.reserve(reservedSize);
         }
 
-        // constructor
-        ByteBuffer(size_t res): _rpos(0), _wpos(0)
+        virtual ~ByteBuffer() = default;
+
+        ByteBuffer(const ByteBuffer&) = default;
+
+        ByteBuffer(ByteBuffer&& byteBuffer) noexcept
+        : _rpos(byteBuffer._rpos), _wpos(byteBuffer._wpos), _storage(std::move(byteBuffer._storage))
         {
-            _storage.reserve(res);
+            // Make sure the moved-from byteBuffer is in a valid state!
+            byteBuffer.clear();
         }
 
-        // copy constructor
-        ByteBuffer(const ByteBuffer& buf): _rpos(buf._rpos), _wpos(buf._wpos), _storage(buf._storage) { }
+        ByteBuffer& operator=(const ByteBuffer&) = default;
+
+        ByteBuffer& operator=(ByteBuffer&& byteBuffer) noexcept
+        {
+            if (&byteBuffer != this)
+            {
+                _rpos = byteBuffer._rpos;
+                _wpos = byteBuffer._wpos;
+                _storage = std::move(byteBuffer._storage);
+
+                // Make sure the moved-from byteBuffer is in a valid state!
+                byteBuffer.clear();
+            }
+            return *this;
+        }
 
         void clear()
         {
@@ -436,9 +452,10 @@ class ByteBuffer
             append((uint8*)&value, sizeof(value));
         }
 
-    protected:
         size_t _rpos, _wpos;
         std::vector<uint8> _storage;
+
+        static constexpr size_t s_defaultSize = 0x1000;
 };
 
 template <typename T>

--- a/src/shared/WorldPacket.h
+++ b/src/shared/WorldPacket.h
@@ -46,7 +46,7 @@ class WorldPacket : public ByteBuffer
         void Initialize(Opcodes opcode, size_t newres = 200)
         {
             clear();
-            _storage.reserve(newres);
+            reserve(newres);
             m_opcode = opcode;
         }
 


### PR DESCRIPTION
## 🍰 Pullrequest

Here's another change I'll move through review first before pushing it.

See the commit for all details. The main motivation here is that this is kind of a no-brainer for me in a C++11 and later world, and that a movable ByteBuffer will, after a next almost trivial change, also make WorldPacket movable (which may open a few other opportunities). There may even be other improvements where we now (implicitly) copy ByteBuffers where this may help, but I have no examples in mind.

A somewhat unrelated question: would you prefer I keep doing this for changes like this, that are hopefully not controversial and are just making better use of C++, but use some of your time to review it, or are you like "you can commit and you seem to know what you're doing in C++, so just push it"?