### PR TITLE
fix castspell server crash

### DIFF
--- a/src/game/AI/BaseAI/PetAI.cpp
+++ b/src/game/AI/BaseAI/PetAI.cpp
@@ -292,7 +292,7 @@ std::vector<std::tuple<SpellEntry const*, Unit*, bool>> PetAI::PickSpellWithTarg
         }
     }
 
-    uint32 creatureEntry = m_pet->getPetType() == HUNTER_PET ? 1 : m_creature->GetCreatureInfo()->Entry;
+    uint32 creatureEntry = (m_pet != nullptr && m_pet->getPetType() == HUNTER_PET) ? 1 : m_creature->GetCreatureInfo()->Entry;
     // Cast a spell from autocast selection
     for (uint8 i = 0; i < m_creature->GetPetAutoSpellSize(); ++i)
     {

--- a/src/game/AI/BaseAI/PetAI.cpp
+++ b/src/game/AI/BaseAI/PetAI.cpp
@@ -292,7 +292,7 @@ std::vector<std::tuple<SpellEntry const*, Unit*, bool>> PetAI::PickSpellWithTarg
         }
     }
 
-    uint32 creatureEntry = (m_pet != nullptr && m_pet->getPetType() == HUNTER_PET) ? 1 : m_creature->GetCreatureInfo()->Entry;
+    uint32 creatureEntry = (m_pet && m_pet->getPetType() == HUNTER_PET) ? 1 : m_creature->GetCreatureInfo()->Entry;
     // Cast a spell from autocast selection
     for (uint8 i = 0; i < m_creature->GetPetAutoSpellSize(); ++i)
     {

--- a/src/game/AI/PlayerAI/PlayerAI.cpp
+++ b/src/game/AI/PlayerAI/PlayerAI.cpp
@@ -48,7 +48,7 @@ void PlayerAI::AddPlayerSpellAction(uint32 spellId, std::function<Unit*()> selec
             if (IsNextMeleeSwingSpell(spellInfo))
                 selector = [&]()->Unit* { return m_player->GetVictim(); };
             else if (HasSpellTarget(spellInfo, TARGET_UNIT_ENEMY) || (spellInfo->Targets & TARGET_FLAG_DEST_LOCATION)) // always random
-                selector = [&, spellId = spellInfo->Id]()->Unit* { return m_player->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, spellId, SELECT_FLAG_PLAYER); };
+                selector = [&, spellId = spellInfo->Id]()->Unit* { return m_player->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, spellId, SELECT_FLAG_IN_LOS); };
             if (HasSpellTarget(spellInfo, TARGET_UNIT_FRIEND) || HasSpellTarget(spellInfo, TARGET_UNIT_FRIEND_CHAIN_HEAL)) // heals only target self
                 selector = [&]()->Unit* { return m_player; };
         }

