### PR TITLE
Proc: initialize canProc with true

### DIFF
--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -298,7 +298,7 @@ pAuraProcHandler AuraProcHandler[TOTAL_AURAS] =
 struct ProcTriggeredData
 {
     ProcTriggeredData(SpellProcEventEntry const* _spellProcEvent, SpellAuraHolder* _triggeredByHolder)
-        : spellProcEvent(_spellProcEvent), triggeredByHolder(_triggeredByHolder)
+        : spellProcEvent(_spellProcEvent), triggeredByHolder(_triggeredByHolder), canProc{true, true, true}
     {}
     SpellProcEventEntry const* spellProcEvent;
     SpellAuraHolder* triggeredByHolder;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes the `canProc` variable being uninitialized making proc behaviour of all spells unpredictable due to memory layout issues

### Issues
- fixes https://github.com/cmangos/issues/issues/3787
- fixes https://github.com/cmangos/issues/issues/3795
- fixes https://github.com/cmangos/issues/issues/3816
- fixes https://github.com/cmangos/issues/issues/3784
- fixes https://github.com/cmangos/issues/issues/3800