### PR TITLE
[Spell] Add "Controlled" Prevention for Backstab and Gouge Spells

### DIFF
--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2702,7 +2702,10 @@ UPDATE `spell_template` SET `AttributesEx4`=`AttributesEx4`|64 WHERE `Id`=33949;
 
 -- Backstab spells used by creatures
 -- these are all easily controlled and made castable only from behind via AI, however when a player Mind Controls the NPC, we need these attributes to prevent usage from the front:
-UPDATE `spell_template` SET AttributesServerside=AttributesServerside|0x00000008 WHERE `Id` IN (7159,15582,15657,22416,30992,34614,37685);
+UPDATE `spell_template` SET AttributesServerside=AttributesServerside|0x00000008 WHERE `Id` IN (53,2589,2590,2591,6595,7159,8355,8721,11279,11280,11281,15582,15657,22416,24016,25300,26863,30992,34171,34614,37685,37956); -- SPELL_ATTR_SS_FACING_BACK
+
+-- Infront only Spells - SPELL_FACING_FLAG_INFRONT "Must be in front of the caster."
+UPDATE `spell_template` SET `FacingCasterFlags` = 1 WHERE `Id` IN (12540,13579,29425,36862,38863);
 
 -- Stormchops - Fix targeting
 UPDATE spell_template SET EffectImplicitTargetA2=1,EffectImplicitTargetB2=0 WHERE Id IN(43730);


### PR DESCRIPTION
Needed to convert some EAI to creature_spell_lists and npcs being controlled by players spamming these abilities from front/back.