### PR TITLE
[Molten Core] Implement Core Hound (11671) collapse/reignite.

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -931,6 +931,7 @@ UPDATE creature_template SET ScriptName='boss_ragnaros' WHERE entry=11502;
 UPDATE creature_template SET ScriptName='mob_firesworn' WHERE entry=12099;
 UPDATE creature_template SET ScriptName='mob_core_rager' WHERE entry=11672;
 UPDATE creature_template SET ScriptName='mob_flamewaker_priest' WHERE entry=11662;
+UPDATE creature_template SET ScriptName='npc_core_hound' WHERE entry=11671;
 UPDATE gameobject_template SET ScriptName='go_molten_core_rune' WHERE entry IN (176951, 176952, 176953, 176954, 176955, 176956, 176957);
 
 /* MOONGLADE */

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/molten_core/molten_coreScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/molten_core/molten_coreScripts.cpp
@@ -24,6 +24,7 @@ EndScriptData */
 /* ContentData
 EndContentData */
 
+#include "AI/EventAI/CreatureEventAI.h"
 #include "AI/ScriptDevAI/include/sc_common.h"
 #include "molten_core.h"
 
@@ -54,6 +55,94 @@ bool GOUse_go_molten_core_rune(Player* /*pPlayer*/, GameObject* pGo)
     return true;
 }
 
+struct npc_core_hound : public CreatureEventAI
+{
+    // Action IDs
+    static constexpr uint32 actionReigniteTimer = 0;
+
+    // Spells
+    static constexpr uint32 spellFullHeal = 17683;
+    static constexpr uint32 spellPlayDead = 19822;
+    static constexpr uint32 spellFireNovaVisual = 19823;
+    static constexpr uint32 spellPacifySelf = 19951;
+
+    npc_core_hound(Creature* creature) : CreatureEventAI(creature)
+    {
+        SetDeathPrevention(true);
+        AddCustomAction(actionReigniteTimer, true, [this] { HandleReigniteTimer(); });
+    }
+
+    void Reset() override
+    {
+        CreatureEventAI::Reset();
+        SetDeathPrevention(true);
+    }
+
+    // Reignite, exiting a fake death.
+    void Reignite()
+    {
+        m_creature->SetStandState(UNIT_STAND_STATE_STAND);
+        m_creature->RemoveAurasDueToSpell(spellPacifySelf);
+        m_creature->RemoveAurasDueToSpell(spellPlayDead);
+        DoCastSpellIfCan(m_creature, spellFullHeal, CAST_TRIGGERED);
+        DoResetThreat();
+        SetCombatMovement(true);
+
+        SetDeathPrevention(true);
+
+        // %s reignites from the heat of another Core Hound!
+        DoBroadcastText(7867, m_creature);
+    }
+
+    // Collapse, entering a fake death.
+    // Notes:
+    // * You can still target a collapsed Core Hound.
+    // * You can still damage a collapsed Core Hound.
+    // * They keep debuffs (Curse of the Elements, Sunders, etc).
+    // To do:
+    // * Confirm they keep combo points.
+    void Collapse()
+    {
+        // %s collapses and begins to smolder.
+        DoBroadcastText(7866, m_creature);
+
+        ResetTimer(actionReigniteTimer, 10000);
+
+        DoCastSpellIfCan(m_creature, spellPlayDead, CAST_TRIGGERED);
+        DoCastSpellIfCan(m_creature, spellPacifySelf, CAST_TRIGGERED);
+
+        m_creature->SetTarget(nullptr);
+        SetCombatMovement(false);
+        m_creature->SetStandState(UNIT_STAND_STATE_DEAD);
+    }
+
+    void JustPreventedDeath(Unit* /*attacker*/) override
+    {
+        Collapse();
+    }
+
+    void HandleReigniteTimer()
+    {
+        // Reignite if there are still other core hounds alive 10 seconds after the collapse.
+        std::list<Creature*> coreHounds;
+        GetCreatureListWithEntryInGrid(coreHounds, m_creature, 11671 /* Core Hound */, 40.0f);
+        for (Creature* coreHound : coreHounds)
+        {
+            // Ignore alive core hounds in groups not in combat with us.
+            if (coreHound && coreHound->IsInCombat() && coreHound->GetHealth() > 1)
+            {
+                Reignite();
+                DoCastSpellIfCan(m_creature, spellFireNovaVisual, CAST_TRIGGERED);
+                return;
+            }
+        }
+
+        // No other core hounds alive: really die (and despawn the corpse).
+        m_creature->Suicide();
+        m_creature->ForcedDespawn();
+    }
+};
+
 void AddSC_molten_core()
 {
     Script* pNewScript;
@@ -61,5 +150,10 @@ void AddSC_molten_core()
     pNewScript = new Script;
     pNewScript->Name = "go_molten_core_rune";
     pNewScript->pGOUse = &GOUse_go_molten_core_rune;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "npc_core_hound";
+    pNewScript->GetAI = &GetNewAIInstance<npc_core_hound>;
     pNewScript->RegisterSelf();
 }

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/molten_core/molten_coreScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/molten_core/molten_coreScripts.cpp
@@ -24,6 +24,7 @@ EndScriptData */
 /* ContentData
 EndContentData */
 
