### PR TITLE
[Spell] Withering Poison Proc 13886 should not be removed on Evade

### DIFF
--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2210,6 +2210,7 @@ UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|4 WH
 11011, -- Stone Watcher of Norgannon Passive
 11048, -- Perm. Illusion Bishop Tyriona
 13377, -- Fire Shield
+13886, -- Withering Poison Proc
 15978, -- Puncture
 21911, -- Puncture
 24692, -- Hakkar Power


### PR DESCRIPTION
used by https://www.wowhead.com/tbc/npc=4139/scorpid-terror and https://www.wowhead.com/tbc/npc=4140/scorpid-reaver