### PR TITLE
[BF] Fix Broggok not entering EvadeMode correctly

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/blood_furnace/blood_furnace.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/blood_furnace/blood_furnace.cpp
@@ -370,7 +370,7 @@ void instance_blood_furnace::Update(uint32 uiDiff)
     {
         if (Creature* pMagtheridon = GetSingleCreatureFromStorage(NPC_MAGTHERIDON))
         {
-            DoScriptText(aRandomTaunt[urand(0, 5)], pMagtheridon);
+            DoBroadcastText(aRandomTaunt[urand(0, 5)], pMagtheridon);
             m_uiRandYellTimer = 90000;
         }
     }

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/blood_furnace/blood_furnace.h
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/blood_furnace/blood_furnace.h
@@ -73,7 +73,7 @@ const std::string FOURTH_BROGGOK_CELL_STRING = "BF_PRISON_CELL_GROUP_04";
 const std::string FIFTH_BROGGOK_CELL_STRING = "BF_PRISON_CELL_GROUP_05";
 
 // Random Magtheridon taunt
-static const int32 aRandomTaunt[] = { -1544000, -1544001, -1544002, -1544003, -1544004, -1544005};
+static const int32 aRandomTaunt[] = {17339, 17340, 17341, 17342, 17343, 17344};
 
 struct BroggokEventInfo
 {

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/blood_furnace/boss_broggok.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/blood_furnace/boss_broggok.cpp
@@ -61,16 +61,12 @@ struct boss_broggokAI : public CombatAI
     ScriptedInstance* m_instance;
     bool m_isRegularMode;
 
-    void Aggro(Unit* /*who*/) override
-    {
-        if (m_instance)
-            m_instance->SetData(TYPE_BROGGOK_EVENT, IN_PROGRESS);
-    }
-
     void EnterEvadeMode() override
     {
         if (m_instance)
             m_instance->SetData(TYPE_BROGGOK_EVENT, FAIL);
+
+        CombatAI::EnterEvadeMode();
     }
 
     void JustSummoned(Creature* summoned) override
@@ -81,6 +77,7 @@ struct boss_broggokAI : public CombatAI
             summoned->AI()->SetReactState(REACT_DEFENSIVE);
             summoned->AI()->SetCombatMovement(false);
             summoned->AI()->SetMeleeEnabled(false);
+            summoned->SetCanCallForAssistance(false);
             summoned->SetInCombatWithZone();
         }
         else


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Some bugfixes to Broggok fight and Blood Furnance instance.
Magtheridon will again uses his correct textes.
CombatTrigger will not put other into Combat (previously broggok always got infight when door opened)
Door should now stay open when Broggok starts moving.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
