### PR TITLE
Missing bot-specific pathfinder modifications to allow for travel node generation.

### DIFF
--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -38,6 +38,9 @@ PathFinder::PathFinder(const Unit* owner, bool ignoreNormalization) :
     m_cachedPoints(m_pointPathLimit * VERTEX_SIZE), m_pathPolyRefs(m_pointPathLimit), m_polyLength(0),
     m_smoothPathPolyRefs(m_pointPathLimit), m_sourceUnit(owner), m_navMesh(nullptr), m_navMeshQuery(nullptr),
     m_defaultMapId(m_sourceUnit->GetMapId()), m_ignoreNormalization(ignoreNormalization)
+#ifdef ENABLE_PLAYERBOTS
+    , m_defaultInstanceId(m_sourceUnit->GetInstanceId())
+#endif
 {
     DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::PathInfo for %u \n", m_sourceUnit->GetGUIDLow());
 
@@ -54,7 +57,7 @@ PathFinder::PathFinder(const Unit* owner, bool ignoreNormalization) :
 PathFinder::PathFinder() :
     m_polyLength(0), m_type(PATHFIND_BLANK),
     m_useStraightPath(false), m_forceDestination(false), m_straightLine(false), m_pointPathLimit(MAX_POINT_PATH_LENGTH), // TODO: Fix legitimate long paths
-    m_sourceUnit(nullptr), m_navMesh(nullptr), m_navMeshQuery(nullptr), m_cachedPoints(m_pointPathLimit* VERTEX_SIZE), m_pathPolyRefs(m_pointPathLimit), m_smoothPathPolyRefs(m_pointPathLimit), m_defaultMapId(0)
+    m_sourceUnit(nullptr), m_navMesh(nullptr), m_navMeshQuery(nullptr), m_cachedPoints(m_pointPathLimit* VERTEX_SIZE), m_pathPolyRefs(m_pointPathLimit), m_smoothPathPolyRefs(m_pointPathLimit), m_defaultMapId(0), m_defaultInstanceId(0)
 {
 
 }
@@ -62,7 +65,7 @@ PathFinder::PathFinder() :
 PathFinder::PathFinder(uint32 mapId, uint32 instanceId) :
     m_polyLength(0), m_type(PATHFIND_BLANK),
     m_useStraightPath(false), m_forceDestination(false), m_straightLine(false), m_pointPathLimit(MAX_POINT_PATH_LENGTH), // TODO: Fix legitimate long paths
-    m_sourceUnit(nullptr), m_navMesh(nullptr), m_navMeshQuery(nullptr), m_cachedPoints(m_pointPathLimit* VERTEX_SIZE), m_pathPolyRefs(m_pointPathLimit), m_smoothPathPolyRefs(m_pointPathLimit), m_defaultMapId(mapId)
+    m_sourceUnit(nullptr), m_navMesh(nullptr), m_navMeshQuery(nullptr), m_cachedPoints(m_pointPathLimit* VERTEX_SIZE), m_pathPolyRefs(m_pointPathLimit), m_smoothPathPolyRefs(m_pointPathLimit), m_defaultMapId(mapId), m_defaultInstanceId(instanceId)
 {
     MMAP::MMapManager* mmap = MMAP::MMapFactory::createOrGetMMapManager();
     m_defaultNavMeshQuery = mmap->GetNavMeshQuery(mapId, instanceId);
@@ -175,7 +178,7 @@ void PathFinder::setArea(uint32 mapId, float x, float y, float z, uint32 area, f
 
     MMAP::MMapManager* mmap = MMAP::MMapFactory::createOrGetMMapManager();
 
-    dtNavMeshQuery const* query = mmap->GetNavMeshQuery(mapId, 0);
+    dtNavMeshQuery const* query = mmap->GetNavMeshQuery(mapId, m_defaultInstanceId);
     dtNavMesh const* cnavMesh = mmap->GetNavMesh(mapId);
     dtNavMesh* navMesh = const_cast<dtNavMesh*> (cnavMesh);
     dtQueryFilter m_filter;
@@ -231,7 +234,7 @@ uint32 PathFinder::getArea(uint32 mapId, float x, float y, float z)
 
     MMAP::MMapManager* mmap = MMAP::MMapFactory::createOrGetMMapManager();
 
-    dtNavMeshQuery const* query = mmap->GetNavMeshQuery(mapId, 0);
+    dtNavMeshQuery const* query = mmap->GetNavMeshQuery(mapId, m_defaultInstanceId);
     dtNavMesh const* cnavMesh = mmap->GetNavMesh(mapId);
     dtNavMesh* navMesh = const_cast<dtNavMesh*> (cnavMesh);
     dtQueryFilter m_filter;

--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -93,20 +93,20 @@ void PathFinder::SetCurrentNavMesh()
             m_navMeshQuery = m_defaultNavMeshQuery;
         }
 
-#ifdef ENABLE_PLAYERBOTS
         if (m_navMeshQuery)
             m_navMesh = m_navMeshQuery->getAttachedNavMesh();
 
     }
+#ifdef ENABLE_PLAYERBOTS
     else if (!m_sourceUnit && MMAP::MMapFactory::IsPathfindingEnabled(m_defaultMapId, nullptr))
     {
         MMAP::MMapManager* mmap = MMAP::MMapFactory::createOrGetMMapManager();
         m_navMeshQuery = m_defaultNavMeshQuery;
-#endif
 
         if (m_navMeshQuery)
             m_navMesh = m_navMeshQuery->getAttachedNavMesh();
     }
+#endif
 }
 
 bool PathFinder::calculate(float destX, float destY, float destZ, bool forceDest/* = false*/, bool straightLine/* = false*/)
