### PR TITLE
Add disabled check in UpdateSpellLists

### DIFF
--- a/src/game/AI/BaseAI/UnitAI.cpp
+++ b/src/game/AI/BaseAI/UnitAI.cpp
@@ -1192,6 +1192,11 @@ void UnitAI::UpdateSpellLists()
 
     CreatureSpellList const& spells = GetSpellList();
 
+    if (spells.Disabled)
+    {
+        return;
+    }
+
     // when probability is 0 for all spells, they will use priority based on positions
     std::vector<std::tuple<uint32, uint32, uint32, Unit*>> eligibleSpells;
     uint32 sum = 0;


### PR DESCRIPTION
## 🍰 Pullrequest
The creature "Infernal Attacker" in Shadowmoon valley seems to cause segfaults in the server when starting up. Its spell list is disabled but contains a single spell with spellId=2, which returns nullptr when we try to run `sSpellTemplate.LookupEntry<SpellEntry>(spell.SpellId);`.
I'm not sure if this is from the spell slot -> spell list migration (looking in the sql migration templates), but at least with this fix my server doesn't bomb out on startup anymore. Unsure if this will break some other behaviour I'm not familiar with, still quite new to the codebase 🙂

### Proof
Crash site:
![image](https://github.com/cmangos/mangos-tbc/assets/601930/482c24d8-8ef0-4103-8930-093fb01f4bc5)
Calling method, UpdateSpellLists, note that spellInfo is nullptr
![image](https://github.com/cmangos/mangos-tbc/assets/601930/bd3babe1-ec6b-478b-9272-7ffd93604113)


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
I can't find any existing issues for this

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
I think the repro for this is to park a character in Shadowmoon valley so that the area gets populated, then restart the server. I'll try it on a fresh instance though.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
