### PR TITLE
Fix wrong AuthSocket idle detection timer.

### DIFF
--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -181,6 +181,10 @@ std::array<uint8, 16> VersionChallenge = { { 0xBA, 0xA3, 0x1E, 0x99, 0xA0, 0x0B,
 AuthSocket::AuthSocket(boost::asio::io_service& service, std::function<void (Socket*)> closeHandler)
     : Socket(service, std::move(closeHandler)), _status(STATUS_CHALLENGE), _build(0), _accountSecurityLevel(SEC_PLAYER), m_timeoutTimer(service)
 {
+}
+
+bool AuthSocket::Open()
+{
     m_timeoutTimer.expires_from_now(boost::posix_time::seconds(30));
     m_timeoutTimer.async_wait([&] (const boost::system::error_code& error)
     {
@@ -192,6 +196,8 @@ AuthSocket::AuthSocket(boost::asio::io_service& service, std::function<void (Soc
         if (!IsClosed())
             Close();
     });
+
+    return Socket::Open();
 }
 
 /// Read the packet from the client

--- a/src/realmd/AuthSocket.h
+++ b/src/realmd/AuthSocket.h
@@ -44,6 +44,8 @@ class AuthSocket : public MaNGOS::Socket
 
         AuthSocket(boost::asio::io_service& service, std::function<void (Socket*)> closeHandler);
 
+        bool Open() override;
+
         void SendProof(Sha1Hash sha);
         void LoadRealmlist(ByteBuffer& pkt, uint32 acctid, uint8 accountSecurityLevel = 0);
         int32 generateToken(char const* b32key);


### PR DESCRIPTION
## 🍰 Pullrequest
I stumbled upon this somewhat unfortunate implementation that kind of defeats the purpose of having a timeout in the first place. Details are in the commit.

One question that remains, and which I didn't address at all, is whether we only want a timeout for the first client command? So after my change we close sockets if the client takes more than 30s to send a first reply, but we cancel the timer rather than reset it (see the ```m_timeoutTimer.cancel()``` in ```AuthSocket::ProcessIncomingData()```) which, well, cancels any asynchronous operations waiting on the timer. So technically speaking after the first client reply we don't bother checking any more...

### How2Test
* Start a server, and in particular realmd, putting a breakpoint in the timeout handler (or adding some output or whatever).
* Wait at least 30s before any client logs in.
* Notice how the accepting socket's timeout expires before a client even attempted to make a connection...
