### PR TITLE
Playerbots: Fix build error caused by iterator refactor

### DIFF
--- a/src/game/Chat/ChatHandler.cpp
+++ b/src/game/Chat/ChatHandler.cpp
@@ -390,14 +390,13 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recv_data)
             PlayerbotMgr* mgr = GetPlayer()->GetPlayerbotMgr();
             if (mgr && GetPlayer()->GetGuildId())
             {
-                for (PlayerBotMap::const_iterator it = mgr->GetPlayerBotsBegin(); it != mgr->GetPlayerBotsEnd(); ++it)
+                mgr->ForEachPlayerbot([&](Player* const bot)
                 {
-                    Player* const bot = it->second;
                     if (bot->GetGuildId() == GetPlayer()->GetGuildId())
                     {
                         bot->GetPlayerbotAI()->HandleCommand(type, msg, *GetPlayer(), lang);
                     }
-                }
+                });
             }
 
             sRandomPlayerbotMgr.HandleCommand(type, msg, *_player, "", GetPlayer()->GetTeam(), lang);


### PR DESCRIPTION
## 🍰 Pullrequest
Recently, `GetPlayerBotsBegin()` and `GetPlayerBotsEnd()` were [removed from the playerbots repo](https://github.com/cmangos/playerbots/commit/d012d24962bd3c3df552e26c78f3fb09e80c8850) in favor of a new function called `ForEachPlayerbot()`. `ChatHandler.cpp` seems to have been the only file that was using these old functions, everything builds fine with this fix.

### Issues
Building `mangos-tbc` master without this change causes a build error if playerbots are enabled.

### Todo / Checklist
I'm not familiar with the codebase or this particular refactor, so I'd appreciate if somebody could review it and make sure everything is idiomatic, doesn't set the world on fire, etc.