### PR TITLE
Feralas: Add Savage Owlbeast as target for Wildkin Muisek Vessel item

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/feralas.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/feralas.cpp
@@ -591,7 +591,7 @@ struct SpecificTargetScript : public SpellScript
 
 struct CaptureWildkin : public SpecificTargetScript // 11886
 {
-    std::set<uint32> m_targets = { 2927, 2928, 7808 };
+    std::set<uint32> m_targets = { 2927, 2928, 2929, 7808 };
 
     std::set<uint32> const& GetRequiredTargets() const override { return m_targets; }
 };


### PR DESCRIPTION
Tested on WoW Classic PTR

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This adds https://www.wowhead.com/classic/npc=2929/savage-owlbeast as target for item Wildkin Muisek Vessel
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
