### PR TITLE
Fix crash during daily worldevent despawns

### DIFF
--- a/src/game/Maps/SpawnGroup.cpp
+++ b/src/game/Maps/SpawnGroup.cpp
@@ -500,7 +500,10 @@ void CreatureGroup::MoveHome()
 void CreatureGroup::Despawn(uint32 timeMSToDespawn, bool onlyAlive, uint32 forcedDespawnTime)
 {
     time_t when = time(nullptr) + forcedDespawnTime;
-    for (auto objItr : m_objects)
+
+    // Take a snapshot of m_objects here so that we can mutate it (via stuff like ForcedDespawn() with timeMSToDespawn = 0 while iterating, typically during world event despawns)
+    auto objects = m_objects;
+    for (auto objItr : objects)
     {
         uint32 dbGuid = objItr.first;
         if (Creature* creature = m_map.GetCreature(dbGuid))
@@ -573,6 +576,8 @@ void GameObjectGroup::RemoveObject(WorldObject* wo)
 void GameObjectGroup::Despawn(uint32 timeMSToDespawn /*= 0*/, uint32 forcedDespawnTime /*= 0*/)
 {
     time_t when = time(nullptr) + forcedDespawnTime;
+    // Take a snapshot of m_objects here so that we can mutate it (via stuff like ForcedDespawn() with timeMSToDespawn = 0 while iterating, typically during world event despawns)
+    auto objects = m_objects;
     for (auto objItr : m_objects)
     {
         uint32 dbGuid = objItr.first;


### PR DESCRIPTION
## 🍰 Pullrequest
I noticed that my world server would crash every day at 20:00 UTC. After attaching a debugger, it looked related to a daily world event despawning creatures:

Access violation, stack trace:
```
mangosd.exe!std::_Tree_unchecked_const_iterator<std::_Tree_val<std::_Tree_simple_types<std::pair<unsigned int const ,unsigned int>>>,std::_Iterator_base0>::operator++() Line 51    C++
     mangosd.exe!std::_Tree_unchecked_iterator<std::_Tree_val<std::_Tree_simple_types<std::pair<unsigned int const ,unsigned int>>>>::operator++() Line 144    C++
>    mangosd.exe!CreatureGroup::Despawn(unsigned int timeMSToDespawn, bool onlyAlive, unsigned int forcedDespawnTime) Line 503    C++
     mangosd.exe!CreatureGroup::Despawn(unsigned int timeMSToDespawn, unsigned int forcedDespawnTime) Line 92    C++
     mangosd.exe!SpawnGroup::Spawn(bool force) Line 161    C++
     mangosd.exe!SpawnGroup::Update() Line 104    C++
     mangosd.exe!CreatureGroup::Update() Line 483    C++
     mangosd.exe!SpawnManager::Update() Line 167    C++
     mangosd.exe!Map::Update(const unsigned int & t_diff) Line 698    C++
     mangosd.exe!MapUpdateWorker::execute() Line 53    C++
     mangosd.exe!MapUpdater::WorkerThread() Line 98    C++
     [External Code]   
```
![image](https://github.com/cmangos/mangos-tbc/assets/601930/6ed617f5-24ba-401b-96d4-b6ac174ff8eb)

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Leave the world server running for a couple of days.