### PR TITLE
TK: remove Countercharge spell_script

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -414,7 +414,6 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (31532,'spell_repair_mekgineer'),
 (37936,'spell_repair_mekgineer'),
 (35284,'spell_summon_nether_wraiths'),
-(35781,'spell_countercharge'),
 (37866,'spell_summon_water_globules'),
 (38028,'spell_watery_grave'),
 (32360,'spell_stolen_soul_summon'),

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_eye/the_eye.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_eye/the_eye.cpp
@@ -215,19 +215,6 @@ void instance_the_eye::OpenDoors()
     DoUseOpenableObject(GO_ARCANE_DOOR_VERT_4, true);
 }
 
-struct CounterCharge : public SpellScript
-{
-    void OnCast(Spell* spell) const override
-    {
-        Unit* caster = spell->GetCaster();
-        if (Unit* target = caster->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, 35039, SELECT_FLAG_PLAYER | SELECT_FLAG_CASTING))
-        {
-            caster->CastSpell(target, 35039, TRIGGERED_OLD_TRIGGERED);
-            caster->RemoveAurasDueToSpell(35035);
-        }
-        spell->SetEffectChance(0, EFFECT_INDEX_1);
-    }
-};
 
 void AddSC_instance_the_eye()
 {
@@ -235,6 +222,4 @@ void AddSC_instance_the_eye()
     pNewScript->Name = "instance_the_eye";
     pNewScript->GetInstanceData = &GetNewInstanceScript<instance_the_eye>;
     pNewScript->RegisterSelf();
-
-    RegisterSpellScript<CounterCharge>("spell_countercharge");
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
As described in here https://github.com/cmangos/mangos-tbc/pull/759

Removing not needed Countercharge spell_script. Caster Interupt will now get handled via creature_spell_list coming with https://github.com/cmangos/tbc-db/pull/1261

Countercharge (35039 Caster Interupt+Knockback) will not consume [Countercharge (Id 35035)](https://www.wowhead.com/tbc/spell=35035/countercharge) buff.


### Proof
<!-- Link resources as proof -->
From MoP Classic tests: https://youtu.be/K2X5yxKSaiE 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
