### PR TITLE
Fix bots not drinking or eating because of dirty movement flags after facing something

### DIFF
--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -192,8 +192,6 @@ void CreatureEventAI::InitAI()
         processMap(creatureEvent);
     }
 
-    if (m_creature->GetDbGuid() == 5026)
-        printf("");
     auto creatureEventsGuidItr = m_creature->GetMap()->GetMapDataContainer().GetCreatureEventGuidAIMap()->find(m_creature->GetDbGuid());
     if (creatureEventsGuidItr != m_creature->GetMap()->GetMapDataContainer().GetCreatureEventGuidAIMap()->end())
     {

--- a/src/game/Entities/MiscHandler.cpp
+++ b/src/game/Entities/MiscHandler.cpp
@@ -787,7 +787,7 @@ void WorldSession::HandleAreaTriggerOpcode(WorldPacket& recv_data)
         {
             std::string message = at->status_failed_text;
             sObjectMgr.GetAreaTriggerLocales(at->entry, GetSessionDbLocaleIndex(), &message);
-            SendAreaTriggerMessage(message.data());
+            SendAreaTriggerMessage("%s", message.data());
         }
         return;
     }

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -4647,7 +4647,7 @@ void Unit::SetFacingTo(float ori)
     init.Launch();
     // orientation change is in-place
     UpdateSplinePosition();
-    movespline->_Finalize();
+    DisableSpline();
 }
 
 void Unit::SetFacingToObject(WorldObject* object)
@@ -4661,7 +4661,7 @@ void Unit::SetFacingToObject(WorldObject* object)
     init.Launch();
     // orientation change is in-place
     UpdateSplinePosition();
-    movespline->_Finalize();
+    DisableSpline();
 }
 
 bool Unit::isInAccessablePlaceFor(Unit const* unit) const


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
I just debugged into the non-drinking/eating bots. The problem is that the spell is aborted, because the bot thinks it's moving all the time. You can see that by targeting your bot and calling ".debug moveflag" with gm permissions.
![image](https://github.com/cmangos/mangos-tbc/assets/1574004/5a7e2ed4-b0bf-4d96-a8f6-6630b4820e9a)
The flags are there, because MoveSplineInit::Launch() sets them, when it is called by [Unit::SetFacingTo](https://github.com/cmangos/mangos-tbc/blob/1789a95a27de389ce5ed771046db98c7d68592da/src/game/Entities/Unit.cpp#L4647) in the FollowMovementGenerator::_setOrientation call.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related? -->
- fixes #2830
- fixes #3309

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
- Log into game, add bot, make bot go out of mana or low on health
- Error: Bot spams chat, but does not drink or eat
- Apply fix provided here
- Solution: Bot drinks and eats as expected

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [x] None