### PR TITLE
[MMAPs] Fix Path Finding for .go c 5540016

### DIFF
--- a/contrib/extractor_scripts/config.json
+++ b/contrib/extractor_scripts/config.json
@@ -50,6 +50,9 @@
 			"walkableHeight": 10.0
 	},
         "554": {
+                "_Info": "The Mechanar - .go c 5540016",
+                "walkableHeight": 5.0,
+                "walkableClimb": 4.5,
                 "walkableSlopeAngle":60,
                 "minRegionArea": 30,
                 "walkableRadius": 1


### PR DESCRIPTION
befor: npcs being stuck ontop unable to path down. 


![](https://cdn.discordapp.com/attachments/911283799827030107/1084256476153000058/grafik.png)

after: no such issue.

![](https://cdn.discordapp.com/attachments/911283799827030107/1084259220695830598/grafik.png)

We might want to think about tweaking the default param for walkable height and climb a bit, just so much that npcs cant go over fences.