### PR TITLE
Add Energizing Spores Spell 35336 to positive effects list

### DIFF
--- a/src/game/Spells/SpellMgr.h
+++ b/src/game/Spells/SpellMgr.h
@@ -1354,6 +1354,7 @@ inline bool IsPositiveEffect(const SpellEntry* spellproto, SpellEffectIndex effI
         case 33241:
         case 33045: // Wrath of the Astromancer - stacks like positive
         case 35424: // Soul Shadows - used by Shade of Mal'druk on Mal'druk the Soulrender
+        case 35336: // Energizing Spores - Cast by Sporebats on death
         case 42628: // Zul'Aman - Fire Bomb - Neutral spell
         case 44406: // Energy Infusion - supposed to be buff despite negative targeting
             return true;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Add Energizing Spores spell 35336 to positive effects list

### Proof
<!-- Link resources as proof -->
https://youtu.be/FsaskRGj7pM?t=548

The spell should also be listed as a debuff and not a buff, this requires an sql change.
You can find the associated sql change in this issue here: 
https://github.com/cmangos/issues/issues/4055

It increases your stats and is therefore always a positive effect.
