### PR TITLE
Spells: Ensure that SpellMods have the right No. of charges

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1107,7 +1107,7 @@ void Aura::HandleAddModifier(bool apply, bool Real)
             priority,
             // prevent expire spell mods with (charges > 0 && m_stackAmount > 1)
             // all this spell expected expire not at use but at spell proc event check
-            spellProto->StackAmount > 1 ? 0 : GetHolder()->GetAuraCharges());
+            spellProto->StackAmount < 1 ? 0 : GetHolder()->GetAuraCharges());
     }
 
     static_cast<Player*>(GetTarget())->AddSpellMod(m_spellmod, apply);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR ensures that spell mods get the right number of charges depending on AuraCharges, I guess?

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3648

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Learn the Clearcasting talent
- cast on enemies a lot
- see that clearcasting now properly decreases stack by stack

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Sanity check. This code was like this for 12 years and looks strange in general. I have no idea why this broke nothing sooner