### PR TITLE
Fix bug with Drijya

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/netherstorm.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/netherstorm.cpp
@@ -1809,6 +1809,9 @@ struct npc_drijyaAI : public npc_escortAI
 
     void WaypointReached(uint32 uiPointId) override
     {
+        if (!HasEscortState(STATE_ESCORT_ESCORTING))
+            return;
+
         switch (uiPointId)
         {
             case 1:
@@ -1889,6 +1892,10 @@ struct npc_drijyaAI : public npc_escortAI
                     pPlayer->RewardPlayerAndGroupAtEventExplored(QUEST_ID_WARP_GATE, m_creature);
                 }
                 m_creature->ClearTemporaryFaction();
+                m_creature->GetMotionMaster()->Clear(false, true);
+                m_creature->GetMotionMaster()->MoveIdle();
+                End();
+                m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
                 break;
         }
     }


### PR DESCRIPTION
Fix bug where Drijya would restart escort path as soon as he returned, preventing others from starting quest after first escort.
This is because the escort starts in the same place where it ends.

He also needs to become a questgiver again at the end of the escort.

https://www.wowhead.com/quest=10310/sabotage-the-warp-gate
