### PR TITLE
Fix crash trying to skip over element, doing a nullptr deref

### DIFF
--- a/src/framework/Utilities/LinkedList.h
+++ b/src/framework/Utilities/LinkedList.h
@@ -38,8 +38,8 @@ class LinkedListElement
         LinkedListElement()  { iNext = nullptr; iPrev = nullptr; }
         ~LinkedListElement() { delink(); }
 
-        bool hasNext() const  { return (iNext->iNext != nullptr); }
-        bool hasPrev() const  { return (iPrev->iPrev != nullptr); }
+        bool hasNext() const  { return (iNext != nullptr && iNext->iNext != nullptr); }
+        bool hasPrev() const  { return (iPrev != nullptr && iPrev->iPrev != nullptr); }
         bool isInList() const { return (iNext != nullptr && iPrev != nullptr); }
 
         LinkedListElement*       next()       { return hasNext() ? iNext : nullptr; }


### PR DESCRIPTION
## 🍰 Pullrequest
Changing `hasNext()` and `hasPrev()` functions to avoid a nullptr dereference when `iNext` or `iPull` is null. The change preserves the current behavior of the functions (minus the crash) but the intended behavior might have been different. The way it is now it may skip an iteration step.

### Proof
Obvious

### Issues
Causes a crash when iterating on linked list references (3 layers of abstraction) sometimes!

## Todo
Test whether there is a point of even using `next()` compared to `nocheck_next()`. Likewise with `prev()`. Equivalently check whether the current behavior is the correct one. 