@@ -154,9 +154,10 @@ bool PathFinder::calculate(Vector3 const& start, Vector3 const& dest, bool force
 
     SetCurrentNavMesh();
 
-#ifndef ENABLE_PLAYERBOTS
-    DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::calculate() for %u \n", m_sourceUnit->GetGUIDLow());
+#ifdef ENABLE_PLAYERBOTS
+    if(m_sourceUnit)
 #endif
+        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::calculate() for %u \n", m_sourceUnit->GetGUIDLow());
 
     // make sure navMesh works - we can run on map w/o mmap
     // check if the start and end point have a .mmtile loaded (can we pass via not loaded tile on the way?)
@@ -393,7 +394,7 @@ void PathFinder::BuildPolyPath(const Vector3& startPos, const Vector3& endPos)
 #ifndef ENABLE_PLAYERBOTS
     if (m_sourceUnit->GetMap()->IsDungeon())
 #else
-    if (sMapMgr.FindMap(m_defaultMapId, m_defaultInstanceId) && sMapMgr.FindMap(m_defaultMapId, m_defaultInstanceId)->IsDungeon())
+    if ((m_sourceUnit && m_sourceUnit->GetMap()->IsDungeon()) || (sMapStore.LookupEntry(m_defaultMapId) && sMapStore.LookupEntry(m_defaultMapId)->IsDungeon()))
 #endif
     {
         float distance = sqrt((endPos.x - startPos.x) * (endPos.x - startPos.x) + (endPos.y - startPos.y) * (endPos.y - startPos.y) + (endPos.z - startPos.z) * (endPos.z - startPos.z));

--- a/src/game/MotionGenerators/PathFinder.h
+++ b/src/game/MotionGenerators/PathFinder.h
@@ -130,6 +130,9 @@ class PathFinder
 
         const dtNavMeshQuery*   m_defaultNavMeshQuery;     // the nav mesh query used to find the path
         uint32                  m_defaultMapId;
+#ifdef ENABLE_PLAYERBOTS
+        uint32                  m_defaultInstanceId;
+#endif
 
         bool                    m_ignoreNormalization;
 


### PR DESCRIPTION
## 🍰 Pullrequest
This PR (re-)implements some adjustments to the existing pathfinder logic to allow for pathfinding without a source unit. This is required for generating travelnodes used in long-range bot pathfinding.
This PR also includes a fix in using the proper instanceId when using get/set area which allows navmesh manipulation by bots in instances.

These changes should have been implemented during the original bot-code merge but where forgotten or have been broken since then.

Note without these changes bots will continue to work fine however we will be unable to re-generate the nodemap to keep up with future map-changes or fix existing minor issues (such as missing zeppelin paths in tbc).

### Proof
An example can be found in the current pathfinder:  https://github.com/cmangos/mangos-tbc/blob/1605ff06b177df6cdb4b4d72b7038ea273ca70d5/src/game/MotionGenerators/PathFinder.cpp#L127

This simply stops any calculation without a m_sourceUnit. This functionality is however essential to generate paths during server start. 

Here you can see the original bot implementation lacks that check: https://github.com/celguar/mangos-tbc/blob/63b2e8f43fb1a10e4a7b55de2f0697fbd46e8979/src/game/MotionGenerators/PathFinder.cpp#L119

If you look at the changes made they are limited to bypassing/implementing some m_sourceUnit checks and only effect builds that include playerbots. Also some extra instanceId handling specifically for get/setArea. Normal pathfinding should not be affected.

### Issues
-Unreported: Bots in tbc no longer use zeppelins to travel between continents.
-Unreported: Bots manipulating the navmesh to avoid mobs crash the server when in an instance.

### How2Test
Testing travelnode generation can be tested by clearing the ai_playerbot_travelnode table. Doing this without this fix will result in 800 travelnodes remaining mostly in instances. With this fix 2500+ nodes will remain including proper paths in the overworld.

### Todo / Checklist
-If this fix is implemented botcode should be adjusted so bots are allowed to manipulate the navmesh inside instances again.