--- a/src/game/AI/PlayerAI/PlayerAI.cpp
+++ b/src/game/AI/PlayerAI/PlayerAI.cpp
@@ -48,7 +48,7 @@ void PlayerAI::AddPlayerSpellAction(uint32 spellId, std::function<Unit*()> selec
             if (IsNextMeleeSwingSpell(spellInfo))
                 selector = [&]()->Unit* { return m_player->GetVictim(); };
             else if (HasSpellTarget(spellInfo, TARGET_UNIT_ENEMY) || (spellInfo->Targets & TARGET_FLAG_DEST_LOCATION)) // always random
-                selector = [&, spellId = spellInfo->Id]()->Unit* { return m_player->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, spellId, SELECT_FLAG_IN_LOS); };
+                selector = [&, spellId = spellInfo->Id]()->Unit* { return m_player->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, spellId, SELECT_FLAG_PLAYER); };
             if (HasSpellTarget(spellInfo, TARGET_UNIT_FRIEND) || HasSpellTarget(spellInfo, TARGET_UNIT_FRIEND_CHAIN_HEAL)) // heals only target self
                 selector = [&]()->Unit* { return m_player; };
         }

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -1565,8 +1565,13 @@ SpellCastResult Unit::CastSpell(Unit* Victim, SpellEntry const* spellInfo, uint3
     SpellCastTargets targets;
     targets.setUnitTarget(Victim);
 
-    if ((spellInfo->Targets & TARGET_FLAG_DEST_LOCATION) && Victim)
-        targets.setDestination(Victim->GetPositionX(), Victim->GetPositionY(), Victim->GetPositionZ());
+    if ((spellInfo->Targets & TARGET_FLAG_DEST_LOCATION))
+    {
+        if (victim)
+            targets.setDestination(Victim->GetPositionX(), Victim->GetPositionY(), Victim->GetPositionZ());
+        else
+            sLog.outError("CastSpell: victim was nullptr but tried to get position: caster %s, spellId %i", GetGuidStr().c_str(), spellInfo->Id);
+    }
     if (spellInfo->Targets & TARGET_FLAG_SOURCE_LOCATION)
         if (WorldObject* caster = spell->GetCastingObject())
             targets.setSource(caster->GetPositionX(), caster->GetPositionY(), caster->GetPositionZ());

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -1567,7 +1567,7 @@ SpellCastResult Unit::CastSpell(Unit* Victim, SpellEntry const* spellInfo, uint3
 
     if ((spellInfo->Targets & TARGET_FLAG_DEST_LOCATION))
     {
-        if (victim)
+        if (Victim)
             targets.setDestination(Victim->GetPositionX(), Victim->GetPositionY(), Victim->GetPositionZ());
         else
             sLog.outError("CastSpell: victim was nullptr but tried to get position: caster %s, spellId %i", GetGuidStr().c_str(), spellInfo->Id);

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -1565,7 +1565,7 @@ SpellCastResult Unit::CastSpell(Unit* Victim, SpellEntry const* spellInfo, uint3
     SpellCastTargets targets;
     targets.setUnitTarget(Victim);
 
-    if (spellInfo->Targets & TARGET_FLAG_DEST_LOCATION)
+    if ((spellInfo->Targets & TARGET_FLAG_DEST_LOCATION) && Victim)
         targets.setDestination(Victim->GetPositionX(), Victim->GetPositionY(), Victim->GetPositionZ());
     if (spellInfo->Targets & TARGET_FLAG_SOURCE_LOCATION)
         if (WorldObject* caster = spell->GetCastingObject())

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -1569,7 +1569,10 @@ SpellCastResult Unit::CastSpell(Unit* Victim, SpellEntry const* spellInfo, uint3
     {
         // This shouldn't happen, but we should return gracefully if it does...
         if (!Victim)
+        {
+            sLog.outError("CastSpell: victim was nullptr but tried to get position: caster %s, spellId %i", GetGuidStr().c_str(), spellInfo->Id);
             return SPELL_FAILED_BAD_TARGETS;
+        }    
         targets.setDestination(Victim->GetPositionX(), Victim->GetPositionY(), Victim->GetPositionZ()); 
     }
     if (spellInfo->Targets & TARGET_FLAG_SOURCE_LOCATION)

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -1567,10 +1567,10 @@ SpellCastResult Unit::CastSpell(Unit* Victim, SpellEntry const* spellInfo, uint3
 
     if ((spellInfo->Targets & TARGET_FLAG_DEST_LOCATION))
     {
-        if (Victim)
-            targets.setDestination(Victim->GetPositionX(), Victim->GetPositionY(), Victim->GetPositionZ());
-        else
-            sLog.outError("CastSpell: victim was nullptr but tried to get position: caster %s, spellId %i", GetGuidStr().c_str(), spellInfo->Id);
+        // This shouldn't happen, but we should return gracefully if it does...
+        if (!Victim)
+            return SPELL_FAILED_BAD_TARGETS;
+        targets.setDestination(Victim->GetPositionX(), Victim->GetPositionY(), Victim->GetPositionZ()); 
     }
     if (spellInfo->Targets & TARGET_FLAG_SOURCE_LOCATION)
         if (WorldObject* caster = spell->GetCastingObject())


### PR DESCRIPTION
Fix bug where a unit with a pet when charmed by castspell would crash the server because victim is nullptr and we're trying to access functions of nullptr.

Fixes https://github.com/cmangos/issues/issues/4079

~~TODO: Pets should stop attacking their current target and instead attack the target that the charmed unit is attacking.~~

Pets are working for the most part. It seems to be random whether pet continues to attack same target or attacks targets hostile to the charmed unit. I'll say it's close enough to correct.
