### PR TITLE
SHH - rewrite gauntlet event using new systems

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.cpp
@@ -306,15 +306,7 @@ static float gauntletSpawnCoords[1][3] =
 
 static float zealotSpawnCoords[1][3] =
 {
-    {519.107f, 273.546f, 1.916f}, // (waves)
-};
-
-static float zealotWaypoints[4][3] =
-{
-    {518.681f, 291.375f, 1.923f}, // 1
-    {504.559f, 315.952f, 1.942f}, // 2
-    {482.445f, 315.779f, 1.939f}, // 3
-    {352.104f, 315.725f, 3.139f}, // 4
+    {520.062f, 255.486f, 2.033f}, // (waves)
 };
 
 void instance_shattered_halls::GauntletReset()
@@ -341,8 +333,10 @@ void instance_shattered_halls::DoSummonSHZealot()
 {
     if (Creature* pAdd = WorldObject::SummonCreature(TempSpawnSettings(nullptr, NPC_SHATTERED_HAND_ZEALOT, zealotSpawnCoords[0][0], zealotSpawnCoords[0][1], zealotSpawnCoords[0][2], 0.0f, TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 150000, true, true), instance))
     {
-        pAdd->GetMotionMaster()->MovePoint(0, zealotWaypoints[0][0], zealotWaypoints[0][1], zealotWaypoints[0][2]);
+        pAdd->GetMotionMaster()->MoveWaypoint(1, 0, 2000, 0, FORCED_MOVEMENT_RUN);
         pAdd->HandleEmoteState(EMOTE_STATE_READY1H);
+        pAdd->SetCanCallForAssistance(false);
+        pAdd->SetCanCheckForHelp(false);
     }
 }
 

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.cpp
@@ -304,11 +304,6 @@ static float gauntletSpawnCoords[1][3] =
     { 409.848f, 315.385f, 1.921f}
 };
 
