### PR TITLE
Allow .go warp command values to use decimals

### DIFF
--- a/src/game/Chat/Level1.cpp
+++ b/src/game/Chat/Level1.cpp
@@ -1954,7 +1954,7 @@ bool ChatHandler::HandleGoWarpCommand(char* args)
         return false;
 
     char dir = arg1[0];
-    int32 value = (int32)atoi(arg2);
+    float value = (float)atof(arg2);
     float x = player->GetPositionX();
     float y = player->GetPositionY();
     float z = player->GetPositionZ();


### PR DESCRIPTION
Allow .go warp command values to use decimals for more precision

For example if you used to write decimals it would've been rounded because the args were converted to int32 instead of float.
.go warp x 1.5 