### PR TITLE
[Spell] Add SPELL_ATTR_SS_FACING_BACK for s.36909 Back Attack

### DIFF
--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2890,7 +2890,7 @@ UPDATE `spell_template` SET `AttributesEx4`=`AttributesEx4`|64 WHERE `Id`=33949;
 
 -- Backstab spells used by creatures
 -- these are all easily controlled and made castable only from behind via AI, however when a player Mind Controls the NPC, we need these attributes to prevent usage from the front:
-UPDATE `spell_template` SET AttributesServerside=AttributesServerside|0x00000008 WHERE `Id` IN (53,2589,2590,2591,6595,7159,8355,8721,11279,11280,11281,15582,15657,22416,24016,25300,26863,30992,34171,34614,37685,37956); -- SPELL_ATTR_SS_FACING_BACK
+UPDATE `spell_template` SET AttributesServerside=AttributesServerside|0x00000008 WHERE `Id` IN (53,2589,2590,2591,6595,7159,8355,8721,11279,11280,11281,15582,15657,22416,24016,25300,26863,30992,34171,34614,36909,37685,37956); -- SPELL_ATTR_SS_FACING_BACK
 
 -- Infront only Spells - SPELL_FACING_FLAG_INFRONT "Must be in front of the caster."
 UPDATE `spell_template` SET `FacingCasterFlags` = 1 WHERE `Id` IN (12540,13579,29425,36862,38863);


### PR DESCRIPTION
Id: 36909
Name: Back Attack
Description: Inflicts normal damage plus $s1 on an enemy, but only if attacking from behind.