### PR TITLE
SP: add worldstate for naturalist bite dbscript

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -657,7 +657,8 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (28695,'spell_gameobject_call_for_help_on_usage'), -- Herb Gathering (Master)
 (29354,'spell_gameobject_call_for_help_on_usage'), -- Mining (Master)
 (30434,'spell_gameobject_call_for_help_on_usage'), -- Elemental Seaforium Charge
-(34799,'spell_arcane_devastation');
+(34799,'spell_arcane_devastation'),
+(32173,'spell_entangling_roots');
 
 -- Wotlk
 INSERT INTO spell_scripts(Id, ScriptName) VALUES

--- a/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/slave_pens/slave_pens.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/slave_pens/slave_pens.cpp
@@ -23,6 +23,7 @@ EndScriptData */
 
 #include "AI/ScriptDevAI/include/sc_common.h"
 #include "slave_pens.h"
+#include "World/WorldStateDefines.h"
 
 instance_slave_pens::instance_slave_pens(Map* map) : ScriptedInstance(map), m_naturalistYelled(false), m_quagmirranTimer(0)
 {
@@ -31,7 +32,7 @@ instance_slave_pens::instance_slave_pens(Map* map) : ScriptedInstance(map), m_na
 
 void instance_slave_pens::Initialize()
 {
-
+    instance->GetVariableManager().SetVariable(WORLD_STATE_NATURALIST_BITE, 0);
 }
 
 void instance_slave_pens::SetData(uint32 type, uint32 data)
@@ -128,6 +129,30 @@ bool GossipHello_npc_naturalist_bite(Player* player, Creature* creature)
     return true;
 }
 
+enum
+{
+    SPELL_LIGHTNING_CLOUD       = 32193,
+    SPELL_LIGHTNING_CLOUD_H     = 37665,
+};
+// 32173 EntanglingRoots
+struct EntanglingRoots : public SpellScript
+{
+    void OnSuccessfulFinish(Spell* spell) const override
+    {
+        Unit* target = spell->m_targets.getUnitTarget();
+        if (!target)
+            return;
+
+        Unit* caster = spell->GetCaster();
+        if (!caster)
+            return;
+
+        caster->CastSpell(target, caster->GetMap()->IsRegularDifficulty() ? SPELL_LIGHTNING_CLOUD : SPELL_LIGHTNING_CLOUD_H, TRIGGERED_NONE);
+        return;
+    }
+};
+
+
 void AddSC_instance_slave_pens()
 {
     Script* pNewScript = new Script;
@@ -144,5 +169,7 @@ void AddSC_instance_slave_pens()
     pNewScript->Name = "npc_naturalist_bite";
     pNewScript->pGossipHello = &GossipHello_npc_naturalist_bite;
     pNewScript->RegisterSelf();
+
+    RegisterSpellScript<EntanglingRoots>("spell_entangling_roots");
 }
 

--- a/src/game/World/WorldStateDefines.h
+++ b/src/game/World/WorldStateDefines.h
@@ -356,6 +356,9 @@ enum WorldStateID : int32
     WORLD_STATE_PROTEAN_HORROR     = 5520001,               // Prevents that Protean Horrors respawn
     WORLD_STATE_PROTEAN_NIGHTMARE  = 5520002,               // Prevents that Protean Nightmare respawn
 
+    // The Slave Pens
+    WORLD_STATE_NATURALIST_BITE    = 5470044,              // Spawns Coilfang Group after freeing Naturalist Bite
+
     // Wotlk
 };
 


### PR DESCRIPTION
add spell_script for entangling roots to use lightning cloud after cast finishs

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
worldstate used to correctly spawn enemy group after releasing naturalist bite from his cage
spellscript for entagling roots, used by Coilfang Enchantress

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
