### PR TITLE
EventAI: add a simple InCombat check to EVENT_T_RECEIVE_AI_EVENT

### DIFF
--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -540,6 +540,19 @@ bool CreatureEventAI::CheckEvent(CreatureEventAIHolder& holder, Unit* actionInvo
             break;
         }
         case EVENT_T_RECEIVE_AI_EVENT:
+            // 0 = Out and in combat
+            // 1 = Only in Combat
+            // 2 = Only out of combat
+            if (event.receiveAIEvent.inCombat == 1)
+            {
+                if (!m_creature->IsInCombat())
+                    return false;
+            }
+            if (event.receiveAIEvent.inCombat == 2)
+            {
+                if (m_creature->IsInCombat())
+                    return false;
+            }
             break;
         case EVENT_T_ENERGY:
         {

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -69,7 +69,7 @@ enum EventAI_Type
     EVENT_T_MISSING_AURA            = 27,                   // Param1 = SpellID, Param2 = Number of time stacked expected, Param3/4 Repeat Min/Max
     EVENT_T_TARGET_MISSING_AURA     = 28,                   // Param1 = SpellID, Param2 = Number of time stacked expected, Param3/4 Repeat Min/Max
     EVENT_T_TIMER_GENERIC           = 29,                   // InitialMin, InitialMax, RepeatMin, RepeatMax
-    EVENT_T_RECEIVE_AI_EVENT        = 30,                   // AIEventType, Sender-Entry, unused, unused
+    EVENT_T_RECEIVE_AI_EVENT        = 30,                   // AIEventType, Sender-Entry, inCombat, unused
     EVENT_T_ENERGY                  = 31,                   // EnergyMax%, EnergyMin%, RepeatMin, RepeatMax
     EVENT_T_SELECT_ATTACKING_TARGET = 32,                   // MinRange, MaxRange, RepeatMin, RepeatMax
     EVENT_T_FACING_TARGET           = 33,                   // Position, unused, RepeatMin, RepeatMax
@@ -757,7 +757,7 @@ struct CreatureEventAI_Event
         {
             uint32 eventType;                               // See UnitAI.h enum AIEventType - Receive only events of this type
             uint32 senderEntry;                             // Optional npc from only whom this event can be received
-            uint32 unused1;
+            uint32 inCombat;
             uint32 unused2;
         } receiveAIEvent;
         // EVENT_T_SELECT_ATTACKING_TARGET                  = 32


### PR DESCRIPTION
## 🍰 Pullrequest

This change will help recreating some OpenWorld RPs. 
As an example i will use the RP from Warp-Raider Nesaad with his 2 Zaxxis Stalker.

https://youtu.be/EY_ur_8Sf4U 

The first part of the Video where he turns to one of the Zaxxis Stalkers and says some text with emote, will happen even if the Stalker is Dead.
The 2nd Part where the Zaxxis Stalker will teleport away, should only happen if they are alive and not in combat.
AFAIK we currently don't support any inCombat checks for dbscripts .

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
