### PR TITLE
[CreatureEventAI] add inCombat Check to EVENT_T_AURA and EVENT_T_MISS…

### DIFF
--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -506,9 +506,36 @@ bool CreatureEventAI::CheckEvent(CreatureEventAIHolder& holder, Unit* actionInvo
             break;
         case EVENT_T_AURA:
         {
-            SpellAuraHolder* auraHolder = m_creature->GetSpellAuraHolder(event.buffed.spellId);
-            if (!auraHolder || auraHolder->GetStackAmount() < event.buffed.amount)
-                return false;
+            // 0 = Out and in combat
+            // 1 = Only in Combat
+            // 2 = Only out of combat
+
+            if (event.buffed.inCombat == 0)
+            {
+                SpellAuraHolder* auraHolder = m_creature->GetSpellAuraHolder(event.buffed.spellId);
+                if (!auraHolder || auraHolder->GetStackAmount() < event.buffed.amount)
+                    return false;
+            }
+
+            if (event.buffed.inCombat == 1)
+            {
+                if (!m_creature->IsInCombat())
+                    return false;
+
+                SpellAuraHolder* auraHolder = m_creature->GetSpellAuraHolder(event.buffed.spellId);
+                if (!auraHolder || auraHolder->GetStackAmount() < event.buffed.amount)
+                    return false;
+            }
+            if (event.buffed.inCombat == 2)
+            {
+
+                if (!m_creature->IsInCombat())
+                    return false;
+
+                SpellAuraHolder* auraHolder = m_creature->GetSpellAuraHolder(event.buffed.spellId);
+                if (!auraHolder || auraHolder->GetStackAmount() < event.buffed.amount)
+                    return false;
+            }           
             break;
         }
         case EVENT_T_TARGET_AURA:
@@ -523,9 +550,36 @@ bool CreatureEventAI::CheckEvent(CreatureEventAIHolder& holder, Unit* actionInvo
         }
         case EVENT_T_MISSING_AURA:
         {
-            SpellAuraHolder* auraHolder = m_creature->GetSpellAuraHolder(event.buffed.spellId);
-            if (auraHolder && auraHolder->GetStackAmount() >= event.buffed.amount)
-                return false;
+            // 0 = Out and in combat
+            // 1 = Only in Combat
+            // 2 = Only out of combat
+
+            if (event.buffed.inCombat == 0)
+            {
+                SpellAuraHolder* auraHolder = m_creature->GetSpellAuraHolder(event.buffed.spellId);
+                if (auraHolder && auraHolder->GetStackAmount() >= event.buffed.amount)
+                    return false;
+            }
+
+            if (event.buffed.inCombat == 1)
+            {
+                if (!m_creature->IsInCombat())
+                    return false;
+
+                SpellAuraHolder* auraHolder = m_creature->GetSpellAuraHolder(event.buffed.spellId);
+                if (auraHolder && auraHolder->GetStackAmount() >= event.buffed.amount)
+                    return false;
+            }
+            if (event.buffed.inCombat == 2)
+            {
+
+                if (!m_creature->IsInCombat())
+                    return false;
+
+                SpellAuraHolder* auraHolder = m_creature->GetSpellAuraHolder(event.buffed.spellId);
+                if (auraHolder && auraHolder->GetStackAmount() >= event.buffed.amount)
+                    return false;
+            }
             break;
         }
         case EVENT_T_TARGET_MISSING_AURA:

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -62,11 +62,11 @@ enum EventAI_Type
     EVENT_T_QUEST_COMPLETE          = 20,                   //
     EVENT_T_REACHED_HOME            = 21,                   // NONE
     EVENT_T_RECEIVE_EMOTE           = 22,                   // EmoteId, ConditionId
-    EVENT_T_AURA                    = 23,                   // Param1 = SpellID, Param2 = Number of time stacked, Param3/4 Repeat Min/Max
+    EVENT_T_AURA                    = 23,                   // Param1 = SpellID, Param2 = Number of time stacked, Param3/4 Repeat Min/Max, inCombat
     EVENT_T_TARGET_AURA             = 24,                   // Param1 = SpellID, Param2 = Number of time stacked, Param3/4 Repeat Min/Max
     EVENT_T_SUMMONED_JUST_DIED      = 25,                   // CreatureId, RepeatMin, RepeatMax
     EVENT_T_SUMMONED_JUST_DESPAWN   = 26,                   // CreatureId, RepeatMin, RepeatMax
-    EVENT_T_MISSING_AURA            = 27,                   // Param1 = SpellID, Param2 = Number of time stacked expected, Param3/4 Repeat Min/Max
+    EVENT_T_MISSING_AURA            = 27,                   // Param1 = SpellID, Param2 = Number of time stacked expected, Param3/4 Repeat Min/Max, inCombat
     EVENT_T_TARGET_MISSING_AURA     = 28,                   // Param1 = SpellID, Param2 = Number of time stacked expected, Param3/4 Repeat Min/Max
     EVENT_T_TIMER_GENERIC           = 29,                   // InitialMin, InitialMax, RepeatMin, RepeatMax
     EVENT_T_RECEIVE_AI_EVENT        = 30,                   // AIEventType, Sender-Entry, unused, unused
@@ -746,6 +746,7 @@ struct CreatureEventAI_Event
             uint32 amount;
             uint32 repeatMin;
             uint32 repeatMax;
+            uint32 inCombat;
         } buffed;
         // EVENT_T_RECEIVE_AI_EVENT                         = 30
         struct


### PR DESCRIPTION
…ING_AURA

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This adds a simple inCombat check to EVENT_T_AURA and EVENT_T_MISSING_AURA

### Proof
<!-- Link resources as proof -->
https://youtu.be/pZOSVT0y_cY 
You can see from wotlk classic, that Baroness Dorothea Millstipe casts her Shadowform Aura only inCombat, thats where this would be needed. 
https://youtu.be/9S7-fpVjypI
Here she casted it ~1 seconds into the fight.

Sniffs shown that she uses this spell between 1500ms and 8000 ms into the fight, if she doesnt have the aura already. 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
