### PR TITLE
Build: Formalize ICU dependency from Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ endif()
 
 # Find needed packages and if necessery abort if something important is missing
 find_package(Boost 1.70.0 REQUIRED COMPONENTS program_options thread regex serialization filesystem)
-if (APPLE)
+if (UNIX OR APPLE)
     find_package(ICU COMPONENTS uc i18n data REQUIRED)
     add_library(icuuc ALIAS ICU::uc)
     add_library(icui18n ALIAS ICU::i18n)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR makes sure the ICU dependency we inherit from Boost::Regex is formally added in CMake, so error messages when the dependency is missing are easy to understand

Depends on commit https://github.com/cmangos/mangos-tbc/commit/cec7e209319fcf6fc7c469c74e750aa1a80ac925

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/4056

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Compile CMaNGOS on a Linux or MacOS system without libicu installed

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
