### PR TITLE
Change when Blackheart resets threat

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/boss_blackheart_the_inciter.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/boss_blackheart_the_inciter.cpp
@@ -123,7 +123,7 @@ struct boss_blackheart_the_inciterAI : public CombatAI
     {
         if (spellInfo->Id == SPELL_INCITE_CHAOS)
             HandleInciteStart();
-        else if (spellInfo->Id == SPELL_WAR_STOMP || spellInfo->Id == SPELL_CHARGE)
+        else if (spellInfo->Id == SPELL_CHARGE)
             DoResetThreat();
     }
 
@@ -145,6 +145,7 @@ struct boss_blackheart_the_inciterAI : public CombatAI
         SetCombatScriptStatus(false);
         SetCombatMovement(true);
         m_meleeEnabled = true;
+        DoResetThreat();
         if (m_creature->GetVictim())
         {
             m_creature->MeleeAttackStart(m_creature->GetVictim());

--- a/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/boss_blackheart_the_inciter.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/boss_blackheart_the_inciter.cpp
@@ -133,7 +133,6 @@ struct boss_blackheart_the_inciterAI : public CombatAI
         SetCombatScriptStatus(true);
         SetCombatMovement(false);
         m_meleeEnabled = false;
-        DoResetThreat();
         m_creature->MeleeAttackStop(m_creature->GetVictim());
         m_creature->SetTarget(nullptr);
         m_creature->CastSpell(nullptr, SPELL_LAUGH_PERIODIC, TRIGGERED_NONE);


### PR DESCRIPTION
He is supposed to reset threat on the following:

Charge random player far away
Incite chaos end

He is not supposed to drop threat during war stomp or start of incite chaos

See following videos:

TBC
https://www.youtube.com/watch?v=kTQefSWeFHY

TBC
https://www.youtube.com/watch?v=1XulHGYZ5ME

TBC Classic
https://www.youtube.com/watch?v=fPZ70Si7wZc&t=1186s
