### PR TITLE
[Spell] Hakkar Power 24692 should not be removed on Evade

### DIFF
--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2200,6 +2200,7 @@ INSERT INTO spell_template(Id, SchoolMask, Category, Dispel, Mechanic, Attribute
 UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|4 WHERE `Id` IN (
 5667, -- Bogling Passive
 5888, -- Darkshore Frenzy
+7131, -- Illusion Passive
 15978, -- Puncture
 21911, -- Puncture
 24692, -- Hakkar Power

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2200,6 +2200,7 @@ INSERT INTO spell_template(Id, SchoolMask, Category, Dispel, Mechanic, Attribute
 UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|4 WHERE `Id` IN (
 15978, -- Puncture
 21911, -- Puncture
+24692, -- Hakkar Power
 28330 -- Flameshocker - Immolate Visual
 );
 

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2206,6 +2206,7 @@ UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|4 WH
 10092, -- Sand Storm
 10868, -- Frost Vulnerable
 11011, -- Stone Watcher of Norgannon Passive
+11048, -- Perm. Illusion Bishop Tyriona
 15978, -- Puncture
 21911, -- Puncture
 24692, -- Hakkar Power

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2203,6 +2203,7 @@ UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|4 WH
 5888, -- Darkshore Frenzy
 7131, -- Illusion Passive
 8203, -- Elemental Spirit Invisibility
+10092, -- Sand Storm
 11011, -- Stone Watcher of Norgannon Passive
 15978, -- Puncture
 21911, -- Puncture

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2198,6 +2198,7 @@ INSERT INTO spell_template(Id, SchoolMask, Category, Dispel, Mechanic, Attribute
 -- SPELL_ATTR_SS_IGNORE_EVADE
 -- ==========================
 UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|4 WHERE `Id` IN (
+3418, -- Improved Blocking
 5667, -- Bogling Passive
 5888, -- Darkshore Frenzy
 7131, -- Illusion Passive

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2204,6 +2204,7 @@ UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|4 WH
 7131, -- Illusion Passive
 8203, -- Elemental Spirit Invisibility
 10092, -- Sand Storm
+10868, -- Frost Vulnerable
 11011, -- Stone Watcher of Norgannon Passive
 15978, -- Puncture
 21911, -- Puncture

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2383,6 +2383,7 @@ UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|0x00
 17205, -- Winterfall Firewater
 18163, -- Strength of Arko'narin
 18167, -- Holy Fire
+21080, -- Putrid Breath
 23378, -- Magma Splash
 27791, -- Suicide (Suicide)
 21789, -- Hate to Half (Hate to Half)

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2373,6 +2373,7 @@ INSERT INTO spell_template(Id, SchoolMask, Category, Dispel, Mechanic, Attribute
 -- ============================================================
 UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|0x00000004 WHERE `Id` IN (
 4044,  -- Target Dummy Passive
+5301, -- Defensive State (DND)
 6742, -- Bloodlust
 8852, -- Moss Hide
 11816, -- Land Mine Arming

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2198,6 +2198,7 @@ INSERT INTO spell_template(Id, SchoolMask, Category, Dispel, Mechanic, Attribute
 -- SPELL_ATTR_SS_IGNORE_EVADE
 -- ==========================
 UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|4 WHERE `Id` IN (
+5888, -- Darkshore Frenzy
 15978, -- Puncture
 21911, -- Puncture
 24692, -- Hakkar Power

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2202,6 +2202,7 @@ UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|4 WH
 5667, -- Bogling Passive
 5888, -- Darkshore Frenzy
 7131, -- Illusion Passive
+8203, -- Elemental Spirit Invisibility
 15978, -- Puncture
 21911, -- Puncture
 24692, -- Hakkar Power

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2203,6 +2203,7 @@ UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|4 WH
 5888, -- Darkshore Frenzy
 7131, -- Illusion Passive
 8203, -- Elemental Spirit Invisibility
+11011, -- Stone Watcher of Norgannon Passive
 15978, -- Puncture
 21911, -- Puncture
 24692, -- Hakkar Power

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2198,6 +2198,7 @@ INSERT INTO spell_template(Id, SchoolMask, Category, Dispel, Mechanic, Attribute
 -- SPELL_ATTR_SS_IGNORE_EVADE
 -- ==========================
 UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|4 WHERE `Id` IN (
+5667, -- Bogling Passive
 5888, -- Darkshore Frenzy
 15978, -- Puncture
 21911, -- Puncture


### PR DESCRIPTION
Else after resetting boss once he is easily killable without clearing anything else.