### PR TITLE
Botanica - Laj changes

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -655,7 +655,8 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (28695,'spell_gameobject_call_for_help_on_usage'), -- Herb Gathering (Master)
 (29354,'spell_gameobject_call_for_help_on_usage'), -- Mining (Master)
 (30434,'spell_gameobject_call_for_help_on_usage'), -- Elemental Seaforium Charge
-(34799,'spell_arcane_devastation');
+(34799,'spell_arcane_devastation'),
+(34700,'spell_allergic_reaction');
 
 -- Wotlk
 INSERT INTO spell_scripts(Id, ScriptName) VALUES

--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -655,8 +655,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (28695,'spell_gameobject_call_for_help_on_usage'), -- Herb Gathering (Master)
 (29354,'spell_gameobject_call_for_help_on_usage'), -- Mining (Master)
 (30434,'spell_gameobject_call_for_help_on_usage'), -- Elemental Seaforium Charge
-(34799,'spell_arcane_devastation'),
-(34700,'spell_allergic_reaction');
+(34799,'spell_arcane_devastation');
 
 -- Wotlk
 INSERT INTO spell_scripts(Id, ScriptName) VALUES

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/botanica/boss_laj.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/botanica/boss_laj.cpp
@@ -172,26 +172,10 @@ struct boss_lajAI : public CombatAI
     }
 };
 
-struct AllergicReaction : public AuraScript
-{
-    bool OnCheckProc(Aura* /*aura*/, ProcExecutionData& data) const override
-    {
-        // Player with aura 34697 can proc Aura 34700 on other Players
-        // Aura 34700 should only proc on players 
-        if (data.target && !data.target->IsPlayer())
-            return false;
-
-        return true;
-    }
-};
-
-
 void AddSC_boss_laj()
 {
     Script* pNewScript = new Script;
     pNewScript->Name = "boss_laj";
     pNewScript->GetAI = &GetNewAIInstance<boss_lajAI>;
     pNewScript->RegisterSelf();
-
-    RegisterSpellScript<AllergicReaction>("spell_allergic_reaction");
 }

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/botanica/boss_laj.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/botanica/boss_laj.cpp
@@ -170,10 +170,26 @@ struct boss_lajAI : public CombatAI
     }
 };
 
+struct AllergicReaction : public AuraScript
+{
+    bool OnCheckProc(Aura* /*aura*/, ProcExecutionData& data) const override
+    {
+        // Player with aura 34697 can proc Aura 34700 on other Players
+        // Aura 34700 should only proc on players 
+        if (data.target && !data.target->IsPlayer())
+            return false;
+
+        return true;
+    }
+};
+
+
 void AddSC_boss_laj()
 {
     Script* pNewScript = new Script;
     pNewScript->Name = "boss_laj";
     pNewScript->GetAI = &GetNewAIInstance<boss_lajAI>;
     pNewScript->RegisterSelf();
+
+    RegisterSpellScript<AllergicReaction>("spell_allergic_reaction");
 }

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/botanica/boss_laj.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/botanica/boss_laj.cpp
@@ -80,6 +80,7 @@ struct boss_lajAI : public CombatAI
         SetCombatMovement(true);
         SetCombatScriptStatus(false);
         DespawnGuids(m_spawns);
+        CombatAI::Reset();
     }
 
     void EnterEvadeMode() override
@@ -87,6 +88,7 @@ struct boss_lajAI : public CombatAI
         SetCombatMovement(true);
         SetCombatScriptStatus(false);
         DespawnGuids(m_spawns);
+        CombatAI::EnterEvadeMode();
     }
 
     void AddTransformCooldowns(uint32 spellId)
@@ -147,7 +149,7 @@ struct boss_lajAI : public CombatAI
                 SetCombatMovement(false, true); 
                 // Remove the target focus 
                 SetCombatScriptStatus(true);
-                m_creature->MeleeAttackStop(m_creature->GetVictim());
+                SetMeleeEnabled(false);
                 m_creature->SetTarget(nullptr);
                 ResetTimer(LAJ_TELEPORT_SUMMON, 4000); 
                 break;
@@ -164,7 +166,7 @@ struct boss_lajAI : public CombatAI
             SetCombatMovement(true);
             SetCombatScriptStatus(false);
 
-            m_creature->MeleeAttackStart(m_creature->GetVictim());
+            SetMeleeEnabled(true);
             m_creature->SetTarget(m_creature->GetVictim());
         }
     }

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/botanica/boss_laj.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/botanica/boss_laj.cpp
@@ -91,6 +91,11 @@ struct boss_lajAI : public CombatAI
         CombatAI::EnterEvadeMode();
     }
 
+    void JustDied(Unit* /*killer*/) override
+    {
+        DespawnGuids(m_spawns);
+    }
+
     void AddTransformCooldowns(uint32 spellId)
     {
         if (spellId != SPELL_LAJ_ARCANE)

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/botanica/boss_laj.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/botanica/boss_laj.cpp
@@ -73,16 +73,20 @@ struct boss_lajAI : public CombatAI
         AddCustomAction(LAJ_TELEPORT_SUMMON, true, [&]() { HandleTeleportSummon(); }, TIMER_COMBAT_COMBAT);
     }
 
+    GuidVector m_spawns;
+
     void Reset() override
     {
         SetCombatMovement(true);
         SetCombatScriptStatus(false);
+        DespawnGuids(m_spawns);
     }
 
     void EnterEvadeMode() override
     {
         SetCombatMovement(true);
         SetCombatScriptStatus(false);
+        DespawnGuids(m_spawns);
     }
 
     void AddTransformCooldowns(uint32 spellId)
@@ -125,6 +129,8 @@ struct boss_lajAI : public CombatAI
         summoned->AI()->DoCastSpellIfCan(nullptr, SPELL_ROOT_SELF, CAST_TRIGGERED | CAST_AURA_NOT_PRESENT);
         if (Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, nullptr, SELECT_FLAG_PLAYER))
             summoned->AI()->AttackStart(target);
+
+        m_spawns.push_back(summoned->GetObjectGuid());
     }
 
     void OnSpellCast(SpellEntry const* spellInfo, Unit* /*target*/) override


### PR DESCRIPTION
## 🍰 Pullrequest
When Laj uses teleport spell he should ignore current target selection. Proof: https://youtu.be/BHgvMdxkrBI?t=2163
After Laj teleprots he summons 2 minions, when minions are summoned he should get CombatMovement again.

When Laj dies, all remaining adds should despawn. Proof:
https://youtu.be/GyZHvxEd5O4?t=3067
https://youtu.be/fhL8ueE6BWA?t=1655

Allergic Reaction:
Laj casts Aura 34697 on his current target. Diseases an enemy for 18 sec., increasing the damage it takes by 500. Nature damage inflicted to an enemy every 5 sec. for 18 sec. 

The Player with Aura 34697 can spread the Disease to other allies, those allies will get aura 34700.

Currently its possible that the Laj or the spawned minions can get affected by aura 34700.
Its also possible that the Player with Aura 34697 spreads it onto his self, resulting in double debuffs. 

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->

- [ ] I dont think its the correct way to Fix the Disease bug, imo the proc should never even select Laj or the minions as Target. Debugging showed that data.target is Laj / Lashers and data.source is Me (OnCheckProc for spell 34700)
- [x] Its possible that Laj gets stuck on Wipe and dont reset properly

- [X] None
