### PR TITLE
Add EVENT_T_OOC_NO_LOS

### DIFF
--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -103,6 +103,7 @@ Some events such as EVENT_T_AGGRO, EVENT_T_DEATH, EVENT_T_SPAWNED, and EVENT_T_E
 35  EVENT_T_DEATH_PREVENTED             NONE                                                                    Expires when Death prevention kicks in
 36  EVENT_T_TARGET_NOT_REACHABLE        NONE                                                                    Expires when target is not reachable
 37  EVENT_T_SPELL_CAST                  SpellID                                                                 Expires when spell list casts spell Id successfully
+38  EVENT_T_OOC_LOS                     NoHostile, MaxRange, RepeatMin, RepeatMax, PlayerOnly, ConditionId      Expires when a unit moves within distance (MaxAllowedRange) of the NPC. If (Param1) is 0 it will expire only when unit is hostile, If (Param1) is 1 it will expire only when unit is friendly. This depends generally on faction relations. Will repeat every (Param3) and (Param4). Does NOT expire when the NPC is in combat.
 
 =========================================
 Action Types
@@ -569,6 +570,18 @@ SPELL_SCHOOL_SHADOW = 5 ==> 32
 SPELL_SCHOOL_ARCANE = 6 ==> 64
 Use These Bitmask Values For Schoolmask (Param2) or Any Combinations Of These School Bitmasks for Multiple Schools.
 
+---------------------
+38 = EVENT_T_OOC_NO_LOS:
+---------------------
+Parameter 1: NoHostile       - This will expire if Unit are hostile. If Param1=1 it will only expire if Unit are not Hostile(generally determined by faction)
+Parameter 2: MaxAllowedRange - Expires when a Unit moves within this distance to creature
+Parameter 3: RepeatMin       - Minimum Time used to calculate Random Repeat Expire
+Parameter 4: RepeatMax       - Maximum Time used to calculate Random Repeat Expire
+Parameter 5: PlayerOnly      - Expires only when a Player moves within distance
+Parameter 6: ConditionId     - Expires only when condition is fulfilled. Only use when other options are not usable since it is a bit more impactful performance wise!!!
+
+OUT OF COMBAT ONLY
+This Event is commonly used for NPC's who do something or say something to you when you walk past them Out of Combat. Has no LoS Check
 =========================================
 Action Types
 =========================================

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -77,6 +77,7 @@ enum EventAI_Type
     EVENT_T_DEATH_PREVENTED         = 35,                   //
     EVENT_T_TARGET_NOT_REACHABLE    = 36,                   //
     EVENT_T_SPELL_CAST              = 37,                   // SpellId
+    EVENT_T_OOC_NO_LOS              = 38,                   // NoHostile, MaxRange, RepeatMin, RepeatMax, PlayerOnly, ConditionId
 
     EVENT_T_END,
 };
@@ -794,6 +795,16 @@ struct CreatureEventAI_Event
         {
             uint32 spellId;
         } spellCast;
+        // EVENT_T_OOC_NO_LOS                                      = 38
+        struct
+        {
+            uint32 noHostile;
+            uint32 maxRange;
+            uint32 repeatMin;
+            uint32 repeatMax;
+            uint32 playerOnly;
+            uint32 conditionId;
+        } ooc_no_los;
         // RAW
         struct
         {

--- a/src/game/AI/EventAI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/EventAI/CreatureEventAIMgr.cpp
@@ -149,6 +149,7 @@ bool IsValidTargetType(EventAI_Type eventType, EventAI_ActionType actionType, ui
                 case EVENT_T_TIMER_OOC:
                 case EVENT_T_OOC_LOS:
                 case EVENT_T_REACHED_HOME:
+                case EVENT_T_OOC_NO_LOS:
                     sLog.outErrorEventAI("Event %u Action%u uses incorrect Target type %u for event-type %u (cannot be used OOC)", eventId, action, targetType, eventType);
                     return false;
                 case EVENT_T_TIMER_GENERIC:
@@ -172,6 +173,7 @@ bool IsValidTargetType(EventAI_Type eventType, EventAI_ActionType actionType, ui
                 case EVENT_T_RECEIVE_EMOTE:
                 case EVENT_T_RECEIVE_AI_EVENT:
                 case EVENT_T_SPELLHIT_TARGET:
+                case EVENT_T_OOC_NO_LOS:
                     return true;
                 default:
                     sLog.outErrorEventAI("Event %u Action%u uses incorrect Target type %u for event-type %u", eventId, action, targetType, eventType);
@@ -557,6 +559,16 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                     }
                     break;
                 }
+                case EVENT_T_OOC_NO_LOS:
+                    if (temp.ooc_los.conditionId && !sConditionStorage.LookupEntry<ConditionEntry>(temp.ooc_los.conditionId))
+                    {
+                        sLog.outErrorDb("Creature %d has `ConditionId` = %u but does not exist. Setting ConditionId to 0 for event %u.", keyField, temp.ooc_los.conditionId, eventId);
+                        temp.ooc_los.conditionId = 0;
+                    }
+
+                    if (temp.ooc_los.repeatMax < temp.ooc_los.repeatMin)
+                        sLog.outErrorEventAI("Creature %d are using repeatable event(%u) with param4 < param3 (RepeatMax < RepeatMin). Event will never repeat.", keyField, eventId);
+                    break;
                 default:
                     sLog.outErrorEventAI("Creature %d using not checked at load event (%u) in event %u. Need check code update?", keyField, temp.event_id, eventId);
                     break;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
We currently have EventType = 10 EVENT_T_OOC_LOS which gets triggered when a Player moves in range of an creature. This Event Type also has an LoS check (https://github.com/cmangos/mangos-tbc/blob/master/src/game/AI/EventAI/CreatureEventAI.cpp#L1686) before processing EventActions.
Because every EventParam (1-5) is taken in this EventType i had to create a new one without breaking old code.

### Proof
<!-- Link resources as proof -->
The Botanica dungeon has RP-Intros for most of the Bloodwarden Protectors, they start moving when a player is in range of ~60 yards to them. With current EventType 10 this will only get triggered when player is in LoS.

https://youtu.be/MZUtPDvZpVs 
https://youtu.be/dIzmjPzoN_M 
https://youtu.be/P2kDansvPsU 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
