### PR TITLE
Crashfix

### DIFF
--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -769,7 +769,7 @@ SpellAuraProcResult Unit::TriggerProccedSpell(Unit* target, std::array<int32, MA
     if (target && (target != this && !target->IsAlive()))
         return SPELL_AURA_PROC_FAILED;
 
-    if (!triggeredByAura->GetHolder()->IsProcReady(GetMap()->GetCurrentClockTime()))
+    if (triggeredByAura && !triggeredByAura->GetHolder()->IsProcReady(GetMap()->GetCurrentClockTime()))
         return SPELL_AURA_PROC_FAILED;
 
     if (basepoints[EFFECT_INDEX_0] || basepoints[EFFECT_INDEX_1] || basepoints[EFFECT_INDEX_2])
@@ -781,7 +781,7 @@ SpellAuraProcResult Unit::TriggerProccedSpell(Unit* target, std::array<int32, MA
     else
         CastSpell(target, spellInfo, TRIGGERED_OLD_TRIGGERED | TRIGGERED_INSTANT_CAST | TRIGGERED_DO_NOT_RESET_LEASH, castItem, triggeredByAura, originalCaster);
 
-    if (cooldown)
+    if (cooldown && triggeredByAura)
         triggeredByAura->GetHolder()->SetProcCooldown(std::chrono::seconds(cooldown), GetMap()->GetCurrentClockTime());
 
     return SPELL_AURA_PROC_OK;


### PR DESCRIPTION
Other methods here do check for triggerAura so I decided to fix it like that. Have reports of that happen e.g. when fighting big green trash mob in Sunwell and other places

## 🍰 Pullrequest
Fixes crash

### Issues
I lack understanding if it's a hackfix or ok fix

### Example of call stack
```
Call stack:
Address   Frame     Function      SourceFile
00007FF763025F0B  0000006A29BFF4A0  Unit::TriggerProccedSpell+AB  D:\MANGOS\cmangos\tbc\src\game\Spells\UnitAuraProcHandler.cpp line 772
00007FF76301FE50  0000006A29BFF600  Unit::HandleDummyAuraProc+3E0  D:\MANGOS\cmangos\tbc\src\game\Spells\UnitAuraProcHandler.cpp line 1964
00007FF76302584E  0000006A29BFF780  Unit::ProcDamageAndSpellFor+42E  D:\MANGOS\cmangos\tbc\src\game\Spells\UnitAuraProcHandler.cpp line 591
00007FF7630252DE  0000006A29BFF7C0  Unit::ProcDamageAndSpell+BE  D:\MANGOS\cmangos\tbc\src\game\Spells\UnitAuraProcHandler.cpp line 452
00007FF762F47708  0000006A29BFF8E0  Spell::DoAllEffectOnTarget+6A8  D:\MANGOS\cmangos\tbc\src\game\Spells\Spell.cpp line 1344
00007FF762F5AAEC  0000006A29BFF910  Spell::handle_immediate+3C  D:\MANGOS\cmangos\tbc\src\game\Spells\Spell.cpp line 3462
00007FF762F5A003  0000006A29BFF9E0  Spell::cast+713  D:\MANGOS\cmangos\tbc\src\game\Spells\Spell.cpp line 3452
00007FF762E0ABA6  0000006A29BFFB70  Unit::AttackerStateUpdate+B6  D:\MANGOS\cmangos\tbc\src\game\Entities\Unit.cpp line 2848
00007FF762E3EC59  0000006A29BFFBC0  Unit::UpdateMeleeAttackingState+139  D:\MANGOS\cmangos\tbc\src\game\Entities\Unit.cpp line 676
00007FF762F9CE72  0000006A29BFFBF0  UnitAI::DoMeleeAttackIfReady+22  D:\MANGOS\cmangos\tbc\src\game\AI\BaseAI\UnitAI.cpp line 290
00007FF762F9F2CB  0000006A29BFFC20  UnitAI::UpdateAI+20B  D:\MANGOS\cmangos\tbc\src\game\AI\BaseAI\UnitAI.cpp line 1113
00007FF762E3E6A0  0000006A29BFFC60  Unit::Update+170  D:\MANGOS\cmangos\tbc\src\game\Entities\Unit.cpp line 548
00007FF762EC7D09  0000006A29BFFC90  Creature::Update+319  D:\MANGOS\cmangos\tbc\src\game\Entities\Creature.cpp line 790
00007FF762DF8C31  0000006A29BFFE10  Map::Update+F31  D:\MANGOS\cmangos\tbc\src\game\Maps\Map.cpp line 1103
00007FF762CED667  0000006A29BFFE40  MapUpdateWorker::execute+17  D:\MANGOS\cmangos\tbc\src\game\Maps\MapWorkers.h line 53
00007FF762FA3E5C  0000006A29BFFE70  MapUpdater::WorkerThread+DC  D:\MANGOS\cmangos\tbc\src\game\Maps\MapUpdater.cpp line 98
00007FF762FA3AAF  0000006A29BFFEA0  std::thread::_Invoke<std::tuple<void (__cdecl MapUpdater::*)(void),MapUpdater *>,0,1>+F  C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.33.31629\include\thread line 56
00007FFEC8DB9363  0000006A29BFFED0  _recalloc+A3
00007FFECA3926AD  0000006A29BFFF00  BaseThreadInitThunk+1D
00007FFECB2CA9F8  0000006A29BFFF80  RtlUserThreadStart+28
```
