### PR TITLE
Fix Ruthlessness bug with Slice and Dice

### DIFF
--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -2475,7 +2475,7 @@ SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(ProcExecutionData& data
             {
                 // Only trigger if you are not the target (Slice and Dice casts twice,
                 // ignore on you, keep on target)
-                if (pVictim->GetGUIDLow() != GetGUIDLow()) 
+                if (pVictim->GetObjectGuid() != GetObjectGuid()) 
                 {
                     spell->AddTriggeredSpell(trigger_spell_id);
                     return SPELL_AURA_PROC_OK;

--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -2475,7 +2475,7 @@ SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(ProcExecutionData& data
             {
                 // Only trigger if you are not the target (Slice and Dice casts twice,
                 // ignore on you, keep on target)
-                if (pVictim->GetName() != GetName()) 
+                if (pVictim->GetGUIDLow() != GetGUIDLow()) 
                 {
                     spell->AddTriggeredSpell(trigger_spell_id);
                     return SPELL_AURA_PROC_OK;

--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -2473,8 +2473,16 @@ SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(ProcExecutionData& data
             // Need add combopoint AFTER finishing move (or they get dropped in finish phase)
             if (Spell* spell = GetCurrentSpell(CURRENT_GENERIC_SPELL))
             {
-                spell->AddTriggeredSpell(trigger_spell_id);
-                return SPELL_AURA_PROC_OK;
+                // Only trigger if you are not the target (Slice and Dice casts twice,
+                // ignore on you, keep on target)
+                if (pVictim->GetName() != GetName()) 
+                {
+                    spell->AddTriggeredSpell(trigger_spell_id);
+                    return SPELL_AURA_PROC_OK;
+                }
+                // player is target, ignore
+                else         
+                    return SPELL_AURA_PROC_FAILED;
             }
             return SPELL_AURA_PROC_FAILED;
         }


### PR DESCRIPTION
Fix Slice and Dice activating Ruthlessness twice. 

Slice and Dice casts on both self and target with combo points which activates the passive twice as often as other finishers and can even result in 2 combo points after cast.

This fix ensures that if Ruthlessness activates but if the target is self (the rogue casting slice and dice), it does not award the combo point. That way, only the cast on the target with existing combo points awards proc.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes https://github.com/cmangos/issues/issues/3927
- relates #XXX
-->
fixes https://github.com/cmangos/issues/issues/3927

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
