### PR TITLE
fix calling .back() on empty vector in MovePositionToFirstCollision

### DIFF
--- a/src/game/Entities/Object.cpp
+++ b/src/game/Entities/Object.cpp
@@ -1750,7 +1750,7 @@ void WorldObject::MovePositionToFirstCollision(Position& pos, float dist, float 
         }
         UpdateAllowedPositionZ(dest.x, dest.y, dest.z);
         path.calculate(src, dest, false, true);
-        if ((path.getPathType() & PATHFIND_NOPATH) == 0)
+        if ((path.getPathType() & PATHFIND_NOPATH) == 0 && !path.getPath().empty())
         {
             G3D::Vector3 result = path.getPath().back();
             destX = result.x;


### PR DESCRIPTION
## 🍰 Pullrequest
Fix segfault in `WorldObject::MovePositionToFirstCollision` calling `.back()` on an empty path vector. `PathFinder::calculate` returns early on invalid map coords without setting `m_type`, leaving it at the ctor default `PATHFIND_BLANK` (0x0000). I hit this when running with PlayerBot, a bot hearthstoned, unmounted then resummoned a pet, triggering sigsegv on my server.

### Proof

Backtrace

```
warning: Section `.reg-xstate/182212' in core file too small.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/nix/store/qdcbgcj27x2kpxj2sf9yfvva7qsgg64g-glibc-2.38-77/lib/libthread_[db.so](http://db.so).1".
Core was generated by `/opt/cmangos-tbc/run/bin/mangosd -c /opt/cmangos-tbc/run/etc/mangosd.conf -a /o'.
Program terminated with signal SIGSEGV, Segmentation fault.
warning: Section `.reg-xstate/182212' in core file too small.
#0  0x0000000000e4544d in WorldObject::MovePositionToFirstCollision (this=this@entry=0x7fcca75d6470, pos=..., dist=dist@entry=2, angle=<optimized out>)
    at /opt/cmangos-tbc/mangos/src/game/Entities/Object.cpp:1755
1755                G3D::Vector3 result = path.getPath().back();
[Current thread is 1 (Thread 0x7fcdd4bfa6c0 (LWP 182212))]
(gdb) bt
#0  0x0000000000e4544d in WorldObject::MovePositionToFirstCollision (this=this@entry=0x7fcca75d6470, pos=..., dist=dist@entry=2, angle=<optimized out>)
    at /opt/cmangos-tbc/mangos/src/game/Entities/Object.cpp:1755
#1  0x0000000001330c73 in WorldObject::GetFirstCollisionPosition (angle=<optimized out>, dist=2, pos=..., this=0x7fcca75d6470)
    at /opt/cmangos-tbc/mangos/src/game/Entities/Object.h:963
#2  Pet::GetPetSpawnPosition (this=this@entry=0x7fcdab359ae0, owner=owner@entry=0x7fcca75d6470) at /opt/cmangos-tbc/mangos/src/game/Entities/Pet.cpp:565
#3  0x0000000000e88630 in Player::ResummonPetTemporaryUnSummonedIfAny (this=this@entry=0x7fcca75d6470) at /opt/cmangos-tbc/mangos/src/game/Entities/Player.cpp:21559
#4  0x0000000000eb7a08 in Player::Unmount (this=0x7fcca75d6470, aura=<optimized out>) at /opt/cmangos-tbc/mangos/src/game/Entities/Player.cpp:1911
#5  0x00000000010ef8ed in Aura::ApplyModifier (this=this@entry=0x7fcc8705cc40, apply=apply@entry=false, Real=Real@entry=true)
    at /opt/cmangos-tbc/mangos/src/game/Spells/SpellAuras.cpp:815
#6  0x0000000000ef030f in Unit::RemoveAura (this=this@entry=0x7fcca75d6470, Aur=<optimized out>, mode=mode@entry=AURA_REMOVE_BY_DEFAULT)
    at /opt/cmangos-tbc/mangos/src/game/Entities/Unit.cpp:5760
#7  0x0000000000efa2aa in Unit::RemoveSpellAuraHolder (this=this@entry=0x7fcca75d6470, holder=0x7fcc576e33b0, mode=mode@entry=AURA_REMOVE_BY_DEFAULT)
    at /opt/cmangos-tbc/mangos/src/game/Entities/Unit.cpp:5676
#8  0x0000000000efa6f2 in Unit::RemoveSpellsCausingAura (this=this@entry=0x7fcca75d6470, auraType=auraType@entry=SPELL_AURA_MOUNTED)
    at /opt/cmangos-tbc/mangos/src/game/Entities/Unit.cpp:824
#9  0x0000000001716c6d in PlayerbotAI::Unmount (this=0x7fcca7608970) at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/PlayerbotAI.cpp:924
#10 0x0000000001c24599 in ai::UseHearthStoneAction::Execute (this=0x7fcd9be06740, event=...)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/actions/UseItemAction.cpp:1254
#11 0x00000000019892f4 in ai::Engine::ListenAndExecute (this=0x7fcca760f000, action=0x7fcd9be06740, event=...)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/Engine.cpp:717
#12 0x000000000198a722 in ai::Engine::ExecuteAction (this=0x7fcca760f000, name="hearthstone", event=...)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/Engine.cpp:458
#13 0x0000000001721bab in PlayerbotAI::DoSpecificAction (this=this@entry=0x7fcca7608970, name="hearthstone", event=..., silent=silent@entry=true)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/PlayerbotAI.cpp:2360
#14 0x0000000001c141d8 in UnstuckAction::Execute (this=<optimized out>, event=...)
    at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-12.3.0/include/c++/12.3.0/bits/basic_string.tcc:238
#15 0x00000000019892f4 in ai::Engine::ListenAndExecute (this=0x7fcca76488e0, action=0x7fcdb19a8d10, event=...)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/Engine.cpp:717
#16 0x000000000198e87b in ai::Engine::DoNextAction (this=<optimized out>, unit=<optimized out>, depth=<optimized out>, minimal=<optimized out>,
    isStunned=<optimized out>) at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/Engine.cpp:243
