### PR TITLE
Include pets for SelectAttackingTarget ATTACKING_TARGET_RANDOM

### DIFF
--- a/src/game/AI/PlayerAI/PlayerAI.cpp
+++ b/src/game/AI/PlayerAI/PlayerAI.cpp
@@ -48,7 +48,7 @@ void PlayerAI::AddPlayerSpellAction(uint32 spellId, std::function<Unit*()> selec
             if (IsNextMeleeSwingSpell(spellInfo))
                 selector = [&]()->Unit* { return m_player->GetVictim(); };
             else if (HasSpellTarget(spellInfo, TARGET_UNIT_ENEMY) || (spellInfo->Targets & TARGET_FLAG_DEST_LOCATION)) // always random
-                selector = [&, spellId = spellInfo->Id]()->Unit* { return m_player->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, spellId, SELECT_FLAG_PLAYER); };
+                selector = [&, spellId = spellInfo->Id]()->Unit* { return m_player->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, spellId, SELECT_FLAG_IN_LOS); };
             if (HasSpellTarget(spellInfo, TARGET_UNIT_FRIEND) || HasSpellTarget(spellInfo, TARGET_UNIT_FRIEND_CHAIN_HEAL)) // heals only target self
                 selector = [&]()->Unit* { return m_player; };
         }


### PR DESCRIPTION
As a continuation of https://github.com/cmangos/mangos-tbc/pull/819, here we fix the bug that Pets are being set to nullptr when they are to be attacked by a charmed player at random.

Here is some evidence that pets should be targets for attacks while players are charmed:

Actual TBC:
https://www.youtube.com/watch?v=moK-ZVRNfeg

Classic:
https://youtu.be/RCkHCuQu1VI?t=1983

You can see in both examples that Pet should be considered targets for random attacks. You can see the druids casting mangle/faerie fire on the hunter pet in the first video. In the second video you can see the warrior using cleave and autos on the balance druid summoned treants. So we can't assume that only players should be targeted for random attacking.

Because the select flag is for player, it then causes a function later to return a nullptr for the victim even though the victim was already the pet, which is passed later on and causes the failure to cast/server crash.