### PR TITLE
Remove escort state when 'End()' gets called

### DIFF
--- a/src/game/AI/ScriptDevAI/base/escort_ai.cpp
+++ b/src/game/AI/ScriptDevAI/base/escort_ai.cpp
@@ -298,6 +298,7 @@ void npc_escortAI::Start(bool run, const Player* player, const Quest* quest, boo
 
 void npc_escortAI::End()
 {
+    RemoveEscortState(STATE_ESCORT_ESCORTING);
     m_playerGuid = ObjectGuid();
     m_questForEscort = nullptr;
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This function got added with gizelton quest changes and currently only gets used by this quest.

When end gets called the STATE_ESCORT_ESCORTING needs to get removed so the npcs can do another escort quest.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
