### PR TITLE
UnitAI: Fix Wandering Eye of Kilrogg

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -64,6 +64,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (20038,'spell_explosion_razorgore'),
 (21651,'spell_opening_capping'),
 (22858,'spell_retaliation_creature'),
+(22876,'spell_summon_netherwalker'),
 (23134,'spell_goblin_bomb'),
 (23226,'spell_ritual_candle_aura'),
 (24228,'spell_arlokk_vanish'),

--- a/src/game/AI/BaseAI/UnitAI.cpp
+++ b/src/game/AI/BaseAI/UnitAI.cpp
@@ -829,10 +829,6 @@ void UnitAI::TimedFleeingEnded()
 
 bool UnitAI::DoFlee(uint32 duration)
 {
-    Unit* victim = m_unit->GetVictim();
-    if (!victim)
-        return false;
-
     if (!duration)
         duration = sWorld.getConfig(CONFIG_UINT32_CREATURE_FAMILY_FLEE_DELAY);
 

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/dire_maul/dire_maul.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/dire_maul/dire_maul.cpp
@@ -308,6 +308,18 @@ struct RitualCandleAura : public SpellScript
     }
 };
 
+// 22876 - Summon Netherwalker
+struct SummonNetherWalker : public SpellScript
+{
+    void OnSuccessfulFinish(Spell* spell) const override
+    {
+        Creature* caster = static_cast<Creature*>(spell->GetCaster());
+        if (!caster || !caster->IsAlive() || !caster->IsCreature())
+            return;
+        caster->ForcedDespawn();
+    }
+};
+
 void AddSC_dire_maul()
 {
     Script* pNewScript = new Script;
@@ -326,4 +338,5 @@ void AddSC_dire_maul()
     pNewScript->RegisterSelf();
 
     RegisterSpellScript<RitualCandleAura>("spell_ritual_candle_aura");
+    RegisterSpellScript<SummonNetherWalker>("spell_summon_netherwalker");
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes the Wandering Eye of Kilrogg, ensuring that it can start casting its summoning spell and then despawning the eye when summon has concluded.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Check for consequences from moving CreatureAI::EnterCombat() behind ProcessEvents()
