### PR TITLE
fix: resist/miss channeled AOE spell cancel

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -4248,7 +4248,7 @@ void Spell::WriteSpellGoTargets(WorldPacket& data)
         if (ihit.effectHitMask == 0 && ihit.effectMask != 0) // No effect apply - all immuned add state
         {
             // possibly SPELL_MISS_IMMUNE2 for this??
-            if (IsChanneledSpell(m_spellInfo) && ihit.targetGUID == m_targets.getUnitTargetGuid()) // can happen due to DR
+            if (!IsAreaOfEffectSpell(m_spellInfo) && IsChanneledSpell(m_spellInfo) && ihit.targetGUID == m_targets.getUnitTargetGuid()) // can happen due to DR
             {
                 m_duration = 0;                              // cancel aura to avoid visual effect continue
                 ihit.effectDuration = 0;
@@ -4267,7 +4267,7 @@ void Spell::WriteSpellGoTargets(WorldPacket& data)
         }
         else
         {
-            if (IsChanneledSpell(m_spellInfo) && (ihit.missCondition == SPELL_MISS_RESIST || ihit.missCondition == SPELL_MISS_REFLECT))
+            if (!IsAreaOfEffectSpell(m_spellInfo) && IsChanneledSpell(m_spellInfo) && (ihit.missCondition == SPELL_MISS_RESIST || ihit.missCondition == SPELL_MISS_REFLECT))
             {
                 m_duration = 0;                              // cancel aura to avoid visual effect continue
                 ihit.effectDuration = 0;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Adds an additional check to the if clause that cancels casting a channeled spell when a target resists to exclude AOE spells.

### Proof
<!-- Link resources as proof -->
[Video showing AOE spell is no longer cancelled if any of the targets resist](https://streamable.com/mrf0v2) 
[Video showing non-AOE spell is still cancelled if the target resists](https://streamable.com/vhxe11)

### Issues
<!-- Which Issues does this fix, which are related? -->
- fixes [#3614](https://github.com/cmangos/issues/issues/3614)
- fixes [#3153](https://github.com/cmangos/issues/issues/3153)


### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
- Test1
Channel AOE a target that will resist 100%
- Test2
Channel non-AOE spell on a target that will resist 100%


### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Merge
