### PR TITLE
Blackheart the Inciter: Cleaner threat resets and target re-engage

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/boss_blackheart_the_inciter.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/boss_blackheart_the_inciter.cpp
@@ -123,6 +123,8 @@ struct boss_blackheart_the_inciterAI : public CombatAI
     {
         if (spellInfo->Id == SPELL_INCITE_CHAOS)
             HandleInciteStart();
+        else if (spellInfo->Id == SPELL_CHARGE)
+            DoResetThreat();
     }
 
     void HandleInciteStart()
@@ -148,12 +150,6 @@ struct boss_blackheart_the_inciterAI : public CombatAI
             m_creature->SetTarget(m_creature->GetVictim());
             DoStartMovement(m_creature->GetVictim());
         }
-    }
-
-    void SpellHitTarget(Unit* target, const SpellEntry* spellInfo) override
-    {
-        if (spellInfo->Id == SPELL_CHARGE)
-            DoResetThreat();
     }
 };
 

--- a/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/boss_blackheart_the_inciter.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/boss_blackheart_the_inciter.cpp
@@ -123,8 +123,6 @@ struct boss_blackheart_the_inciterAI : public CombatAI
     {
         if (spellInfo->Id == SPELL_INCITE_CHAOS)
             HandleInciteStart();
-        else if (spellInfo->Id == SPELL_CHARGE)
-            DoResetThreat();
     }
 
     void HandleInciteStart()
@@ -145,11 +143,18 @@ struct boss_blackheart_the_inciterAI : public CombatAI
         SetCombatMovement(true);
         m_meleeEnabled = true;
         DoResetThreat();
-        if (m_creature->GetVictim())
+        Unit* target = m_creature->getAttackerForHelper();
+        if (target)
         {
-            m_creature->MeleeAttackStart(m_creature->GetVictim());
-            m_creature->SetTarget(m_creature->GetVictim());
+            m_creature->SetTarget(target);
+            m_creature->MeleeAttackStart(target);
         }
+    }
+
+    void SpellHitTarget(Unit* target, const SpellEntry* spellInfo) override
+    {
+        if (spellInfo->Id == SPELL_CHARGE)
+            DoResetThreat();
     }
 };
 

--- a/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/boss_blackheart_the_inciter.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/boss_blackheart_the_inciter.cpp
@@ -133,7 +133,7 @@ struct boss_blackheart_the_inciterAI : public CombatAI
         SetCombatScriptStatus(true);
         SetCombatMovement(false);
         SetMeleeEnabled(false);
-        m_creature->CastSpell(m_creature, SPELL_LAUGH_PERIODIC, TRIGGERED_NONE);
+        m_creature->CastSpell(nullptr, SPELL_LAUGH_PERIODIC, TRIGGERED_NONE);
         ResetTimer(BLACKHEART_INCITE_TIMER, 19000);
     }
 
@@ -145,11 +145,6 @@ struct boss_blackheart_the_inciterAI : public CombatAI
         SetCombatScriptStatus(false);
         m_creature->SetInCombatWithZone(false);
         AttackClosestEnemy();
-        if (m_creature->GetVictim())
-        {
-            m_creature->SetTarget(m_creature->GetVictim());
-            DoStartMovement(m_creature->GetVictim());
-        }
     }
 };
 

--- a/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/boss_blackheart_the_inciter.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/auchindoun/shadow_labyrinth/boss_blackheart_the_inciter.cpp
@@ -130,24 +130,23 @@ struct boss_blackheart_the_inciterAI : public CombatAI
         DoBroadcastText(SAY_INCITE, m_creature);
         SetCombatScriptStatus(true);
         SetCombatMovement(false);
-        m_meleeEnabled = false;
-        m_creature->MeleeAttackStop(m_creature->GetVictim());
-        m_creature->SetTarget(nullptr);
-        m_creature->CastSpell(nullptr, SPELL_LAUGH_PERIODIC, TRIGGERED_NONE);
+        SetMeleeEnabled(false);
+        m_creature->CastSpell(m_creature, SPELL_LAUGH_PERIODIC, TRIGGERED_NONE);
         ResetTimer(BLACKHEART_INCITE_TIMER, 19000);
     }
 
     void HandleInciteEnd()
     {
-        SetCombatScriptStatus(false);
-        SetCombatMovement(true);
-        m_meleeEnabled = true;
         DoResetThreat();
-        Unit* target = m_creature->getAttackerForHelper();
-        if (target)
+        SetCombatMovement(true);
+        SetMeleeEnabled(true);
+        SetCombatScriptStatus(false);
+        m_creature->SetInCombatWithZone(false);
+        AttackClosestEnemy();
+        if (m_creature->GetVictim())
         {
-            m_creature->SetTarget(target);
-            m_creature->MeleeAttackStart(target);
+            m_creature->SetTarget(m_creature->GetVictim());
+            DoStartMovement(m_creature->GetVictim());
         }
     }
 


### PR DESCRIPTION
Cleaner threat resets and target re-engage after incite chaos, since it's possible that he may not have a victim so sometimes he would evade and reset the fight.  Now he should always choose to attack someone after.

With respect to the charge, reset threat as the charge connects, not as soon as it casts, which puts this in line with other charging bosses.

<img width="952" height="279" alt="image" src="https://github.com/user-attachments/assets/edfd4eb5-05ac-4a2d-ab6b-172cc3a9ff87" />
