### PR TITLE
[Spell] Add script for z level fix for [DND] TAR Pedestal npcs

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -1197,6 +1197,30 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 
 -- World Events
 INSERT INTO spell_scripts(Id, ScriptName) VALUES
+-- PTR
+(47327,'spell_summon_pedestal_npc'),
+(47347,'spell_summon_pedestal_npc'),
+(47348,'spell_summon_pedestal_npc'),
+(47349,'spell_summon_pedestal_npc'),
+(47350,'spell_summon_pedestal_npc'),
+(47351,'spell_summon_pedestal_npc'),
+(47352,'spell_summon_pedestal_npc'),
+(47353,'spell_summon_pedestal_npc'),
+(47354,'spell_summon_pedestal_npc'),
+(47355,'spell_summon_pedestal_npc'),
+(47356,'spell_summon_pedestal_npc'),
+(47357,'spell_summon_pedestal_npc'),
+(47358,'spell_summon_pedestal_npc'),
+(47359,'spell_summon_pedestal_npc'),
+(47360,'spell_summon_pedestal_npc'),
+(47361,'spell_summon_pedestal_npc'),
+(47362,'spell_summon_pedestal_npc'),
+(47363,'spell_summon_pedestal_npc'),
+(47364,'spell_summon_pedestal_npc'),
+(47365,'spell_summon_pedestal_npc'),
+(47366,'spell_summon_pedestal_npc'),
+(47367,'spell_summon_pedestal_npc'),
+(47368,'spell_summon_pedestal_npc'),
 -- Lunar Festival
 (26286, 'spell_lunar_festival_firework'),
 (26291, 'spell_lunar_festival_firework'),

--- a/src/game/AI/ScriptDevAI/scripts/world/spell_scripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/spell_scripts.cpp
@@ -974,6 +974,12 @@ struct InvisibleForAlive : public AuraScript
     }
 };
 
+// 47327,47347,47348,47349,47350,47351,47352,47353,47354,47355,47356,47357,47358,47359,47360,47361,47362,47363,47364,47365,47366,47367,47368 - TAR Pedestal
+struct SummonPedestalNpc : public SpellScript
+{
+    void OnDestTarget(Spell* spell) const override { spell->m_targets.m_destPos.z += 3.68333f; }
+};
+
 void AddSC_spell_scripts()
 {
     RegisterSpellScript<CastFishingNet>("spell_cast_fishing_net");
@@ -1025,4 +1031,5 @@ void AddSC_spell_scripts()
     RegisterSpellScript<RandomAggro>("spell_random_aggro");
     RegisterSpellScript<RandomAggro1000000>("spell_random_aggro_1000000");
     RegisterSpellScript<InvisibleForAlive>("spell_shroud_of_death");
+    RegisterSpellScript<SummonPedestalNpc>("spell_summon_pedestal_npc");
 }


### PR DESCRIPTION
![pedestal](https://github.com/user-attachments/assets/f0fa1c5b-127f-406b-8d57-1e435aed2f1e)

without script in the texture, with script at the hight it is where it is spawned with sniffed position.
seemingly should stand perfectly ontop, this seems to not be possible due to gobject clipping.

wit further adjustments it works sometimes, but not always.

<img width="1048" height="322" alt="grafik" src="https://github.com/user-attachments/assets/12128c0a-61fa-4f70-995e-f709334dc6a7" />
<img width="871" height="230" alt="grafik" src="https://github.com/user-attachments/assets/bcef3ef4-5a9d-442d-b306-33697ee9fed8" />
