### PR TITLE
Battle Shout used from various tbc trash npcs should not stack

### DIFF
--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -131,6 +131,9 @@ UPDATE `spell_template` SET `MaxTargetLevel`=63 WHERE `id`=15366;
 -- Watchkeeper Gargolmar - Mortal Wound should stack to 50/100%
 UPDATE `spell_template` SET `StackAmount`=10 WHERE `id` IN(30641,36814);
 
+-- Battle Shout used from various trash npcs
+UPDATE `spell_template` SET `StackAmount`=1 WHERE `id` = 31403;
+
 -- Warlock Ritual of Summoning
 -- 5 yd summoning radius
 UPDATE `spell_template` SET `EffectRadiusIndex1`=8 WHERE `id`=698;

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -132,7 +132,7 @@ UPDATE `spell_template` SET `MaxTargetLevel`=63 WHERE `id`=15366;
 UPDATE `spell_template` SET `StackAmount`=10 WHERE `id` IN(30641,36814);
 
 -- Battle Shout used from various trash npcs
-UPDATE `spell_template` SET `StackAmount`=1 WHERE `id` = 31403;
+UPDATE `spell_template` SET `AttributesEx`= 2048 WHERE `id` = 31403;
 
 -- Warlock Ritual of Summoning
 -- 5 yd summoning radius


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
[Battle Shout](https://www.wowhead.com/spell=31403/battle-shout) should not be stackable.


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
Using Ethereal Crypt Raider as example here:
This npcs can use Battle Shout on their self. Pulling multiple npcs of this type can result in overstacking Battle Shout.
![Wow_eM1jdiM3z9](https://github.com/user-attachments/assets/29cdc320-3bbd-4561-8ec1-9dbff982bb7a)

Tests on retail showed that they use it on their self even if they have the Buff (refreshing timer from 1min to 2 minutes)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
