### PR TITLE
[RFC] Fix spell modifiers memory leak.

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -5798,6 +5798,11 @@ void Unit::RemoveAura(Aura* Aur, AuraRemoveMode mode)
             case SPELL_AURA_MOD_POSSESS_PET:
                 Aur->ApplyModifier(false, true);
                 break;
+            // We need to undo any auras with spell modifiers so they get deleted.
+            case SPELL_AURA_ADD_FLAT_MODIFIER:
+            case SPELL_AURA_ADD_PCT_MODIFIER:
+                Aur->ApplyModifier(false, true);
+                break;
             default: break;
         }
     }

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1118,7 +1118,8 @@ void Aura::HandleAddModifier(bool apply, bool Real)
 
     ((Player*)GetTarget())->AddSpellMod(m_spellmod, apply);
 
-    ReapplyAffectedPassiveAuras();
+    if (apply)
+      ReapplyAffectedPassiveAuras();
 }
 
 void Aura::TriggerSpell()


### PR DESCRIPTION
## 🍰 Pullrequest
I noticed a while ago that all (or most?) ```SpellModifier``` objects created [here](https://github.com/cmangos/mangos-tbc/blob/master/src/game/Spells/SpellAuras.cpp#L1108) are basically leaked. Note that this is in ```Aura::HandleAddModifier()``` which gets called by ```Aura::ApplyModifier()``` (with ```apply``` being true).

As you can see in [Player::AddSpellMod()](https://github.com/cmangos/mangos-tbc/blob/master/src/game/Entities/Player.cpp#L17895) the SpellModifier object is added to ```m_spellMods```, and that code clearly suggests that the same path - but with ```apply``` being false - is intended to be taken to get it removed and deleted again. Except... this never seems to happen.

Some digging explained why. In the case of player talents/spells, the SpellModifier object stays around as long as the player exists. Then when the player logs out, all auras get removed, and we get a call stack like this:

```
#0 Unit::RemoveAura (this=0x627000085100, Aur=0x6080012a21a0, mode=AURA_REMOVE_BY_DELETE) at cmangos-tbc/src/game/Entities/Unit.cpp:5772
#1 Unit::RemoveSpellAuraHolder (this=0x627000085100, holder=0x60d00013cb00, mode=AURA_REMOVE_BY_DELETE) at cmangos-tbc/src/game/Entities/Unit.cpp:5722
#2 Unit::RemoveAllAuras (this=0x627000085100, mode=AURA_REMOVE_BY_DELETE) at cmangos-tbc/src/game/Entities/Unit.cpp:5817
#3 Unit::CleanupsBeforeDelete (this=0x627000085100) at cmangos-tbc/src/game/Entities/Unit.cpp:10122
#4 Player::CleanupsBeforeDelete (this=0x627000085100) at cmangos-tbc/src/game/Entities/Player.cpp:717
#5 Map::Remove (this=0x7fffe74e6800, player=0x627000085100, remove=true) at cmangos-tbc/src/game/Maps/Map.cpp:833
#6 WorldSession::LogoutPlayer (this=0x6190015da680) at cmangos-tbc/src/game/Server/WorldSession.cpp:742
...
```
where ```Unit::RemoveAura``` looks like this (at least in the TBC core):
```
void Unit::RemoveAura(Aura* Aur, AuraRemoveMode mode)
{
    // remove from list before mods removing (prevent cyclic calls, mods added before including to aura list - use reverse order)
    if (Aur->GetModifier()->m_auraname < TOTAL_AURAS)
    {
        m_modAuras[Aur->GetModifier()->m_auraname].remove(Aur);
    }

    // Set remove mode
    Aur->SetRemoveMode(mode);

    // some ShapeshiftBoosts at remove trigger removing other auras including parent Shapeshift aura
    // remove aura from list before to prevent deleting it before
    /// m_Auras.erase(i);

    DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Aura %u now is remove mode %d", Aur->GetModifier()->m_auraname, mode);

    // aura _MUST_ be remove from holder before unapply.
    // un-apply code expected that aura not find by diff searches
    // in another case it can be double removed for example, if target die/etc in un-apply process.
    Aur->GetHolder()->RemoveAura(Aur->GetEffIndex());

    // some auras also need to apply modifier (on caster) on remove
    if (mode == AURA_REMOVE_BY_DELETE)
    {
        switch (Aur->GetModifier()->m_auraname)
        {
            // need properly undo any auras with player-caster mover set (or will crash at next caster move packet)
            case SPELL_AURA_MOD_POSSESS:
            case SPELL_AURA_MOD_POSSESS_PET:
                Aur->ApplyModifier(false, true);
                break;
            default: break;
        }
    }
    else
        Aur->ApplyModifier(false, true);

    // If aura in use (removed from code that plan access to it data after return)
    // store it in aura list with delayed deletion
    m_deletedAuras.push_back(Aur);
}
```
Note in particular that when logging out (see the call stack), ```mode``` is ```AURA_REMOVE_BY_DELETE``` so we're _NOT_ in the else case that just calls ```ApplyModifier(false, true)```. But for these auras the switch is also a no-op, because they're ```SPELL_AURA_ADD_FLAT_MODIFIER``` or ```SPELL_AURA_ADD_PCT_MODIFIER```, so we never call ```ApplyModifier(false, true)``` as I would expect, and thus the SpellModifier object is never removed again and the memory is leaked.

So I created a somewhat experimental fix (this PR) that solves this particular problem, but I'm not really familiar with all the spell code in the core, and thus the next thing I'm wondering is what, if anything, this could break. So I'm creating this PR as a request for comments.

So far I have done limited testing, with a paladin and druid (relevant talents that use SPELL_AURA_ADD_FLAT_MODIFIER or SPELL_AURA_ADD_PCT_MODIFIER are Sacred Duty, Improved Hammer of Justice, Improved Righteous Fury, Improved Devotion Aura, Ferocity, Feral Aggression, etc), so I'm also opening this to a wider public for additional testing.

### Issues
As the server is running, players will generally speaking be logging in and out, so the underlying issue contributes to a constantly growing memory use of the server. Related issues are cmangos/issues#3265 and (in the WotLK core) cmangos/issues#3140.