### PR TITLE
Possible fix to XP per kill rounding/truncation issue

### DIFF
--- a/src/game/Tools/Formulas.h
+++ b/src/game/Tools/Formulas.h
@@ -129,7 +129,7 @@ namespace MaNGOS
             return 17;
         }
 
-        inline uint32 BaseGain(uint32 unit_level, uint32 mob_level, ContentLevels content)
+        inline float BaseGain(uint32 unit_level, uint32 mob_level, ContentLevels content)
         {
             uint32 nBaseExp = unit_level * 5;
             switch (content)

--- a/src/game/Tools/Formulas.h
+++ b/src/game/Tools/Formulas.h
@@ -131,7 +131,7 @@ namespace MaNGOS
 
         inline float BaseGain(uint32 unit_level, uint32 mob_level, ContentLevels content)
         {
-            uint32 nBaseExp = unit_level * 5;
+            float nBaseExp = unit_level * 5;
             switch (content)
             {
                 case CONTENT_1_60:  nBaseExp += 45;  break;


### PR DESCRIPTION
The multiplication steps `return nBaseExp * (1.0f + (0.05f * nLevelDiff));` and `return nBaseExp * (1.0f - (float(nLevelDiff) / ZD));` produce `float` values, but since the return type of `BaseGain` is `uint32`, the compiler implicitly truncates the XP value when converting from `float` to `uint32`.

By changing the return type of `BaseGain` from `uint32` to `float`, this preserves the fractional XP value until the very end, when the XP value is converted to an integer using `std:nearbyint()`.

I did very limited testing, but, for example, killing a Level 3 mob as Level 2 player did, in fact, yield `58` rather than `57` XP after this change, as intended (I observed on official Blizzard realms that XP per kill is always rounded up rather than truncated/rounded down).


This conversation was originally had over in VMaNGOS, where I proposed a similar change. I observed the same behaviour in CMaNGOS.

I, in no way, pretend to be an expert, and I'm happy to be educated in a different direction if this change is flawed in some way.
