### PR TITLE
AI: Prevent crash when killing a guard with a gameobject (like a trap)

### DIFF
--- a/src/game/AI/ScriptDevAI/base/guard_ai.cpp
+++ b/src/game/AI/ScriptDevAI/base/guard_ai.cpp
@@ -54,6 +54,9 @@ void guardAI::Aggro(Unit* who)
 
 void guardAI::JustDied(Unit* killer)
 {
+    if (!killer)
+        return; 
+
     // Send Zone Under Attack message to the LocalDefense and WorldDefense Channels
     if (Player* pPlayer = killer->GetBeneficiaryPlayer())
         m_creature->SendZoneUnderAttackMessage(pPlayer);


### PR DESCRIPTION
## 🍰 Pullrequest
This is a small crash fix which occurs when a guard is killed using a spell cast by a gameobject. See also https://github.com/cmangos/mangos-wotlk/pull/570

### Proof
The killer in JustDied of the guardai is filled here: https://github.com/cmangos/mangos-tbc/blob/dc062a594bbd2f6f474932752b767eb570aeae18/src/game/Spells/SpellAuras.cpp#L6640
Which is filled with nullptr if the caster is a gameObject: https://github.com/cmangos/mangos-tbc/blob/dc062a594bbd2f6f474932752b767eb570aeae18/src/game/Spells/SpellAuras.cpp#L8090

This results in a crash trying to find the Beneficiary Player of nullptr.

### How2Test
-Make an alliance hunter with immolation trap.
-Go to mulgore and place the trap near a Brave Dawneagle (or other guard near bloodhoof village) killing it.
-The server will crash.
