### PR TITLE
Fixed: ERROR 1067 (42000): Invalid default value for 'last_login'

### DIFF
--- a/sql/updates/realmd/s2417_01_realmd_account_logons.sql
+++ b/sql/updates/realmd/s2417_01_realmd_account_logons.sql
@@ -9,6 +9,6 @@ loginTime timestamp NOT NULL,
 loginSource INT UNSIGNED NOT NULL
 );
 
+SET sql_mode = 'NO_ZERO_DATE';
 ALTER TABLE account CHANGE `last_ip` `lockedIp` VARCHAR(30) NOT NULL DEFAULT '0.0.0.0';
 ALTER TABLE account DROP COLUMN last_login;
-


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
https://stackoverflow.com/questions/36882149/error-1067-42000-invalid-default-value-for-created-at
```
mysql> SET sql_mode = 'NO_ZERO_DATE';
Query OK, 0 rows affected, 1 warning (0,00 sec)

mysql> ALTER TABLE account CHANGE `last_ip` `lockedIp` VARCHAR(30) NOT NULL DEFAULT '0.0.0.0';
Query OK, 0 rows affected, 1 warning (0,04 sec)
Records: 0  Duplicates: 0  Warnings: 1

mysql> ALTER TABLE account DROP COLUMN last_login;
Query OK, 6 rows affected (0,06 sec)
Records: 6  Duplicates: 0  Warnings: 0

```

### Issues
```
> Trying to process last Realm CORE updates
  - Applying s2417_01_realmd_account_logons.sql ... FAILED!
>>> ERROR 1067 (42000) at line 12: Invalid default value for 'last_login'
```

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
Install core updates for 4yo server.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] Merge the PR