#17 0x000000000173294b in PlayerbotAI::DoNextAction (this=this@entry=0x7fcca7608970, min=min@entry=false)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/PlayerbotAI.cpp:2055
#18 0x000000000173c0f6 in PlayerbotAI::UpdateAIInternal (this=0x7fcca7608970, elapsed=<optimized out>, minimal=<optimized out>)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/PlayerbotAI.cpp:1203
#19 0x000000000173045e in PlayerbotAI::UpdateAI (this=<optimized out>, elapsed=101, minimal=<optimized out>)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/PlayerbotAI.cpp:604
#20 0x0000000000e5e4ff in Player::UpdateAI (this=0x7fcca75d6470, diff=101, minimal=<optimized out>) at /opt/cmangos-tbc/mangos/src/game/Entities/Player.cpp:1679
#21 0x0000000000fd8d97 in Map::Update (this=0x212f9180, t_diff=@0x7fcd1c009fc8: 101) at /opt/cmangos-tbc/mangos/src/game/Maps/Map.cpp:883
#22 0x0000000000fe6c62 in MapUpdateWorker::execute (this=0x7fcd1c009fb0) at /opt/cmangos-tbc/mangos/src/game/Maps/MapWorkers.h:52
#23 0x0000000000ff111c in MapUpdater::WorkerThread (this=0xd1278b0) at /opt/cmangos-tbc/mangos/src/game/Maps/MapUpdater.cpp:96
#24 0x00007fcdd9ee05c3 in execute_native_thread_routine () from /nix/store/g7mbqlvnfrz032bl5aryaifdk7m45xwr-gcc-12.3.0-lib/lib/libstdc++.so.6
#25 0x00007fcdd9ca20e4 in start_thread () from /nix/store/qdcbgcj27x2kpxj2sf9yfvva7qsgg64g-glibc-2.38-77/lib/[libc.so](http://libc.so).6
#26 0x00007fcdd9d2477c in clone3 () from /nix/store/qdcbgcj27x2kpxj2sf9yfvva7qsgg64g-glibc-2.38-77/lib/[libc.so](http://libc.so).6
(gdb)
```

### Issues
- None opened

### How2Test
- A playerbot will call unstuck -> hearthstone -> unmount. Previously crashed at the listed frame, with this fix it should no longer crash.

### Todo / Checklist
- [X] None
