### PR TITLE
Fix .npc spawntime gm command

### DIFF
--- a/src/game/Chat/Level2.cpp
+++ b/src/game/Chat/Level2.cpp
@@ -2248,7 +2248,7 @@ bool ChatHandler::HandleNpcSpawnTimeCommand(char* args)
 
     uint32 u_guidlow = pCreature->GetGUIDLow();
 
-    WorldDatabase.PExecuteLog("UPDATE creature SET spawntimesecs=%i WHERE guid=%u", stime, u_guidlow);
+    WorldDatabase.PExecuteLog("UPDATE creature SET spawntimesecsmin=%i, spawntimesecsmax=%i WHERE guid=%u", stime, u_guidlow);
     pCreature->SetRespawnDelay(stime);
     PSendSysMessage(LANG_COMMAND_SPAWNTIME, stime);
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Small change to the sql used to update spawntime
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- Did not find the issue in the open issues, noticed it on my server:
When using the `.npc spawntime XXX` gm command, the produced SQL is wrong (uses a missing field instead of existing ones, probably artifact).
The cmangos terminal produces following error:
`SQL ERROR: Unknown column 'spawntimesecs' in 'field list'`

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- build&compile code
- use  `.npc spawntime XXX` 
- see it work / confirm in database

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