-static float scoutCoords[1][3] =
-{
-    {494.015f, 316.213f, 1.945f}
-};
-
 static float zealotSpawnCoords[3][3] =
 {
     {519.107f, 273.546f, 1.916f}, // (waves)
@@ -733,9 +728,9 @@ struct npc_Shattered_Hand_Scout : public ScriptedAI
     void DoStartRunning()
     {
         m_bRunning = true;
-        m_creature->SetWalk(false);
         m_creature->AI()->SetCombatMovement(false);
-        m_creature->GetMotionMaster()->MovePoint(0, scoutCoords[0][0], scoutCoords[0][1], scoutCoords[0][2]);
+        m_creature->SetInCombatWithZone();
+        m_creature->GetMotionMaster()->MoveWaypoint(1, 0, 0, 0, FORCED_MOVEMENT_RUN);
         CreatureList guards;
         GetCreatureListWithEntryInGrid(guards, m_creature, NPC_SHATTERED_HAND_ZEALOT, 15.f);
         for (Creature* creature : guards)
@@ -759,11 +754,11 @@ struct npc_Shattered_Hand_Scout : public ScriptedAI
 
     void MovementInform(uint32 movementType, uint32 data) override
     {
-        if (movementType == POINT_MOTION_TYPE && m_creature->IsAlive())
+        if (movementType == WAYPOINT_MOTION_TYPE && m_creature->IsAlive())
         {
             switch (data)
             {
-                case 0:
+                case 4:
                     DoZealotsEmoteReady();
 
                     m_creature->GetMap()->GetInstanceData()->SetData(TYPE_GAUNTLET, IN_PROGRESS);

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.cpp
@@ -299,11 +299,6 @@ bool instance_shattered_halls::CheckConditionCriteriaMeet(Player const* player, 
     return false;
 }
 
-static float gauntletSpawnCoords[1][3] =
-{
-    { 409.848f, 315.385f, 1.921f}
-};
-
 static float zealotSpawnCoords[1][3] =
 {
     {520.062f, 255.486f, 2.033f}, // (waves)
@@ -564,8 +559,7 @@ void instance_shattered_halls::DoCastGroupDebuff(uint32 spellId)
 struct npc_shattered_hands_zealotAI : public CreatureEventAI
 {
     npc_shattered_hands_zealotAI(Creature* creature) : CreatureEventAI(creature), m_instance(static_cast<ScriptedInstance*>(creature->GetInstanceData()))
-    {
-    
+    {    
     }
 
     ScriptedInstance* m_instance;
@@ -579,20 +573,18 @@ struct npc_shattered_hands_zealotAI : public CreatureEventAI
                 case 2:
                     if (m_creature->GetMotionMaster()->GetPathId() == 1)
                     {
-                        m_creature->SetInCombatWithZone();
-                        m_creature->AI()->AttackClosestEnemy();
+                        if (m_instance && m_creature->GetHealth() > 0)
+                    
+                        {
+                            m_creature->SetInCombatWithZone();
+                            if (!m_creature->IsInCombat())
+                                m_instance->SetData(TYPE_GAUNTLET, FAIL);
+                            else
+                                m_creature->AI()->AttackClosestEnemy();
+                        }
                     }
                     break;
                 default:
-                    m_creature->GetMotionMaster()->MoveIdle();
-                    if (m_instance && m_creature->GetHealth() > 0)
-                    {
-                        m_creature->SetInCombatWithZone();
-                        if (!m_creature->IsInCombat())
-                            m_instance->SetData(TYPE_GAUNTLET, FAIL);
-                        else
-                            m_creature->AI()->AttackClosestEnemy();
-                    }
                     break;
             }
         }        

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.cpp
@@ -574,13 +574,16 @@ struct npc_shattered_hands_zealotAI : public CreatureEventAI
 
     void MovementInform(uint32 motionType, uint32 data) override
     {
-        if (motionType == POINT_MOTION_TYPE) // sanity check
+        if (motionType == WAYPOINT_MOTION_TYPE) // sanity check
         {
             switch (data)
             {                
-                case 99:
-                    m_creature->SetFacingTo(-2.8f);
-                    m_creature->GetMotionMaster()->MoveIdle();
+                case 2:
+                    if (m_creature->GetMotionMaster()->GetPathId() == 1)
+                    {
+                        m_creature->SetInCombatWithZone();
+                        m_creature->AI()->AttackClosestEnemy();
+                    }
                     break;
                 default:
                     m_creature->GetMotionMaster()->MoveIdle();

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.cpp
@@ -730,14 +730,7 @@ struct npc_Shattered_Hand_Scout : public ScriptedAI
         m_bRunning = true;
         m_creature->AI()->SetCombatMovement(false);
         m_creature->SetInCombatWithZone();
-        m_creature->GetMotionMaster()->MoveWaypoint(1, 0, 0, 0, FORCED_MOVEMENT_RUN);
-        CreatureList guards;
-        GetCreatureListWithEntryInGrid(guards, m_creature, NPC_SHATTERED_HAND_ZEALOT, 15.f);
-        for (Creature* creature : guards)
-        {
-            creature->SetInCombatWithZone();
-            creature->AI()->AttackClosestEnemy();
-        }
+        m_creature->GetMotionMaster()->MoveWaypoint(1, 0, 0, 0, FORCED_MOVEMENT_RUN);       
         DoScriptText(SCOUT_AGGRO_YELL, m_creature);
     }
 

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.h
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.h
@@ -72,6 +72,8 @@ enum
     NPC_HEARTHEN_GUARD          = 17621,
     NPC_SHARPSHOOTER_GUARD      = 17622,
     NPC_REAVER_GUARD            = 17623,
+
+    WORLD_STATE_CUSTOM_SPAWN_WAVES = 5400004,
 };
 
 struct SpawnLocation

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.h
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/shattered_halls/shattered_halls.h
@@ -122,8 +122,6 @@ class instance_shattered_halls : public ScriptedInstance
 
         void DoInitialGets();
 
-        void DoSummonInitialWave();
-
         void DoSummonSHZealot();
 
         void DoBeginArcherAttack(bool leftOrRight);
@@ -144,9 +142,9 @@ class instance_shattered_halls : public ScriptedInstance
         uint8 m_executionStage;
         uint8 m_prisonersLeft;
 
-        GuidVector m_gauntletPermanentGuids;
+        std::vector<uint32> m_gauntletPermanentGuids;
         GuidVector m_gauntletTemporaryGuids;
-        GuidVector m_gauntletBossGuids;
+        std::vector<uint32>  m_gauntletBossGuids;
 
         std::vector<std::pair<ObjectGuid, uint32>> m_blazeTimers;
 


### PR DESCRIPTION
## 🍰 Pullrequest
This rewrites the Gauntlet of Fire event in shattered halls. Putting most of the things into the database, like waypoints, spawns.
https://github.com/cmangos/tbc-db/pull/1160

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->


### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->

- [x] Respawn of already killed npcs on gauntlet fail isnt working corretly (respawning scout and his 3 zealots for example)
- [x] The 8 spawned Zealots from frist wave respawn on fail even if worldstate gets switched to 0 again.
