### PR TITLE
STV: Colonel Kurzen AI rework

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -1160,6 +1160,7 @@ UPDATE creature_template SET ScriptName='npc_field_marshal_afrasiabi' WHERE entr
 /* STRANGLETHORN VALE */
 UPDATE creature_template SET ScriptName='mob_yenniku' WHERE entry=2530;
 UPDATE gameobject_template SET ScriptName='go_transpolyporter_bb' WHERE entry IN(142172);
+UPDATE creature_template SET ScriptName='mob_colonel_kurzen' WHERE entry=813;
 
 /* STRATHOLME */
 UPDATE instance_template SET ScriptName='instance_stratholme' WHERE map=329;

--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -171,6 +171,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (28857,'spell_increased_spell_damage_done_dummy'),
 (21056,'spell_mark_of_lord_kazzak'),
 (21063,'spell_twisted_reflection'),
+(8822,'spell_kurzen_stealth'),
 (491,'spell_gameobject_call_for_help_on_usage'), -- Khadgar's Unlocking
 (857,'spell_gameobject_call_for_help_on_usage'), -- Khadgar's Unlocking
 (1804,'spell_gameobject_call_for_help_on_usage'), -- Pick Lock

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/stranglethorn_vale.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/stranglethorn_vale.cpp
@@ -124,7 +124,9 @@ struct mob_colonel_kurzenAI : public CombatAI
 {
     mob_colonel_kurzenAI(Creature* creature) : CombatAI(creature, KURZEN_ACTION_MAX)
     {
-        AddCombatAction(KURZEN_ACTION_VANISH, 40000u);
+        // Old timer in creature AI were 8000-12000 repeat 18000-25000
+        // Classic tests first were around 12 seconds
+        AddCombatAction(KURZEN_ACTION_VANISH, 12000u);
         AddCustomAction(KURZEN_ACTION_GAROTTE, true, [&]()
             {
                 if (m_creature->GetVictim())
@@ -151,7 +153,7 @@ struct mob_colonel_kurzenAI : public CombatAI
             if (m_creature->IsInCombat()) // can happen on evade
                 DoStartMovement(m_creature->GetVictim());
 
-            ResetTimer(KURZEN_ACTION_VANISH, urand(12000, 22000));
+            ResetTimer(KURZEN_ACTION_VANISH, urand(10000, 18000));
         }
     }
 


### PR DESCRIPTION
## 🍰 Pullrequest
This is a WiP and will take some more debugging.

[Colonel Kurzen ](https://www.wowhead.com/classic/npc=813/colonel-kurzen#abilities) will use [Smoke Bomb](https://www.wowhead.com/classic/spell=8817/smoke-bomb) on a 10-18 second timer (guessed from classic tests).
When using Smoke Bomb, player gets stunned and Colonel Kurzen will get [Stealth](https://www.wowhead.com/classic/spell=8822/stealth) and SPELL_AURA_MOD_FEAR.
Player should keep in Combat with Colonel Kurzen while he is in Stealth.

After 6-12 seconds Colonel Kurzen will cast [Garrote](https://www.wowhead.com/classic/spell=8818/garrote) onto Player and loose Stealth.

This will repeat till Colonel Kurzen is dead.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->

Currently Player will loose aggro with Colonel Kurzen and he will keep running back to spawn position.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
