### PR TITLE
Fix issue with GO 178559 not being activated on use

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -3688,6 +3688,7 @@ void Spell::SendLoot(ObjectGuid guid, LootType loottype, LockType lockType)
                         {
                             case LOCKTYPE_NONE:
                             case LOCKTYPE_DISARM_TRAP:
+                            case LOCKTYPE_OPEN: // handle GO 178559 in patch 2.4.3 which apparently uses open and not open_attacking
                             case LOCKTYPE_OPEN_ATTACKING:
                                 gameObjTarget->SetLootState(GO_ACTIVATED);
                                 return;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Fix interaction for GO 178559 which currently does nothing when a player interacts with it

### Proof
<!-- Link resources as proof -->
(https://www.youtube.com/watch?v=3tPJJUgqLKY)

### Issues

GO 178559 currently does nothing when a player interacts with it. It should play an animation and as a consequence stop the associated mob from spawning.

In investigating this issue it turns out the 2.4.3 client is the reason for this issue, this code change is not needed for 1.12, 3.3.5 client,

Animation bug caused by client is also present in other GO but they function normally.


### How2Test

.tele maraudon, enter
.go object 3490001
right click on the object to use it, it deflates, and the green larva npc no longer spawns.

### Todo / Checklist


Remaining problem is that trap type GO still display an unavailable interaction "Too far away" when clicked after use, even if distance to the GO is 0 (.go object ### is used). This is also visible for Suppression Devices in Blackwing Lair, there should be no hover after they are disarmed.
