### PR TITLE
Creature pet unsummon crash fix

### DIFF
--- a/src/game/MotionGenerators/HomeMovementGenerator.cpp
+++ b/src/game/MotionGenerators/HomeMovementGenerator.cpp
@@ -103,7 +103,7 @@ void HomeMovementGenerator<Creature>::Finalize(Creature& owner)
                         pSummoner->AI()->SummonedJustReachedHome(&owner);
         }
 
-        if (!wasActive)
+        if (!wasActive && owner.IsInWorld())
             owner.SetActiveObjectState(false);
 
         owner.SetCombatStartPosition(Position());


### PR DESCRIPTION
## 🍰 Pullrequest
This fixes a crash which is triggered after a creature's pet is unsummoned. 

### Proof
In https://github.com/cmangos/mangos-tbc/blob/910d594493c2bd715efdba876cb3fd5f490a7cd3/src/game/MotionGenerators/HomeMovementGenerator.cpp#L88 
owner.TriggerHomeEvents(); is called before owner.SetActiveObjectState(false);
For TriggerHomeEvents, if the owner is a pet of a creature that has died this will trigger an unsummon here: https://github.com/cmangos/mangos-tbc/blob/910d594493c2bd715efdba876cb3fd5f490a7cd3/src/game/Entities/Unit.cpp#L629
This leads to it being added to the removelist here: https://github.com/cmangos/mangos-tbc/blob/910d594493c2bd715efdba876cb3fd5f490a7cd3/src/game/Entities/Pet.cpp#L1111
This leads to a cleanupbeforedlete here: https://github.com/cmangos/mangos-tbc/blob/910d594493c2bd715efdba876cb3fd5f490a7cd3/src/game/Maps/Map.cpp#L1538
Which triggers RemoveFromWorld() in https://github.com/cmangos/mangos-tbc/blob/910d594493c2bd715efdba876cb3fd5f490a7cd3/src/game/Entities/Object.cpp#L1241

However SetActiveObjectState only removes our pet from the active object list if it is still in world here: https://github.com/cmangos/mangos-tbc/blob/910d594493c2bd715efdba876cb3fd5f490a7cd3/src/game/Entities/Object.cpp#L2625

The result is an WorldObject with m_isActiveObject = false while it's still in m_activeNonPlayers on a map. Once deleted this results to a dangling pointer and a crash when the map tries to update.

### Issues
-None

### How2Test
-Teleport to skull rock (map 1, x:1477 y:-4770 z:6)
-Kill an burning blade apprentice with a voidwalker minion.
-Drop aggro with the voidwalker.
-The server crashes once the voidwalker walks back to it's original position and despawns.