### PR TITLE
fix 3fadd9f

### DIFF
--- a/src/game/Anticheat/module/Warden/warden.cpp
+++ b/src/game/Anticheat/module/Warden/warden.cpp
@@ -418,7 +418,7 @@ void Warden::HandlePacket(WorldPacket& recvData)
                 uint32 checksum;
                 recvData >> length >> checksum;
 
-                if (length > (recvData.size() - (recvData.rpos() + 1)))
+                if (length > (recvData.size() - recvData.rpos()))
                 {
                     recvData.rpos(recvData.wpos());
                     _anticheat->RecordCheatInternal(CheatType::CHEAT_TYPE_WARDEN, "Packet checksum length fail");


### PR DESCRIPTION
## 🍰 Pullrequest
Removes redundant +1 from warden packet checksum length check 

### Proof
Using local server (Debian Linux 5.15.153) + fresh TBC client (2.4.3 8606)
```
sLog.outDebug("LENGTH %u, SIZE  %u, RPOS  %u, DIFF %u", length, recvData.size(), recvData.rpos(), length - (recvData.size() - recvData.rpos()));
LENGTH 13, SIZE 20, RPOS 7, DIFF 12
LENGTH 10, SIZE 17, RPOS 7, DIFF 9
LENGTH 42, SIZE 49, RPOS 7, DIFF 41
LENGTH 5, SIZE 12, RPOS 7, DIFF 4
LENGTH 17, SIZE 24, RPOS 7, DIFF 16
```
same change to vmangos/core: https://github.com/vmangos/core/commit/07d959f38af0d5cd2ebb61386afc6b94b8e544d9

### Issues
- fixes https://github.com/cmangos/issues/issues/3748

### How2Test
try to login without fix -> apply fix -> recompile -> try to login again
