### PR TITLE
Disable SetFacingTo to prevent animation interruption during channel

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -3769,7 +3769,8 @@ void Spell::update(uint32 difftime)
                                 if (!m_caster->IsClientControlled())
                                 {
                                     m_caster->SetOrientation(orientation);
-                                    m_caster->SetFacingTo(orientation);
+                                    // This was causing animation interruption
+                                    // m_caster->SetFacingTo(orientation);
                                 }
                                 m_castOrientation = orientation; // need to update cast orientation due to the attribute
                             }

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -3769,8 +3769,6 @@ void Spell::update(uint32 difftime)
                                 if (!m_caster->IsClientControlled())
                                 {
                                     m_caster->SetOrientation(orientation);
-                                    // This was causing animation interruption
-                                    // m_caster->SetFacingTo(orientation);
                                 }
                                 m_castOrientation = orientation; // need to update cast orientation due to the attribute
                             }


### PR DESCRIPTION
Blackheart the incter's laugh_periodic during the charm phase was considered NYI. During the charm phase he will stare at people but he won't do his laugh channel like he's supposed to.

It turns out the code as is already implements the laugh, but you don't see his laugh animation because SetFacingTo during the channel is interrupting the Animation. If you cast this spell as a player, this function isn't called and the spell works (try .cast 33722), since players are client controlled so this code never reaches. Removing this function call fixes the implementation.