### PR TITLE
Release loot at end of HandleAutostoreLootItemOpcode

### DIFF
--- a/src/game/Loot/LootHandler.cpp
+++ b/src/game/Loot/LootHandler.cpp
@@ -70,6 +70,10 @@ void WorldSession::HandleAutostoreLootItemOpcode(WorldPacket& recv_data)
         if (Item* item = _player->GetItemByGuid(lguid))
             item->SetLootState(ITEM_LOOT_CHANGED);
     }
+
+    if (loot->IsLootedFor(_player)) {
+        loot->Release(_player);
+    }
 }
 
 void WorldSession::HandleLootMoneyOpcode(WorldPacket& /*recv_data*/)

--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -1520,24 +1520,24 @@ void Loot::GroupCheck()
                 masterLooter = player;
         }
 
-		// check if there is need to launch a roll
-		if (m_lootMethod != MASTER_LOOT)
-		{
-			for (auto lootItem : m_lootItems)
-			{
-				if (!lootItem->isBlocked)
-					continue;
+        if (masterLooter)
+            break;
 
-				uint32 itemSlot = lootItem->lootSlot;
+        // check if there is need to launch a roll
+        for (auto lootItem : m_lootItems)
+        {
+             if (!lootItem->isBlocked)
+                 continue;
 
-				if (m_roll.find(itemSlot) == m_roll.end() && lootItem->IsAllowed(player, this))
-				{
-					if (!m_roll[itemSlot].TryToStart(*this, itemSlot))      // Create and try to start a roll
-						m_roll.erase(m_roll.find(itemSlot));                // Cannot start roll so we have to delete it (find will not fail as the item was just created)
-				}
-			}
-		}
-	}
+              uint32 itemSlot = lootItem->lootSlot;
+
+              if (m_roll.find(itemSlot) == m_roll.end() && lootItem->IsAllowed(player, this))
+              {
+                  if (!m_roll[itemSlot].TryToStart(*this, itemSlot))      // Create and try to start a roll
+                      m_roll.erase(m_roll.find(itemSlot));                // Cannot start roll so we have to delete it (find will not fail as the item was just created)
+              }
+         }
+    }
 
     // in master loot case we have to send looter list to client
     if (masterLooter)

--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -1520,20 +1520,23 @@ void Loot::GroupCheck()
                 masterLooter = player;
         }
 
-        // check if there is need to launch a roll
-        for (auto lootItem : m_lootItems)
-        {
-            if (!lootItem->isBlocked)
-                continue;
+		// check if there is need to launch a roll
+		if (m_lootMethod != MASTER_LOOT)
+		{
+			for (auto lootItem : m_lootItems)
+			{
+				if (!lootItem->isBlocked)
+					continue;
 
-            uint32 itemSlot = lootItem->lootSlot;
+				uint32 itemSlot = lootItem->lootSlot;
 
-            if (m_roll.find(itemSlot) == m_roll.end() && lootItem->IsAllowed(player, this))
-            {
-                if (!m_roll[itemSlot].TryToStart(*this, itemSlot))      // Create and try to start a roll
-                    m_roll.erase(m_roll.find(itemSlot));                // Cannot start roll so we have to delete it (find will not fail as the item was just created)
-            }
-        }
+				if (m_roll.find(itemSlot) == m_roll.end() && lootItem->IsAllowed(player, this))
+				{
+					if (!m_roll[itemSlot].TryToStart(*this, itemSlot))      // Create and try to start a roll
+						m_roll.erase(m_roll.find(itemSlot));                // Cannot start roll so we have to delete it (find will not fail as the item was just created)
+				}
+			}
+		}
     }
 
     // in master loot case we have to send looter list to client

--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -1537,7 +1537,7 @@ void Loot::GroupCheck()
 				}
 			}
 		}
-    }
+	}
 
     // in master loot case we have to send looter list to client
     if (masterLooter)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Resolve dup involving opening chests in inventory or chest objects. Player can open a chest at the same time as forcing a logout or teleport (making player leave world) to restore contents of chest item. This pull request forces the server to handle the looting of item.

I'm going through my repo changes and I'm pretty sure this was the only thing we needed to resolves the dupe from our end.

Tested in main repo as well to make sure it wasn't something from just our core.

To replicate - Open a chest item from inventory with autoloot enabled, whilst disconnecting or going through a portal. Timing has to be right.

### Issues
<!-- Which Issues does this fix, which are related?
fixes server not handling loot release allowing players to dupe contents of chest items.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
Open a chest item from inventory whilst disconnecting or going through a portal. Timing has to be right.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] None
