### PR TITLE
Ashenvale: add Destroy Karangs Banner handling for Quest King of the …

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -52,6 +52,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (11889,'spell_capture_mountain_giant'),
 (11610,'spell_gammerita_turtle_camera'),
 (12479,'spell_hex_of_jammalan'),
+(20786,'spell_destroy_karangs_banner'),
 (12890,'spell_deep_slumber'),
 (13258,'spell_summon_goblin_bomb'),
 (16380,'spell_greater_invisibility_mob'),

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/ashenvale.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/ashenvale.cpp
@@ -637,7 +637,8 @@ bool QuestAccept_npc_feero_ironhand(Player* pPlayer, Creature* pCreature, const 
 }
 
 // Destroy Karang's Banner used by Enraged Foulwealds during quest King of the Foulweald (6621)
-enum {
+enum 
+{
     GO_KARANGS_BANNER = 178205,
 };
 
@@ -698,4 +699,6 @@ void AddSC_ashenvale()
     pNewScript->GetAI = &GetAI_npc_feero_ironhand;
     pNewScript->pQuestAcceptNPC = &QuestAccept_npc_feero_ironhand;
     pNewScript->RegisterSelf();
+
+    RegisterSpellScript<DestroyKarangsBanner>("spell_destroy_karangs_banner");
 }

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/ashenvale.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/ashenvale.cpp
@@ -30,6 +30,7 @@ EndContentData */
 
 #include "AI/ScriptDevAI/include/sc_common.h"
 #include "AI/ScriptDevAI/base/escort_ai.h"
+#include "World/WorldStateDefines.h"
 
 /*####
 # npc_muglash
@@ -634,6 +635,38 @@ bool QuestAccept_npc_feero_ironhand(Player* pPlayer, Creature* pCreature, const 
 
     return true;
 }
+
+// Destroy Karang's Banner used by Enraged Foulwealds during quest King of the Foulweald (6621)
+enum {
+    GO_KARANGS_BANNER = 178205,
+};
+
+struct DestroyKarangsBanner : public SpellScript
+{
+    void OnSuccessfulFinish(Spell* spell) const override
+    {
+        if (!spell->GetCaster()->IsCreature())
+            return;
+
+        Creature* caster = static_cast<Creature*>(spell->GetCaster());
+        if (!caster || !caster->IsAlive())
+            return;
+
+        // Tested on Classic, spell should despawn ALL Gameobjects
+        GameObjectList bannerList;
+        GetGameObjectListWithEntryInGrid(bannerList, caster, GO_KARANGS_BANNER, 50.f);
+        for (const auto gobanner : bannerList)
+        {
+            gobanner->ForcedDespawn();
+        }
+
+        // Change Worldstate so NPCs stop respawning
+        caster->GetMap()->GetVariableManager().SetVariable(WORLD_STATE_CUSTOM_FOULWEALD, 0);
+
+        // SendAIEvent to handle Despawning after leaving Combat
+        caster->AI()->SendAIEventAround(AI_EVENT_CUSTOM_EVENTAI_A, caster, 0, 50);
+    }
+};
 
 void AddSC_ashenvale()
 {

--- a/src/game/World/WorldStateDefines.h
+++ b/src/game/World/WorldStateDefines.h
@@ -344,7 +344,7 @@ enum WorldStateID : int32
     WORLD_STATE_CUSTOM_STV_GRP_02      = 330002,
 
     // Ashenvale Quest King of the Foulweald
-    WORLD_STATE_CUSTOM_FOULWEALD       = 18005,
+    WORLD_STATE_CUSTOM_FOULWEALD       = 18003,
 
     // Tbc
     WORLD_STATE_CUSTOM_SPAWN_MALACRASS = 5680001,

--- a/src/game/World/WorldStateDefines.h
+++ b/src/game/World/WorldStateDefines.h
@@ -343,6 +343,9 @@ enum WorldStateID : int32
     WORLD_STATE_CUSTOM_STV_GRP_01      = 330001,
     WORLD_STATE_CUSTOM_STV_GRP_02      = 330002,
 
+    // Ashenvale Quest King of the Foulweald
+    WORLD_STATE_CUSTOM_FOULWEALD       = 18005,
+
     // Tbc
     WORLD_STATE_CUSTOM_SPAWN_MALACRASS = 5680001,
 


### PR DESCRIPTION
…Foulweald

## 🍰 Pullrequest
On Quest King of the Foulweald (6621) Player uses Item Karang's Banner (16972).
After using the Item, Karangs Banner object will spawn and start a small Event.

Custom WorldState will change to true and 2 Enraged Foulwealds from a SpawnGroup will start spawning.
SpawnGroup has 11 different Creature spawn positions, all creatures have static waypoints.

On Waypoint reach NPCs will start to channel the spell Destroy Karang's Banner ID: 20786.
If they finish the Channel, all Banner objects will despawn, Custom WorldState gets changed to false so spawn_group will stop respawning.
All npcs that are spawned will despawn if they are not InCombat (handled via cai).
Event will stop.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
