### PR TITLE
[Hunter] Fix clever Traps increasing freezing trap duration in PvP

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -667,6 +667,9 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (34799,'spell_arcane_devastation'),
 (34145,'spell_ritual_of_souls_dummy'),
 (34219,'spell_recharging_battery'),
+(3355,'spell_freezing_trap'),
+(14308,'spell_freezing_trap'),
+(14309,'spell_freezing_trap'),
 (32173,'spell_entangling_roots');
 
 -- Wotlk

--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Hunter.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Hunter.cpp
@@ -134,10 +134,36 @@ struct ExposeWeakness : public AuraScript
     }
 };
 
+// 3355 - Freezing Trap (Rank 1)
+// 14308 - Freezing Trap (Rank 2)
+// 14309 - Freezing Trap (Rank 3)
+
+struct FreezingTrapEffect : public AuraScript
+{
+    int32 OnDurationCalculate(WorldObject const* caster, Unit const* target, int32 duration) const override
+    {
+        if (caster && caster->IsUnit())
+        {
+            if (target && target->IsPlayerControlled())
+            {
+                // Clever Traps Rank 1
+                if (static_cast<Unit const*>(caster)->HasAura(19239))
+                    return 11500;
+
+                // Clever Traps Rank 1
+                if (static_cast<Unit const*>(caster)->HasAura(19245))
+                    return 13000;
+            }
+        }
+        return duration;
+    }
+};
+
 void LoadHunterScripts()
 {
     RegisterSpellScript<HuntersMark>("spell_hunters_mark");
     RegisterSpellScript<KillCommand>("spell_kill_command");
     RegisterSpellScript<Misdirection>("spell_misdirection");
     RegisterSpellScript<ExposeWeakness>("spell_expose_weakness");
+    RegisterSpellScript<FreezingTrapEffect>("spell_freezing_trap");
 }

--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Hunter.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Hunter.cpp
@@ -150,7 +150,7 @@ struct FreezingTrapEffect : public AuraScript
                 if (static_cast<Unit const*>(caster)->HasAura(19239))
                     return 11500;
 
-                // Clever Traps Rank 1
+                // Clever Traps Rank 2
                 if (static_cast<Unit const*>(caster)->HasAura(19245))
                     return 13000;
             }


### PR DESCRIPTION
Freezing Trap should have a 10/11.5/13 sec duration in pvp if hunter has Clever Traps skilled

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->


### Proof
<!-- Link resources as proof -->
[Video 1](https://www.youtube.com/watch?t=209&v=hLKGHtvYdhQ&feature=youtu.be)


### Issues
<!-- Which Issues does this fix, which are related?  -->
Fixes https://github.com/cmangos/issues/issues/3126

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.  -->

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
Testing multiple situations
