### PR TITLE
Darkshore: add SitState to Volcor

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/darkshore.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/darkshore.cpp
@@ -401,7 +401,7 @@ struct npc_volcorAI : public npc_escortAI
     uint32 m_uiQuestId;
 
     void Reset() override
-    {        
+    {
         if (!HasEscortState(STATE_ESCORT_ESCORTING))
         {
             m_uiQuestId = 0;

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/darkshore.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/darkshore.cpp
@@ -401,9 +401,12 @@ struct npc_volcorAI : public npc_escortAI
     uint32 m_uiQuestId;
 
     void Reset() override
-    {
+    {        
         if (!HasEscortState(STATE_ESCORT_ESCORTING))
+        {
             m_uiQuestId = 0;
+            m_creature->SetStandState(UNIT_STAND_STATE_SIT, true);
+        }
     }
 
     void Aggro(Unit* /*pWho*/) override


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Volcor has UNIT_STAND_STATE_SIT on spawn and will StandUp when Players accept EscortQuests.

This got handled via creature_template_addon till now, resulting in Volcor getting SitState everytime resets during Escort Quests.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
