### PR TITLE
Gruul's Lair: add bct texts to maulgar and let door open when maulgar…

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -4556,17 +4556,6 @@ INSERT INTO script_texts (entry,content_default,sound,type,language,emote,broadc
 
 -- -1 565 000 GRUUL'S LAIR
 INSERT INTO script_texts (entry,content_default,sound,type,language,emote,broadcast_text_id,comment) VALUES
-('-1565000','Gronn are the real power in Outland!','11367','1','0','0','20066','maulgar SAY_AGGRO'),
-('-1565001','You will not defeat the hand of Gruul!','11368','1','0','0','20067','maulgar SAY_ENRAGE'),
-('-1565002','You won''t kill next one so easy.','11369','1','0','0','20068','maulgar SAY_OGRE_DEATH1'),
-('-1565003','Pah! Does not prove anything!','11370','1','0','0','20069','maulgar SAY_OGRE_DEATH2'),
-('-1565004','I''m not afraid of you!','11371','1','0','0','20070','maulgar SAY_OGRE_DEATH3'),
-('-1565005','Good, now you fight me!','11372','1','0','0','20071','maulgar SAY_OGRE_DEATH4'),
-('-1565006','You not so tough after all!','11373','1','0','0','20072','maulgar SAY_SLAY1'),
-('-1565007','%s laughs.','11374','2','0','0','20073','maulgar SAY_SLAY2'),
-('-1565008','Maulgar is king!','11375','1','0','0','20074','maulgar SAY_SLAY3'),
-('-1565009','Gruul... will crush you.','11376','1','0','0','20075','maulgar SAY_DEATH'),
-
 ('-1565010','Come.... and die.','11355','1','0','0','20116','gruul SAY_AGGRO'),
 ('-1565011','Scurry.','11356','1','0','0','20117','gruul SAY_SLAM1'),
 ('-1565012','No escape.','11357','1','0','0','20118','gruul SAY_SLAM2'),

--- a/src/game/AI/ScriptDevAI/scripts/outland/gruuls_lair/boss_high_king_maulgar.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/gruuls_lair/boss_high_king_maulgar.cpp
@@ -27,16 +27,16 @@ EndScriptData */
 
 enum
 {
-    SAY_AGGRO                   = -1565000,
-    SAY_ENRAGE                  = -1565001,
-    SAY_OGRE_DEATH1             = -1565002,
-    SAY_OGRE_DEATH2             = -1565003,
-    SAY_OGRE_DEATH3             = -1565004,
-    SAY_OGRE_DEATH4             = -1565005,
+    SAY_AGGRO                   = 20066,
+    SAY_ENRAGE                  = 20067,
+    SAY_OGRE_DEATH1             = 20068,
+    SAY_OGRE_DEATH2             = 20069,
+    SAY_OGRE_DEATH3             = 20070,
+    SAY_OGRE_DEATH4             = 20071,
     SAY_SLAY1                   = 20072,
     SAY_SLAY2                   = 20073,
     SAY_SLAY3                   = 20074,
-    SAY_DEATH                   = -1565009,
+    SAY_DEATH                   = 20075,
 
     // High King Maulgar Spells
     SPELL_ARCING_SMASH          = 39144,
@@ -111,16 +111,16 @@ struct boss_high_king_maulgarAI : public CombatAI
 
     void JustDied(Unit* /*killer*/) override
     {
-        DoScriptText(SAY_DEATH, m_creature);
+        DoBroadcastText(SAY_DEATH, m_creature);
 
-        // Set data to Special on Death
+        // Set data to Done on Death
         if (m_instance)
-            m_instance->SetData(TYPE_MAULGAR_EVENT, SPECIAL);
+            m_instance->SetData(TYPE_MAULGAR_EVENT, DONE);
     }
 
     void Aggro(Unit* /*who*/) override
     {
-        DoScriptText(SAY_AGGRO, m_creature);
+        DoBroadcastText(SAY_AGGRO, m_creature);
 
         if (m_instance)
             m_instance->SetData(TYPE_MAULGAR_EVENT, IN_PROGRESS);
@@ -130,10 +130,10 @@ struct boss_high_king_maulgarAI : public CombatAI
     {
         switch (++m_uiCouncilDeathCount)
         {
-            case 1: DoScriptText(SAY_OGRE_DEATH1, m_creature); break;
-            case 2: DoScriptText(SAY_OGRE_DEATH2, m_creature); break;
-            case 3: DoScriptText(SAY_OGRE_DEATH3, m_creature); break;
-            case 4: DoScriptText(SAY_OGRE_DEATH4, m_creature); break;
+            case 1: DoBroadcastText(SAY_OGRE_DEATH1, m_creature); break;
+            case 2: DoBroadcastText(SAY_OGRE_DEATH2, m_creature); break;
+            case 3: DoBroadcastText(SAY_OGRE_DEATH3, m_creature); break;
+            case 4: DoBroadcastText(SAY_OGRE_DEATH4, m_creature); break;
         }
     }
 
@@ -146,7 +146,7 @@ struct boss_high_king_maulgarAI : public CombatAI
                 {
                     if (DoCastSpellIfCan(nullptr, SPELL_FLURRY) == CAST_OK)
                     {
-                        DoScriptText(SAY_ENRAGE, m_creature);
+                        DoBroadcastText(SAY_ENRAGE, m_creature);
                         SetActionReadyStatus(action, false);
                         ResetCombatAction(MAULGAR_FEAR, urand(10000, 25000));
                         ResetCombatAction(MAULGAR_CHARGE, 2000);
@@ -196,9 +196,6 @@ struct Council_Base_AI : public CombatAI
             if (boss_high_king_maulgarAI* pMaulgarAI = dynamic_cast<boss_high_king_maulgarAI*>(pMaulgar->AI()))
                 pMaulgarAI->EventCouncilDeath();
         }
-
-        // Set data to Special on Death
-        m_instance->SetData(TYPE_MAULGAR_EVENT, SPECIAL);
     }
 };
 

--- a/src/game/AI/ScriptDevAI/scripts/outland/gruuls_lair/gruuls_lair.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/gruuls_lair/gruuls_lair.cpp
@@ -76,18 +76,7 @@ void instance_gruuls_lair::SetData(uint32 uiType, uint32 uiData)
 {
     switch (uiType)
     {
-        case TYPE_MAULGAR_EVENT:
-            if (uiData == SPECIAL)
-            {
-                ++m_uiCouncilMembersDied;
-
-                if (m_uiCouncilMembersDied == MAX_COUNCIL)
-                    SetData(TYPE_MAULGAR_EVENT, DONE);
-                // Don't store special data
-                break;
-            }
-            if (uiData == FAIL)
-                m_uiCouncilMembersDied = 0;
+        case TYPE_MAULGAR_EVENT:            
             if (uiData == DONE)
                 DoUseDoorOrButton(GO_PORT_GRONN_1);
             m_auiEncounter[uiType] = uiData;


### PR DESCRIPTION
… is dead

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
On tbcc it was possible to cheese this fight with just killing maulgar and not his adds. you still get loot and the door to gruul 
https://www.youtube.com/watch?v=hEOCBzTiZrA
On this video you can see that the door is open after maulgar is dead

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