+#include "AI/EventAI/CreatureEventAI.h"
 #include "AI/ScriptDevAI/include/sc_common.h"
 #include "molten_core.h"
 
@@ -54,6 +55,91 @@ bool GOUse_go_molten_core_rune(Player* /*pPlayer*/, GameObject* pGo)
     return true;
 }
 
+struct npc_core_hound : public CreatureEventAI
+{
+    // Action IDs
+    static constexpr uint32 actionReigniteTimer = 0;
+
+    // Spells
+    static constexpr uint32 spellFullHeal = 17683;
+    static constexpr uint32 spellFireNovaVisual = 19823;
+    static constexpr uint32 spellPacifySelf = 19951;
+
+    npc_core_hound(Creature* creature) : CreatureEventAI(creature)
+    {
+        SetDeathPrevention(true);
+        AddCustomAction(actionReigniteTimer, true, [this] { HandleReigniteTimer(); });
+    }
+
+    void Reset() override
+    {
+        CreatureEventAI::Reset();
+        SetDeathPrevention(true);
+    }
+
+    // Reignite, exiting a fake death.
+    void Reignite()
+    {
+        m_creature->SetStandState(UNIT_STAND_STATE_STAND);
+        m_creature->RemoveAurasDueToSpell(spellPacifySelf);
+        DoCastSpellIfCan(m_creature, spellFullHeal, CAST_TRIGGERED);
+        DoResetThreat();
+        SetCombatMovement(true);
+
+        SetDeathPrevention(true);
+
+        // %s reignites from the heat of another Core Hound!
+        DoBroadcastText(7867, m_creature);
+    }
+
+    // Collapse, entering a fake death.
+    // Notes:
+    // * You can still target a collapsed Core Hound.
+    // * You can still damage a collapsed Core Hound.
+    // * They keep debuffs (Curse of the Elements, Sunders, etc).
+    // To do:
+    // * Confirm they keep combo points.
+    void Collapse()
+    {
+        // %s collapses and begins to smolder.
+        DoBroadcastText(7866, m_creature);
+
+        ResetTimer(actionReigniteTimer, 10000);
+
+        DoCastSpellIfCan(m_creature, spellPacifySelf, CAST_TRIGGERED);
+
+        m_creature->SetTarget(nullptr);
+        SetCombatMovement(false);
+        m_creature->SetStandState(UNIT_STAND_STATE_DEAD);
+    }
+
+    void JustPreventedDeath(Unit* /*attacker*/) override
+    {
+        Collapse();
+    }
+
+    void HandleReigniteTimer()
+    {
+        // Reignite if there are still other core hounds alive 10 seconds after the collapse.
+        std::list<Creature*> coreHounds;
+        GetCreatureListWithEntryInGrid(coreHounds, m_creature, 11671 /* Core Hound */, 40.0f);
+        for (Creature* coreHound : coreHounds)
+        {
+            // Ignore alive core hounds in groups not in combat with us.
+            if (coreHound && coreHound->IsInCombat() && coreHound->GetHealth() > 1)
+            {
+                Reignite();
+                DoCastSpellIfCan(m_creature, spellFireNovaVisual, CAST_TRIGGERED);
+                return;
+            }
+        }
+
+        // No other core hounds alive: really die (and despawn the corpse).
+        m_creature->Suicide();
+        m_creature->ForcedDespawn();
+    }
+};
+
 void AddSC_molten_core()
 {
     Script* pNewScript;
@@ -61,5 +147,10 @@ void AddSC_molten_core()
     pNewScript = new Script;
     pNewScript->Name = "go_molten_core_rune";
     pNewScript->pGOUse = &GOUse_go_molten_core_rune;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "npc_core_hound";
+    pNewScript->GetAI = &GetNewAIInstance<npc_core_hound>;
     pNewScript->RegisterSelf();
 }


### PR DESCRIPTION
## 🍰 Pullrequest

I recently noticed that we don't seem to have the Core Hound's collapse/reignite mechanic implemented in Molten Core, so currently you can easily kill these packs by just killing them individually, rather than all within 10 seconds.

This PR is my implementation of this mechanic, but given I'm not familiar with core scripts, I'd like to have this reviewed before I push this.

### Proof
See for example the description [here](https://warcraft.wiki.gg/wiki/Core_Hound_(Molten_Core)).

### How2Test
* Enter Molten Core, go to the trash packs before Lucifron.
* Try to kill a Core Hound pack.
* Notice Core Hounds now collapse when you 'kill' them, but they reignite after 10s if any of the others are still alive at that time.
