### PR TITLE
TK: Fix countercharge usage

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -327,7 +327,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (31532,'spell_repair_mekgineer'),
 (37936,'spell_repair_mekgineer'),
 (35284,'spell_summon_nether_wraiths'),
-(35781,'spell_countercharge'),
+(35035,'spell_countercharge'),
 (37866,'spell_summon_water_globules'),
 (38028,'spell_watery_grave'),
 (32360,'spell_stolen_soul_summon'),

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_eye/the_eye.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_eye/the_eye.cpp
@@ -215,17 +215,18 @@ void instance_the_eye::OpenDoors()
     DoUseOpenableObject(GO_ARCANE_DOOR_VERT_4, true);
 }
 
-struct CounterCharge : public SpellScript
+struct CounterCharge : public AuraScript
 {
-    void OnCast(Spell* spell) const override
+    void OnHeartbeat(Aura* aura) const override
     {
-        Unit* caster = spell->GetCaster();
-        if (Unit* target = caster->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, 35039, SELECT_FLAG_PLAYER | SELECT_FLAG_CASTING))
+        if (urand(0, 3) == 0)
         {
-            caster->CastSpell(target, 35039, TRIGGERED_OLD_TRIGGERED);
-            caster->RemoveAurasDueToSpell(35035);
+            Unit* caster = aura->GetCaster();
+            if (Unit* target = caster->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, 35039, SELECT_FLAG_PLAYER | SELECT_FLAG_CASTING))
+            {
+                caster->CastSpell(target, 35039, TRIGGERED_OLD_TRIGGERED);
+            }
         }
-        spell->SetEffectChance(0, EFFECT_INDEX_1);
     }
 };
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
**_Current Implementation:_**
[Crystalcore Devastator](https://www.wowhead.com/tbc/npc=20040/crystalcore-devastator) - casts Countercharge on self (timer based via acid)
[Countercharge (Id 35035)](https://www.wowhead.com/tbc/spell=35035/countercharge) will proc Spell: 35781 when hitting the Player.
When Countercharge (35781) hit the Player, it will check if random player is casting and will let Crystalcore Devastator also cast [Countercharge (ID 35039)](https://www.wowhead.com/tbc/spell=35039/countercharge).

**_New Implementation_**
[Crystalcore Devastator](https://www.wowhead.com/tbc/npc=20040/crystalcore-devastator) will cast [Countercharge (35035)](https://www.wowhead.com/tbc/spell=35035/countercharge) on self via spell_list.
When Crystalcore Devastor has aura 35035, it has a chance to cast spell [Countercharge (35039)](https://www.wowhead.com/tbc/spell=35039/countercharge) on a random casting Player, without having to proc Countercharge (35781) first.

### Proof
<!-- Link resources as proof -->
Its realy hard to proof that this also works like Described above on TBC but ill try to show it with Videos from retail and why we think it should work like this.

First video from MoP Classic, you can see that Crystalcore Devastator casts Countercharge on them self, and looses it after he hits Player.
[Video 1](https://www.youtube.com/watch?v=qgKxRbOZQHs&feature=youtu.be)

2nd Video, and this is the Important part, he casts the range Interupt [Countercharge (35039](https://www.wowhead.com/tbc/spell=35039/countercharge)) even if the tank never gets meleed from the npc. (See Combatlog)
[Video 2](https://www.youtube.com/watch?v=AjNVrSMfvuo&feature=youtu.be)

Why this should work like this?
On current implementation this would mean, that Crystalcore Devastator will never use the caster Interupt if the tank has enough dodge/block/parry (not hitting tank = not proccing spell 35781)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
