### PR TITLE
SHH - Netherkurse intro

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -69,6 +69,7 @@ INSERT INTO scripted_areatrigger VALUES
 (4115,'at_naxxramas'),
 (4156,'at_naxxramas'),
 (4288,'at_dark_portal'),
+(4347,'at_shh_netherkurse'),
 (4422,'at_area_52'),
 (4466,'at_area_52'),
 (4471,'at_area_52'),
@@ -798,6 +799,7 @@ UPDATE creature_template SET ScriptName='npc_blade_dance_target' WHERE entry IN(
 UPDATE creature_template SET ScriptName='npc_shattered_hand_zealot' WHERE entry=17462;
 UPDATE creature_template SET ScriptName='npc_shattered_hand_scout' WHERE entry=17693;
 UPDATE instance_template SET ScriptName='instance_shattered_halls' WHERE map=540;
+UPDATE gameobject_template SET ScriptName='go_netherkurse_door' WHERE entry=182539;
 
 /* MAGTHERIDON'S LAIR */
 UPDATE instance_template SET ScriptName='instance_magtheridons_lair' WHERE map=544;

--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -422,6 +422,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (40887,'spell_assist_bt'),
 (40892,'spell_fixate_bt'),
 (30745,'spell_target_fissures'),
+(30741,'spell_death_coil'),
 (34852,'spell_call_of_the_falcon'),
 (39581,'spell_storm_blink'),
 (34630,'spell_scrap_reaver_spell'),


### PR DESCRIPTION
## 🍰 Pullrequest
This partly fixes the intro RP from boss Netherkurse.
- Intro gets activated on door use, or on areatrigger 4347
- Peons should run to their home position when DeathCoil aura ends
- 4 seconds after the 4th add dies, netherkurse will join the fight

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->

- [x] SPELL_SHADOW_FISSURE should also deal damage to Peons
- [x] DoYellForPeonAggro needs a ~5 second cooldown so it doesnt get spammed when all 4 peons aggro at same time
- [x] DoYellForPeonDeath same as aggro
