### PR TITLE
Implementation of Autobroadcast & XP Rate Command

### DIFF
--- a/sql/custom/characters/xpBoost.sql
+++ b/sql/custom/characters/xpBoost.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS `experience_bracket_cap`;
+CREATE TABLE `experience_bracket_cap` (
+  `low` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Lower bracket bound',
+  `high` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Upper bracket bound',
+  `team` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Bracket team',
+  `value` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Bracket XP cap',
+  PRIMARY KEY (`low`,`high`,`team`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPACT COMMENT='XP System';
+
+DROP TABLE IF EXISTS `character_settings`;
+CREATE TABLE `character_settings` (
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Player GUID',
+  `id` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Setting ID',
+  `value` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Setting value',
+  PRIMARY KEY (`guid`,`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPACT COMMENT='Player System';

--- a/sql/custom/mangos/autobroadcast.sql
+++ b/sql/custom/mangos/autobroadcast.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS `autobroadcast`;
+CREATE TABLE IF NOT EXISTS `autobroadcast` (
+  `id` tinyint unsigned NOT NULL AUTO_INCREMENT,
+  `content` text,
+  `ratio` smallint unsigned NOT NULL DEFAULT '1',
+  PRIMARY KEY (`id`) USING BTREE
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb3;
+
+INSERT INTO tbcmangos.mangos_string
+(entry, content_default, content_loc1, content_loc2, content_loc3, content_loc4, content_loc5, content_loc6, content_loc7, content_loc8)
+VALUES(10000, '|cffff0000[Server Announce]:|r %s', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/sql/custom/mangos/xpcommand.sql
+++ b/sql/custom/mangos/xpcommand.sql
@@ -1,0 +1,1 @@
+INSERT INTO tbcmangos.command VALUES('xp', '0', 'Syntax: .xp #subcommand XP boost commands');

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -122,6 +122,14 @@ ChatCommand* ChatHandler::getCommandTable()
         { nullptr,          0,                  false, nullptr,                                        "", nullptr }
     };
 
+    static ChatCommand xpCommandTable[] =
+    {
+        { "set",            SEC_PLAYER,         true,  &ChatHandler::HandleXPCommandSet,               "", nullptr },
+        { "current",        SEC_PLAYER,         true,  &ChatHandler::HandleXPCommandCurrent,           "", nullptr },
+        { "available",      SEC_PLAYER,         true,  &ChatHandler::HandleXPCommandAvailable,         "", nullptr },
+        { nullptr,          0,                  false, nullptr,                                        "", nullptr }
+    };
+
     static ChatCommand banlistCommandTable[] =
     {
         { "account",        SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleBanListAccountCommand,      "", nullptr },
@@ -657,7 +665,8 @@ ChatCommand* ChatHandler::getCommandTable()
         { "locales_quest",               SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadLocalesQuestCommand,            "", nullptr },
         { "locales_questgiver_greeting", SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadQuestgiverGreetingLocalesCommand, "", nullptr },
         { "locales_trainer_greeting",    SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadLocalesTrainerGreetingCommand,  "", nullptr },
-        { "locales_areatrigger_teleport", SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadLocalesAreaTriggerCommand, "", nullptr },
+        { "locales_areatrigger_teleport", SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadLocalesAreaTriggerCommand, "",    nullptr },
+        { "autobroadcast",               SEC_ADMINISTRATOR, true,   &ChatHandler::HandleReloadAutoBroadcastCommand, "",         nullptr }, //Autobroadcast Module
         { "mail_level_reward",           SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadMailLevelRewardCommand,         "", nullptr },
         { "mail_loot_template",          SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadLootTemplatesMailCommand,       "", nullptr },
         { "mangos_string",               SEC_ADMINISTRATOR, true,  &ChatHandler::HandleReloadMangosStringCommand,            "", nullptr },
@@ -1014,6 +1023,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "additemset",     SEC_ADMINISTRATOR,  false, &ChatHandler::HandleAddItemSetCommand,          "", nullptr },
         { "bank",           SEC_ADMINISTRATOR,  false, &ChatHandler::HandleBankCommand,                "", nullptr },
         { "wchange",        SEC_ADMINISTRATOR,  false, &ChatHandler::HandleChangeWeatherCommand,       "", nullptr },
+        { "xp",             SEC_PLAYER,         false, nullptr,                                         "", xpCommandTable }, //Induvidial XP Module
         { "testing",        SEC_GAMEMASTER,     false, nullptr,                                        "", testingCommandTable },
         { "ticket",         SEC_GAMEMASTER,     false, nullptr,                                        "", ticketCommandTable   },
         { "tickets",        SEC_GAMEMASTER,     false, nullptr,                                        "", ticketsCommandTable  },

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -559,6 +559,7 @@ class ChatHandler
         bool HandleReloadGossipMenuCommand(char* args);
         bool HandleReloadQuestgiverGreetingCommand(char* args);
         bool HandleReloadTrainerGreetingCommand(char* args);
+        bool HandleReloadAutoBroadcastCommand(char* args);
         bool HandleReloadGOQuestRelationsCommand(char* args);
         bool HandleReloadGOQuestInvRelationsCommand(char* args);
         bool HandleReloadItemEnchantementsCommand(char* args);
@@ -636,6 +637,11 @@ class ChatHandler
         bool HandleSendMassMailCommand(char* args);
         bool HandleSendMassMoneyCommand(char* args);
 
+        // Custom
+        bool HandleXPCommandSet(char* args);
+        bool HandleXPCommandCurrent(char* args);
+        bool HandleXPCommandAvailable(char* args);
+        // Custom
         bool HandleServerCorpsesCommand(char* args);
         bool HandleServerExitCommand(char* args);
         bool HandleServerIdleRestartCommand(char* args);

--- a/src/game/Chat/Level0.cpp
+++ b/src/game/Chat/Level0.cpp
@@ -305,3 +305,55 @@ bool ChatHandler::HandleWhisperRestrictionCommand(char* args)
 
     return true;
 }
+// Custom
+bool ChatHandler::HandleXPCommandSet(char* args)
+{
+    Player* player = m_session->GetPlayer();
+
+    uint32 modifier;
+    if (!ExtractOptUInt32(&args, modifier, 10))
+    {
+        PSendSysMessage("XP modifier not a valid number.");
+        return false;
+    }
+
+    uint32 cap = sWorld.GetExperienceCapForLevel(player->GetLevel(), player->GetTeam());
+    if (modifier && modifier <= cap)
+    {
+        player->SetPlayerXPModifier(modifier);
+        PSendSysMessage("You have set XP modifier to %u.", modifier);
+    }
+    else
+    {
+        PSendSysMessage("XP modifier not valid. Permitted values: 1 - %u.", cap);
+        return false;
+    }
+
+    return true;
+}
+
+bool ChatHandler::HandleXPCommandCurrent(char* /*args*/)
+{
+    Player* player = m_session->GetPlayer();
+
+    PSendSysMessage("Current XP modifier: %u.", player->GetPlayerXPModifier());
+
+    return true;
+}
+
+bool ChatHandler::HandleXPCommandAvailable(char* args)
+{
+    Player* player = m_session->GetPlayer();
+
+    PSendSysMessage("Current available XP modifiers:");
+    std::array<uint32, 255> caps;
+    sWorld.GetExperienceCapArray(player->GetTeam(), caps);
+
+    for (uint32 i = 1; i < MAX_LEVEL_TBC; i += 10)
+    {
+        PSendSysMessage("%u: %u, %u: %u, %u: %u, %u: %u, %u: %u, %u: %u, %u: %u, %u: %u, %u: %u, %u: %u",
+            i, caps[i], i + 1, caps[i + 1], i + 2, caps[i + 2], i + 3, caps[i + 3], i + 4, caps[i + 4], i + 5, caps[i + 5], i + 6, caps[i + 6], i + 7, caps[i + 7], i + 8, caps[i + 8], i + 9, caps[i + 9]);
+    }
+
+    return true;
+}

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -358,6 +358,14 @@ bool ChatHandler::HandleReloadCommandCommand(char* /*args*/)
     SendGlobalSysMessage("DB table `command` will be reloaded at next chat command use.");
     return true;
 }
+    // Handle Reload for Autobroadcast.
+bool ChatHandler::HandleReloadAutoBroadcastCommand(char* /*args*/)
+{
+    sLog.outString("Re-Loading broadcast strings...");
+    sWorld.LoadBroadcastStrings();
+    SendGlobalSysMessage("Broadcast strings reloaded.");
+    return true;
+}
 
 bool ChatHandler::HandleReloadCreatureQuestRelationsCommand(char* /*args*/)
 {

--- a/src/game/Entities/CharacterHandler.cpp
+++ b/src/game/Entities/CharacterHandler.cpp
@@ -830,6 +830,7 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
 
     if (!pCurrChar->IsStandState() && !pCurrChar->IsStunned())
         pCurrChar->SetStandState(UNIT_STAND_STATE_STAND);
+        pCurrChar->SendXPRateToPlayer();
 
     m_playerLoading = false;
     delete holder;

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -656,6 +656,7 @@ Player::Player(WorldSession* session): Unit(), m_taxiTracker(*this), m_mover(thi
 
     m_lastDbGuid = 0;
     m_lastGameObject = false;
+    m_experienceModifier = 1; // Defaults to 1x XP rates, Available rates are stated in database
 }
 
 Player::~Player()
@@ -2684,6 +2685,8 @@ void Player::GiveXP(uint32 xp, Creature* victim, float groupRate)
     if (level >= GetMaxAttainableLevel())
         return;
 
+    xp *= m_experienceModifier;
+
     // handle SPELL_AURA_MOD_XP_PCT auras
     Unit::AuraList const& ModXPPctAuras = GetAurasByType(SPELL_AURA_MOD_XP_PCT);
     for (auto ModXPPctAura : ModXPPctAuras)
@@ -2798,7 +2801,15 @@ void Player::GiveLevel(uint32 level)
     // resend quests status directly
     GetSession()->SetCurrentPlayerLevel(level);
     SendQuestGiverStatusMultiple();
+
+    uint32 cap = sWorld.GetExperienceCapForLevel(GetLevel(), m_team);
+    if (cap < m_experienceModifier)
+    {
+        SetPlayerXPModifier(cap);
+        SendXPRateToPlayer();
+    }
 }
+
 
 void Player::UpdateFreeTalentPoints(bool resetIfNeed)
 {
@@ -15539,6 +15550,25 @@ bool Player::LoadFromDB(ObjectGuid guid, SqlQueryHolder* holder)
 
     _LoadCreatedInstanceTimers();
 
+        // voa only custom code
+    std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT value FROM character_settings WHERE guid = %u AND id = %u", GetGUIDLow(), PLAYER_SETTING_XP_MODIFIER);
+    if (result)
+    {
+        Field* fields = result->Fetch();
+        m_experienceModifier = fields[0].GetUInt32();
+        uint32 cap = sWorld.GetExperienceCapForLevel(GetLevel(), m_team);
+        if (m_experienceModifier > cap)
+        {
+            m_experienceModifier = cap;
+            CharacterDatabase.PExecute("UPDATE character_settings SET value = '%u' WHERE guid = '%u' AND id = '%u'", m_experienceModifier, GetGUIDLow(), PLAYER_SETTING_XP_MODIFIER);
+        }
+    }
+    else
+    {
+        m_experienceModifier = 1;
+    }
+    // voa only custom code end
+
     return true;
 }
 
@@ -15861,6 +15891,7 @@ void Player::_LoadInventory(std::unique_ptr<QueryResult> queryResult, uint32 tim
     // if(IsAlive())
     _ApplyAllItemMods();
 }
+
 
 void Player::_LoadItemLoot(std::unique_ptr<QueryResult> queryResult)
 {
@@ -16780,6 +16811,7 @@ void Player::SaveToDB()
     _SaveNewInstanceIdTimer();
     m_reputationMgr.SaveToDB();
     GetSession()->SaveTutorialsData();                      // changed only while character in game
+    _SaveXPModifier();
 
     CharacterDatabase.CommitTransaction();
 
@@ -18555,6 +18587,33 @@ void Player::OnTaxiFlightRouteProgress(const TaxiPathNodeEntry* node, const Taxi
             StartEvents_Event(GetMap(), eventid, this, this, !arrival);
         }
     }
+}
+
+void Player::_SaveXPModifier()
+{
+    std::unique_ptr<QueryResult> result = CharacterDatabase.PQuery("SELECT value FROM character_settings WHERE guid = %u AND id = %u", GetGUIDLow(), PLAYER_SETTING_XP_MODIFIER);
+
+    if (result)
+    {
+        Field* fields = result->Fetch();
+        uint32 modifier = fields[0].GetUInt32();
+
+        if (modifier != m_experienceModifier)
+            CharacterDatabase.PExecute("UPDATE character_settings SET value = '%u' WHERE guid = '%u' AND id = '%u'", m_experienceModifier, GetGUIDLow(), PLAYER_SETTING_XP_MODIFIER);
+    }
+    else
+    {
+        CharacterDatabase.PExecute("INSERT INTO character_settings(guid,id,value) VALUES('%u','%u','%u')", GetGUIDLow(), PLAYER_SETTING_XP_MODIFIER, m_experienceModifier);
+    }
+}
+
+void Player::SendXPRateToPlayer()
+{
+    std::string xpLine = "Current XP rate:" + std::to_string(m_experienceModifier) + "\n";
+    WorldPacket data;
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_SYSTEM, xpLine.data(), LANG_UNIVERSAL, CHAT_TAG_NONE, GetObjectGuid());
+    if (WorldSession* session = GetSession())
+        session->SendPacket(data);
 }
 
 void Player::InitDataForForm(bool reapplyMods)
@@ -22123,6 +22182,7 @@ bool Player::GetsRecruitAFriendBonus()
     }
     return false;
 }
+
 
 void Player::SetSpellModSpell(Spell* spell)
 {

--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -817,6 +817,11 @@ enum PlayerRestState
     REST_STATE_RAF_LINKED       = 0x04                      // Exact use unknown
 };
 
+enum PlayerSettings
+{
+    PLAYER_SETTING_XP_MODIFIER = 1,
+};
+
 class PlayerTaxi
 {
     public:
@@ -2250,7 +2255,10 @@ class Player : public Unit
         bool HasTitle(CharTitlesEntry const* title) const { return HasTitle(title->bit_index); }
         void SetTitle(uint32 titleId, bool lost = false);
         void SetTitle(CharTitlesEntry const* title, bool lost = false, bool send = true);
-
+        uint32 GetPlayerXPModifier() { return m_experienceModifier; }
+        void SetPlayerXPModifier(uint32 modifier) { m_experienceModifier = modifier; }
+        void _SaveXPModifier();
+        void SendXPRateToPlayer();
         void SendMessageToPlayer(std::string const& message) const; // debugging purposes
 
 #ifdef BUILD_DEPRECATED_PLAYERBOT
@@ -2394,6 +2402,7 @@ class Player : public Unit
         void _SaveSpells();
         void _SaveBGData();
         void _SaveStats();
+        uint32 m_experienceModifier; // XP Boost
 
         /*********************************************************/
         /***              ENVIRONMENTAL SYSTEM                 ***/

--- a/src/game/Tools/Language.h
+++ b/src/game/Tools/Language.h
@@ -1095,6 +1095,7 @@ enum MangosStrings
 
     // Use for not-in-official-sources patches
     //                                    10000-10999
+    LANG_AUTOBROADCAST = 10000, /* |cffff0000[Server Announce]:|r%s */
 
     // Use for custom patches             11000-11999
 

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -260,6 +260,7 @@ AddonChannel = 1
 CleanCharacterDB = 1
 MaxWhoListReturns = 49
 AccountData = 0
+AutoBroadcast = 1200
 
 ###################################################################################################################
 # SERVER LOGGING


### PR DESCRIPTION
## 🍰 Pullrequest
Added .xp command to the core with options to choose xp rates, rates are set in the database with the included sql in custom/xpBoost.sql

### Proof
[Images](https://imgur.com/a/ek5FsvT)

### Issues
None, works like a charm

### How2Test
Autobroadcast:
Import custom/mangos/autobroadcast.sql to your world database
Add any text you want in autobroadcast table in database.
Enable with a new line in config.

**AutoBroadcast = 60** Where 60 equals seconds where the autobroadcast should post a message in chat.


XP Part:
Import custom/mangos/xpcommand.sql to your world database
Import custom/character/xpBoost.sql to your character table. 
Find experience_brakcet_cap, add 2 new lines with the desired information
Min/Max - Equals what level this rate will be available to
Team = 0 Alliance - 1 Horde
Value = Maximum XP Rate

### Todo / Checklist
