### PR TITLE
SSC: Remove Boss-Requirements from Vashj (2.4.0)

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/serpent_shrine/serpent_shrine.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/serpent_shrine/serpent_shrine.cpp
@@ -118,6 +118,9 @@ void instance_serpentshrine_cavern::OnObjectCreate(GameObject* pGo)
             m_goEntryGuidStore[pGo->GetEntry()] = pGo->GetObjectGuid();
             break;
         case GO_CONSOLE_VASHJ:
+#ifdef PRENERF_2_3
+            pGo->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NO_INTERACT);
+#endif
             m_goEntryGuidStore[pGo->GetEntry()] = pGo->GetObjectGuid();
             EngageBridgeConsole(pGo);
             break;

--- a/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/serpent_shrine/serpent_shrine.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/serpent_shrine/serpent_shrine.cpp
@@ -174,7 +174,7 @@ void instance_serpentshrine_cavern::SetData(uint32 uiType, uint32 uiData)
         case TYPE_MOROGRIM_EVENT:
             m_auiEncounter[uiType] = uiData;
             if (uiData == DONE)
-                EngageBossConsole(uiType, 0);
+                EngageBossConsole(uiType, nullptr);
             if (uiData == SPECIAL)
                 EngageBridgeConsole();
             break;
@@ -323,10 +323,15 @@ void instance_serpentshrine_cavern::SpawnFishCorpses()
 
 void instance_serpentshrine_cavern::EngageBridgeConsole(GameObject* _console)
 {
+    #ifdef PRENERF_2_3
     if(m_auiEncounter[TYPE_HYDROSS_EVENT] == SPECIAL && m_auiEncounter[TYPE_THELURKER_EVENT] == SPECIAL && m_auiEncounter[TYPE_LEOTHERAS_EVENT] == SPECIAL
         && m_auiEncounter[TYPE_KARATHRESS_EVENT] == SPECIAL && m_auiEncounter[TYPE_MOROGRIM_EVENT] == SPECIAL)
+    #endif
         if(GameObject* console = _console ? _console : instance->GetGameObject(m_goEntryGuidStore[GO_CONSOLE_VASHJ]))
+        {
+            console->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED);
             console->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_NO_INTERACT);
+        }
 }
 
 uint32 EncounterTypeFromGOEntry(uint32 goEntry)
@@ -375,10 +380,15 @@ void instance_serpentshrine_cavern::EngageBossConsole(uint32 uiType, GameObject*
         }
         console = instance->GetGameObject(m_goEntryGuidStore[goEntry]);
     }
+    #ifdef PRENERF_2_3
     if (m_auiEncounter[uiType] == DONE)
+    {
+        console->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED);
         console->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_NO_INTERACT);
+    }
     else if(m_auiEncounter[uiType] == SPECIAL)
         console->SetGoState(GO_STATE_ACTIVE);
+    #endif
 }
 
 bool GOUse_go_ssc_boss_consoles(Player* /*pPlayer*/, GameObject* pGo)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR removes the requirement to kill all bosses in SSC prior to attempting Lady Vashj, as per Patchnotes of 2.4.0

### Proof
<!-- Link resources as proof -->
- [Patch 2.4.0](https://warcraft.wiki.gg/wiki/Patch_2.4.0#Dungeons_and_raids)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Go to Lady Vashj's bridge console. Click on it immediately

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Maybe gate the "removal" behind PRENERF macro, to ensure both types of behaviour can be observed if desired.