### PR TITLE
Fix missing template instantiation in RelWithDebInfo builds

### DIFF
--- a/src/game/MotionGenerators/TargetedMovementGenerator.cpp
+++ b/src/game/MotionGenerators/TargetedMovementGenerator.cpp
@@ -28,6 +28,7 @@
 #include "Grids/GridNotifiersImpl.h"
 #include "Entities/Transports.h"
 #include "Maps/SpawnGroup.h"
+#include "Grids/CellImpl.h"
 
 #define IGNORE_M2 true // simple define for avoiding bugs due to different setting across movechase
 


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes a linking issue on Linux for `VisitAllObjects` in `RelWithDebInfo` (`-O2 -g`) and ASan (`-fsanitize=address`) builds by ensuring `CellImpl.h` is included in `TargetedMovementGenerator.cpp`.  

### Proof
- **Build tested successfully on Linux (`RelWithDebInfo`, `Debug`, `Release`).**
- **Confirmed that missing template instantiation was the cause of the issue.**  

### Issues
- No existing issue reports for this specific problem.

### How2Test
1. Compile with `-DCMAKE_BUILD_TYPE=RelWithDebInfo -fsanitize=address` on Linux.
2. Before this fix: Linker fails with **undefined reference to `VisitAllObjects`**.
3. After this fix: Compiles and links successfully.

### Todo / Checklist
- [X] Ensure `VisitAllObjects` is correctly instantiated.
- [X] Fix Linux linker error.
- [X] Tested across different build types.