### PR TITLE
Fix level scaling issue with certain spells like racials

### DIFF
--- a/src/game/Entities/Object.cpp
+++ b/src/game/Entities/Object.cpp
@@ -3065,7 +3065,10 @@ int32 WorldObject::CalculateSpellEffectValue(Unit const* target, SpellEntry cons
     int32 randomPoints = spellProto->EffectDieSides[effect_index];
     if (unitCaster && basePointsPerLevel != 0.f)
     {
-        int32 level = int32(unitCaster->GetSpellRank(spellProto) / 5);
+        // It's possible that for players, this is not a skill type of spell, such as Orc Racial Blood Fury
+        // we can't always assume it is divisible by 5
+        int32 level = int32(unitCaster->GetSpellRank(spellProto)) == 1 && unitPlayer ?
+            int32(unitCaster->GetLevel()) : int32(unitCaster->GetSpellRank(spellProto) / 5);
         if (level > (int32)spellProto->maxLevel && spellProto->maxLevel > 0)
             level = (int32)spellProto->maxLevel;
         else if (level < (int32)spellProto->baseLevel)


### PR DESCRIPTION
This commit addresses https://github.com/cmangos/issues/issues/4007

Fix spells like Blood Fury and Gift of the Naaru not scaling their effect based on their level

However, a lingering issue remains:

The client does not display the correct value in the spellbook. It does continue to display the correct value in the buff tooltip.

This is different from behavior in actual 2.4.3 where it should display the correct value in the spellbook.

2.4.3 Video evidence:
https://youtu.be/FqsXQP_2Ek4?t=80

<img width="948" height="307" alt="image" src="https://github.com/user-attachments/assets/9c7b3160-159d-4024-a997-e511c970b649" />
You can see that when they hover over the spell, it displays the same value as it would in the buff tooltip

<img width="345" height="163" alt="image" src="https://github.com/user-attachments/assets/97a9951d-cc62-4742-a3bd-33e30a599e89" />
However currently, with or without this change, the value when hovered over the spell is different and only displays the base level 1 value.


How to test this out:

Cast any Orc racial, note the value in the spellbook, the increased values (attack power, spell power, ranged attack power, or healing power depending on the spell) in the character sheet, and the value in the buff tooltip. Only the buff tooltip shows the value scaling with level, the character sheet will not show an increase based on level.

