### PR TITLE
compiler warnings: suppress known C++20 warnings till fixed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,27 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Option to suppress known C++20 warnings till fixed
+option(SUPPRESS_CXX20_DEPRECATED_WARNINGS "Suppress deprecated C++20 warnings (enum conversions, implicit this-capture, enum compare, volatile)" OFF)
+
+if (SUPPRESS_CXX20_DEPRECATED_WARNINGS)
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(
+      -Wno-deprecated-enum-enum-conversion
+      -Wno-deprecated-enum-float-conversion
+      -Wno-deprecated-this-capture
+      -Wno-enum-compare
+    )
+  elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    add_compile_options(
+      -Wno-deprecated-enum-enum-conversion
+      -Wno-deprecated-enum-float-conversion
+      -Wno-volatile
+      -Wno-enum-compare
+    )
+  endif()
+endif()
+
 # Define here name of the binaries
 set(CMANGOS_BINARY_SERVER_NAME "mangosd")
 set(CMANGOS_BINARY_REALMD_NAME "realmd")


### PR DESCRIPTION

Purpose
After switching to C++20, recent compiler versions (GCC/Clang) now trigger several new warnings — especially from older code like ScriptDevAI.
Examples:
    -Wdeprecated-enum-enum-conversion
    -Wdeprecated-enum-float-conversion
    -Wdeprecated-this-capture
    -Wenum-compare, -Wvolatile
These warnings clutter the build output and make it harder to spot real issues.

Why suppress (temporarily)
    Cleaner build logs – Easier to work with.
    Legacy code – Updating every warning would require large refactoring.
    Optional toggle – A new CMake flag SUPPRESS_CXX20_DEPRECATED_WARNINGS lets users choose.
    
 Solution (temporarily)
 option(SUPPRESS_CXX20_DEPRECATED_WARNINGS "Suppress deprecated C++20 warnings" OFF)
 If enabled, known C++20 warnings are suppressed via add_compile_options(...)
 
![grafik](https://github.com/user-attachments/assets/b13ed708-27b7-451f-8d37-e87a9a7dbd12)
