### PR TITLE
Spell: Compact Harvest Reaper should have same level as the summoning…

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -29,6 +29,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (6467,'spell_unarmed_woodcutter'),
 (7054,'spell_forsaken_skill'),
 (7131,'spell_illusion_passive'),
+(7979,'spell_compact_harvest_reaper'),
 (8555,'spell_left_for_dead'),
 (8603,'spell_tribal_death'),
 (8655,'spell_tribal_death'),

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/stonetalon_mountains.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/stonetalon_mountains.cpp
@@ -211,7 +211,7 @@ GameObjectAI* GetAIgo_covertops(GameObject* pGo)
 }
 
 // Venture Co. Machine Smith - summon Compact Harvest Reaper
-struct CompactHarvestReaper : public SpellScript, public AuraScript
+struct CompactHarvestReaper : public SpellScript
 {
     void OnSummon(Spell* spell, Creature* summon) const override
     {

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/stonetalon_mountains.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/stonetalon_mountains.cpp
@@ -210,6 +210,15 @@ GameObjectAI* GetAIgo_covertops(GameObject* pGo)
     return new go_covertopsAI(pGo);
 }
 
+// Venture Co. Machine Smith - summon Compact Harvest Reaper
+struct CompactHarvestReaper : public SpellScript, public AuraScript
+{
+    void OnSummon(Spell* spell, Creature* summon) const override
+    {
+        summon->SetLevel(spell->GetCaster()->GetLevel());
+    }
+};
+
 /*######
 ## AddSC
 ######*/
@@ -226,4 +235,6 @@ void AddSC_stonetalon_mountains()
     pNewScript->Name = "go_covert_ops";
     pNewScript->GetGameObjectAI = &GetAIgo_covertops;
     pNewScript->RegisterSelf();
+
+    RegisterSpellScript<CompactHarvestReaper>("spell_compact_harvest_reaper");
 }


### PR DESCRIPTION
… npc

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Multiple NPCs like [Venture Co. Machine Smith](https://www.wowhead.com/classic/npc=3993/venture-co-machine-smith#abilities) use the spell [Compact Harvest Reaper](https://www.wowhead.com/classic/spell=7979/compact-harvest-reaper#summons) that summons a [Compact Harvest Reaper](https://www.wowhead.com/classic/npc=2676/compact-harvest-reaper) with wrong Level.
It should always have the same Level as the summoner.

### Proof
<!-- Link resources as proof -->
- None
Classic Tests

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
