### PR TITLE
Nazan should not target ground fireballs randomly

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/hellfire_ramparts/boss_nazan_and_vazruden.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/hellfire_ramparts/boss_nazan_and_vazruden.cpp
@@ -349,7 +349,7 @@ struct boss_vazruden_heraldAI : public CombatAI
             }
             case NAZAN_FIREBALL_GROUND:
             {
-                if (Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_TOPAGGRO, 0, nullptr, SELECT_FLAG_PLAYER))
+                if (Unit* target = m_creature->SelectAttackingTarget(m_creature->GetVictim(), 0, nullptr, SELECT_FLAG_PLAYER))
                 {
                     if (DoCastSpellIfCan(target, m_inRegularMode ? SPELL_FIREBALL_GROUND : SPELL_FIREBALL_GROUND_H) == CAST_OK)
                         ResetCombatAction(action, urand(7300, 13200));

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/hellfire_ramparts/boss_nazan_and_vazruden.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/hellfire_ramparts/boss_nazan_and_vazruden.cpp
@@ -349,11 +349,9 @@ struct boss_vazruden_heraldAI : public CombatAI
             }
             case NAZAN_FIREBALL_GROUND:
             {
-                if (Unit* target = m_creature->SelectAttackingTarget(m_creature->GetVictim(), 0, nullptr, SELECT_FLAG_PLAYER))
-                {
-                    if (DoCastSpellIfCan(target, m_inRegularMode ? SPELL_FIREBALL_GROUND : SPELL_FIREBALL_GROUND_H) == CAST_OK)
-                        ResetCombatAction(action, urand(7300, 13200));
-                }
+
+                if (DoCastSpellIfCan(m_creature->GetVictim(), m_inRegularMode ? SPELL_FIREBALL_GROUND : SPELL_FIREBALL_GROUND_H) == CAST_OK)
+                    ResetCombatAction(action, urand(7300, 13200));
                 break;
             }
             case NAZAN_CONE_OF_FIRE:

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/hellfire_ramparts/boss_nazan_and_vazruden.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/hellfire_ramparts/boss_nazan_and_vazruden.cpp
@@ -349,7 +349,6 @@ struct boss_vazruden_heraldAI : public CombatAI
             }
             case NAZAN_FIREBALL_GROUND:
             {
-
                 if (DoCastSpellIfCan(m_creature->GetVictim(), m_inRegularMode ? SPELL_FIREBALL_GROUND : SPELL_FIREBALL_GROUND_H) == CAST_OK)
                     ResetCombatAction(action, urand(7300, 13200));
                 break;

--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/hellfire_ramparts/boss_nazan_and_vazruden.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/hellfire_ramparts/boss_nazan_and_vazruden.cpp
@@ -349,7 +349,7 @@ struct boss_vazruden_heraldAI : public CombatAI
             }
             case NAZAN_FIREBALL_GROUND:
             {
-                if (Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, nullptr, SELECT_FLAG_PLAYER))
+                if (Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_TOPAGGRO, 0, nullptr, SELECT_FLAG_PLAYER))
                 {
                     if (DoCastSpellIfCan(target, m_inRegularMode ? SPELL_FIREBALL_GROUND : SPELL_FIREBALL_GROUND_H) == CAST_OK)
                         ResetCombatAction(action, urand(7300, 13200));


### PR DESCRIPTION
Final boss of Hellfire Ramparts (Nazan, the dragon) does a fireball spell in the two phases. In the first phase he targets random players from the air. In the second phase, Nazan comes down to the ground and the fireball is targeted at the top aggro (not necessarily the current target, since ranged players can have higher aggro than the tank). This is why in the videos you may see a ranged dps targeted, but never the healer by this point.

Evidence:

TBC:
https://www.youtube.com/watch?v=GBxlxfPsOSM

TBC Classic:
https://youtu.be/RTFoY7z4GiI?t=1609

The fireball in phase 2 is always paired with the conal breath, it's the attack that leaves the fire on the ground, just like in phase 1.

Seeing as how the documented strategy is to keep the boss faced away from the group because of the cone breath, and even have tank use some fire resistance, the fireball no longer targets random players by this point. Currently, what often happens is that because he targets a random player for fireball, he'll end up hitting that player with the cone breath also since they come out at the same time, even though the cone is supposed to be focused on the tank, which defeats the purpose of the strategy. 

This is a similar issue as what was addressed for the final boss of the Ring of Blood quest in Nagrand, where he was targeting random people for chain lighting when evidence shows it is an aggro based attack. But this time it has to be fixed in core since that's where his scripts are handled.