### PR TITLE
Fix Lady Vashj not correctly resetting Timers on Wipe resulting in sp…

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/serpent_shrine/boss_lady_vashj.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/serpent_shrine/boss_lady_vashj.cpp
@@ -435,6 +435,8 @@ struct boss_lady_vashjAI : public CombatAI
         if (m_instance)
             m_instance->SetData(TYPE_LADYVASHJ_EVENT, FAIL);
 
+        ResetAllTimers();
+
         DespawnGuids(m_spawns);
     }
 


### PR DESCRIPTION
…awning adds while being ooc.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Lady Vashj and prob. other Bosses dont correctly reset timers on wipe resulting in constantly spawning adds, even while being ooc or being in phase 1.

Prob. came with this change: https://github.com/cmangos/mangos-tbc/commit/e512fc1a6e3e764ddf88e429c2a6714e0365aea3

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None
https://github.com/cmangos/issues/issues/3589

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
