### PR TITLE
Fix Spelllist Loading garbage values

### DIFF
--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -1252,6 +1252,8 @@ std::shared_ptr<CreatureSpellListContainer> ObjectMgr::LoadCreatureSpellLists()
             spell.Probability = fields[8].GetUInt32();
             spell.InitialMin = fields[9].GetUInt32();
             spell.InitialMax = fields[10].GetUInt32();
+            spell.RepeatMin = fields[11].GetUInt32();
+            spell.RepeatMax = fields[12].GetUInt32();
 
             if (spell.InitialMin > spell.InitialMax)
             {
@@ -1265,8 +1267,7 @@ std::shared_ptr<CreatureSpellListContainer> ObjectMgr::LoadCreatureSpellLists()
                 continue;
             }
 
-            spell.RepeatMin = fields[11].GetUInt32();
-            spell.RepeatMax = fields[12].GetUInt32();
+
             spell.DisabledForAI = !spellInfo || spellInfo->HasAttribute(SPELL_ATTR_EX_NO_AUTOCAST_AI);
             newContainer->spellLists[spell.Id].Spells.emplace(spell.Position, spell);
         } while (result->NextRow());


### PR DESCRIPTION
Set values before you check them, otherwise garbage values are loaded which could be different depending on machine and version.