### PR TITLE
Fix crash when applying earth shield aura to shaman

### DIFF
--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -769,7 +769,7 @@ SpellAuraProcResult Unit::TriggerProccedSpell(Unit* target, std::array<int32, MA
     if (target && (target != this && !target->IsAlive()))
         return SPELL_AURA_PROC_FAILED;
 
-    if (!triggeredByAura->GetHolder()->IsProcReady(GetMap()->GetCurrentClockTime()))
+    if (triggeredByAura && triggeredByAura->GetHolder() && !triggeredByAura->GetHolder()->IsProcReady(GetMap()->GetCurrentClockTime()))
         return SPELL_AURA_PROC_FAILED;
 
     if (basepoints[EFFECT_INDEX_0] || basepoints[EFFECT_INDEX_1] || basepoints[EFFECT_INDEX_2])
@@ -781,7 +781,7 @@ SpellAuraProcResult Unit::TriggerProccedSpell(Unit* target, std::array<int32, MA
     else
         CastSpell(target, spellInfo, TRIGGERED_OLD_TRIGGERED | TRIGGERED_INSTANT_CAST | TRIGGERED_DO_NOT_RESET_LEASH, castItem, triggeredByAura, originalCaster);
 
-    if (cooldown)
+    if (cooldown && triggeredByAura && triggeredByAura->GetHolder())
         triggeredByAura->GetHolder()->SetProcCooldown(std::chrono::seconds(cooldown), GetMap()->GetCurrentClockTime());
 
     return SPELL_AURA_PROC_OK;


### PR DESCRIPTION
## 🍰 Pullrequest
Using the shaman's earth shield spell causes the server to crash

Spell_id 379

Exception not handled
A fatal exception was thrown: read access violation.
this was nullptr

### Proof
https://www.youtube.com/watch?v=4GmmriJgEaU


### Issues
- None

### How2Test
- None

### Todo / Checklist
- [X] None
