### PR TITLE
Modify WorldSocket::HandleAuthSession to store realmID instead of LOGIN_TYPE_MANGOSD constant in loginSource column of account_logons table.

### DIFF
--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -502,7 +502,7 @@ bool WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     static SqlStatementID updAccount;
 
     SqlStatement stmt = LoginDatabase.CreateStatement(updAccount, "INSERT INTO account_logons(accountId,ip,loginTime,loginSource) VALUES(?,?," _NOW_ ",?)");
-    stmt.PExecute(id, address.c_str(), std::to_string(LOGIN_TYPE_MANGOSD).c_str());
+    stmt.PExecute(id, address.c_str(), std::to_string(realmID).c_str());
 
     m_crypt.Init(&K);
 


### PR DESCRIPTION
This PR modifies WorldSocket::HandleAuthSession to store the realmID in the loginSource column of the account_logons table, rather than the LOGIN_TYPE_MANGOSD constant.
This is required for those who use a single realmd instance to serve multiple mangosd instances.

As it stands a server "owner" can't tell the difference between an authentication to mangosd instance X and an authentication to mangosd instance Y. They're logged with the same number (1).

This change would maintain the value 0 for AuthSocket::verifyVersionAndFinalizeAuthentication, and different realmIDs (non 0 values) for each separate mangosd instance.