### PR TITLE
[Spell] Correct Spell Bonus Data for Earth Shield

### DIFF
--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -3403,6 +3403,8 @@ UPDATE spell_template SET AttributesEx5=AttributesEx5|0x00800000 WHERE Id IN(398
 -- ============================================================
 
 -- Bonus coeff fixes
+-- https://web.archive.org/web/20080913121625/http://elitistjerks.com/f47/t24796-shaman_restoration/ - It receives 28.6% of your +healing per charge (or 26.55% if you downrank to Rank 1 Earth Shield - done via CalculateLevelPenalty)
+UPDATE spell_template SET EffectBonusCoefficient1=0.286 WHERE Id IN (974,32593,32594); -- SELECT Id,SpellName,Rank1,spellfamilyflags,EffectBonusCoefficient1,EffectBonusCoefficient2,EffectBonusCoefficient3,EffectBonusCoefficientFromAP1,EffectBonusCoefficientFromAP2,EffectBonusCoefficientFromAP3 FROM spell_template where spellname LIKE '%Earth Shield%' and spellfamilyflags = spellfamilyflags|4398046511104;
 UPDATE spell_template SET EffectBonusCoefficient1=0.8 WHERE Id IN(1454,1455,1456,11687,11688,11689,27222); -- Life Tap
 UPDATE spell_template SET EffectBonusCoefficient1=0.022 WHERE Id IN(42463); -- Seal of Vengeance
 UPDATE spell_template SET EffectBonusCoefficientFromAP1=0.15 WHERE Id IN(3044,14281,14282,14283,14284); -- Arcane Shot


### PR DESCRIPTION
https://web.archive.org/web/20080913121625/http://elitistjerks.com/f47/t24796-shaman_restoration/

It receives 28.6% of your +healing per charge (or 26.55% if you downrank to Rank 1 Earth Shield)

<img width="640" height="123" alt="grafik" src="https://github.com/user-attachments/assets/586cbcab-8834-4bdb-967d-1de89b321cc6" />

Preserve Old spell_bonus_data:

```
--
-- Table structure for spell_bonus_data
--
DROP TABLE IF EXISTS `spell_bonus_data`;
CREATE TABLE `spell_bonus_data` (
  `entry` smallint(5) unsigned NOT NULL,
    `direct_bonus` float NOT NULL default '0',
      `dot_bonus` float NOT NULL default '0',
        `ap_bonus` float NOT NULL default '0',
	  `ap_dot_bonus` float NOT NULL default '0',
	    `comments` varchar(255) default NULL,
	      PRIMARY KEY  (`entry`)
	      ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

	      INSERT INTO `spell_bonus_data` (`entry`, `direct_bonus`,
	      `dot_bonus`, `ap_bonus`, `ap_dot_bonus`, `comments`)
	      VALUES
	      (17, 0.3, 0, 0, 0, 'Priest - Power Word: Shield'),
	      (116, 0.8143, 0, 0, 0, 'Mage - Frost Bolt'),
	      (122, 0.0279, 0, 0, 0, 'Mage - Frost Nova'),
	      (133, 1, 0, 0, 0, 'Mage - Fire Ball'),
	      (139, 0, 0.2, 0, 0, 'Priest - Renew'),
	      (172, 0, 0.156, 0, 0, 'Warlock - Corruption'),
	      (331, 0.8571, 0, 0, 0, 'Shaman - Healing Wave'),
	      (339, 0, 0.1, 0, 0, 'Druid - Entangling Roots'),
	      (379, 0, 0, 0, 0, 'Shaman - Earth Shield Triggered'),
	      (403, 0.794, 0, 0, 0, 'Shaman - Lightning Bolt'),
	      (421, 0.641, 0, 0, 0, 'Shaman - Chain Lightning'),
	      (543, 0.3, 0, 0, 0, 'Mage - Fire Ward'),
	      (585, 0.7143, 0, 0, 0, 'Priest - Smite'),
	      (603, 0, 2, 0, 0, 'Warlock - Curse of Doom'),
	      (686, 0.8571, 0, 0, 0, 'Warlock - Shadow Bolt'),
	      (703, 0, 0, 0, 0.03, 'Rogue - Garrote'),
	      (755, 0, 0.2857, 0, 0, 'Warlock - Health Funnel'),
	      (774, 0, 0.2, 0, 0, 'Druid - Rejuvenation'),
	      (779, 0, 0, 0.08, 0, 'Druid - Swipe'),
	      (974, 0.2857, 0, 0, 0, 'Shaman - Earth Shield'),
	      (980, 0, 0.1, 0, 0, 'Warlock - Curse of Agony'),
	      (1120, 0, 0.4286, 0, 0, 'Warlock - Drain Soul'),
	      (1454, 0.8, 0, 0, 0, 'Warlock - Life Tap'),
	      (1463, 0.5, 0, 0, 0, 'Mage - Mana Shield'),
	      (1495, 0, 0, 0.2, 0, 'Hunter - Mongoose Bite'),
	      (1822, 0, 0, 0.01, 0.02, 'Druid - Rake'),
	      (1949, 0, 0.0946, 0, 0, 'Warlock - Hellfire on Self'),
	      (1978, 0, 0.2, 0, 0.02, 'Hunter - Serpent Sting'),
	      (2120, 0.2361, 0.0274, 0, 0, 'Mage - Flamestrike'),
	      (2812, 0.1905, 0, 0, 0, 'Paladin - Holy Wrath'),
	      (2818, 0, 0, 0, 0, 'Rogue - Deadly Poison (Rank 1)'),
	      (2943, 0.1, 0, 0, 0, 'Priest - Touch of Weakness Proc'),
	      (2944, 0, 0.2, 0, 0, 'Priest - Devouring Plague'),
	      (3044, 0.4286, 0, 0.15, 0, 'Hunter - Arcane Shot'),
	      (3606, 0.1667, 0, 0, 0, 'Shaman - Searing Totem Attack'),
	      (5019, 0, 0, 0, 0, 'Shoot - Wand'),
	      (5138, 0, 0, 0, 0, 'Warlock - Drain Mana'),
	      (5176, 0.5714, 0, 0, 0, 'Druid - Wrath'),
	      (5185, 1, 0, 0, 0, 'Druid - Healing Touch'),
	      (5570, 0, 0.1667, 0, 0, 'Druid - Insect Swarm'),
	      (5672, 0, 0.045, 0, 0, 'Shaman - Healing Stream Totem'),
	      (5707, 0, 0, 0, 0, 'Item - Lifestone Regeneration'),
	      (5857, 0.1428, 0, 0, 0, 'Warlock - Hellfire Triggered on
	      Enemy'),
	      (6143, 0.3, 0, 0, 0, 'Mage - Frost Ward'),
	      (6229, 0.3, 0, 0, 0, 'Warlock - Shadow Ward'),
	      (6297, 0, 0, 0, 0, 'Item - Enchant: Fiery Blaze
	      (s.6296)'),
	      (6353, 1.15, 0, 0, 0, 'Warlock - Soul Fire'),
	      (7001, 0, 0.33, 0, 0, 'Priest - Lightwell Renew'),
	      (7268, 0.2857, 0, 0, 0, 'Mage - Arcane Missiles
	      Triggered'),
	      (7712, 0, 0, 0, 0, 'Item - Add Fire Dam - Weap 02
	      (s.7711)'),
	      (7714, 0, 0, 0, 0, 'Item - Add Fire Dam - Weap 04
	      (s.7721)'),
	      (8026, 0.1, 0, 0, 0, 'Shaman - Flametongue Weapon Proc
	      Rank 1'),
	      (8034, 0.1, 0, 0, 0, 'Shaman - Frostbrand Attack'),
	      (8042, 0.3857, 0, 0, 0, 'Shaman - Earth Shock'),
	      (8056, 0.3857, 0, 0, 0, 'Shaman - Frost Shock'),
	      (8129, 0, 0, 0, 0, 'Priest - Mana Burn'),
	      (8187, 0.0667, 0, 0, 0, 'Shaman - Magma Totem Cast'),
	      (8680, 0, 0, 0, 0, 'Rogue - Instant Poison (Rank 1)'),
	      (8921, 0.1491, 0.13, 0, 0, 'Druid - Moonfire'),
	      (8936, 0.2898, 0.1, 0, 0, 'Druid - Regrowth'),
	      (9007, 0, 0, 0, 0.03, 'Druid - Pounce Bleed'),
	      (10444, 0, 0, 0, 0, 'Shaman - Flametongue Attack
	      Triggered'),
	      (10797, 0, 0.1714, 0, 0, 'Priest - Starshards'),
	      (11351, 0, 0, 0, 0, 'Item - Oil of Immolation'),
	      (11426, 0.3, 0, 0, 0, 'Mage - Ice Barrier'),
	      (11538, 0, 0, 0, 0, 'Item - Six Demon Bag - Frostbolt'),
	      (12654, 0, 0, 0, 0, 'Mage - Ignite'),
	      (13218, 0, 0, 0, 0, 'Rogue - Wound Poison (Rank 1)'),
	      (13220, 0, 0, 0, 0, 'Rogue - Wound Poison'),
	      (13797, 0, 0, 0, 0.02, 'Hunter - Immolation Trap'),
	      (13812, 0, 0, 0.1, 0.1, 'Hunter - Explosive Trap'),
	      (13897, 0, 0, 0, 0, 'Item - Fiery Weapon Enchant'),
	      (14914, 0.75, 0.05, 0, 0, 'Priest - Holy Fire'),
	      (15237, 0.1606, 0, 0, 0, 'Priest - Holy Nova Damage'),
	      (15407, 0, 0.19, 0, 0, 'Priest - Mind Flay'),
	      (15662, 0, 0, 0, 0, 'Item - Six Demon Bag - Fireball'),
	      (15851, 0, 0, 0, 0, 'Item - Dragonbreath Chili
	      (s.15852)'),
	      (16368, 0, 0, 0, 0, 'Shaman - Flametongue Attack'),
	      (16614, 0, 0, 0, 0, 'Item - Add Lightning Dam - Weap 03
	      (s.16615)'),
	      (17484, 0, 0, 0, 0, 'Item - Skullforge Reaver'),
	      (17712, 0, 0, 0, 0, 'Item - Lifestone Healing'),
	      (18220, 0.96, 0, 0, 0, 'Warlock - Dark Pact'),
	      (18562, 0, 0, 0, 0, 'Druid - Swiftmend'),
	      (18790, 0, 0, 0, 0, 'Warlock - Fel Stamina'),
	      (19503, 0, 0, 0, 0, 'Hunter - Scatter Shot'),
	      (20004, 0, 0, 0, 0, 'Item - Lifestealing Enchant'),
	      (20154, 0, 0, 0, 0, 'Paladin - Seal of Righteousness'),
	      (20187, 0.7143, 0, 0, 0, 'Paladin - Judgement of
	      Righteousness'),
	      (20424, 0.29, 0, 0, 0, 'Paladin - Seal of Command Proc'),
	      (20911, 0, 0, 0, 0, 'Paladin - Blessing of Sanctuary'),
	      (20925, 0.05, 0, 0, 0, 'Paladin - Holy Shield'),
	      (21179, 0, 0, 0, 0, 'Item - Six Demon Bag - Chain
	      Lightning'),
	      (22600, 0, 0, 0, 0, 'Item - Force Reactive Disk'),
	      (23455, 0.1606, 0, 0, 0, 'Priest - Holy Nova Heal'),
	      (23687, 0, 0, 0, 0, 'Item - Darkmoon Card: Maelstrom'),
	      (23722, 1, 0, 0, 0, 'Item - Arcane Infused Gem'),
	      (23781, 0, 0, 0, 0, NULL),
	      (24844, 0.1, 0, 0, 0, 'Hunter - Lightning Breath (Rank
	      1)'),
	      (25742, 0, 0, 0, 0, 'Paladin - Seal of Righteousness'),
	      (25899, 0, 0, 0, 0, 'Paladin - Greater Blessing of
	      Sanctuary'),
	      (26170, 0, 0, 0, 0, 'Item - Garments of the Oracle Set -
	      Oracular Heal'),
	      (26364, 0.33, 0, 0, 0, 'Shaman - Lightning Shield Proc'),
	      (26573, 0, 0.125, 0, 0, 'Paladin - Consecration'),
	      (26688, 0, 0, 0, 0, 'Rogue - Anesthetic Poison (Rank 1)'),
	      (27243, 0, 0.25, 0, 0, 'Warlock - Seed of Corruption
	      DoT'),
	      (28176, 0, 0, 0, 0, 'Warlock - Fel Armor'),
	      (28377, 0.33, 0, 0, 0, 'Priest - Shadowguard Proc'),
	      (28715, 0, 0, 0, 0, 'Item - Flame Cup'),
	      (30455, 0.1429, 0, 0, 0, 'Mage - Ice Lance'),
	      (30564, 0, 0, 0, 0, 'Item - Torment of the Worgen'),
	      (31024, 0, 0, 0, 0, 'Item - Living Ruby Pedant'),
	      (31117, 1.8, 0, 0, 0, 'Warlock - Unstable Affliction
	      Dispell'),
	      (31803, 0, 0.034, 0, 0, 'Paladin - Seal of Vengeance Proc
	      on Enemy'),
	      (31893, 0, 0, 0, 0, 'Paladin - Seal of Blood Proc on
	      Enemy'),
	      (31935, 0.19, 0, 0, 0, 'Paladin - Avengers Shield'),
	      (32220, 0, 0, 0, 0, 'Paladin - Judgement of Blood Proc on
	      Self'),
	      (32221, 0, 0, 0, 0, 'Paladin - Seal of Blood Proc on
	      Self'),
	      (32643, 0, 0, 0, 0, 'Item - Petrified Lichen Guard'),
	      (32645, 0, 0, 0, 0, 'Rogue - Envenom Rank 1'),
	      (32897, 0, 0, 0, 0, 'Priest - Feedback'),
	      (33090, 0, 0, 0, 0, 'Item - Figurine of the Colossus'),
	      (33619, 0, 0, 0, 0, 'Priest - Reflective Shield'),
	      (33745, 0, 0, 0.01, 0.01, 'Druid - Lacerate'),
	      (33763, 0.3428, 0.0742, 0, 0, 'Druid - Lifebloom'),
	      (33778, 0, 0, 0, 0, 'Druid - Lifebloom (Rank 1)'),
	      (34120, 0, 0, 0.2, 0, 'Hunter - Steady Shot'),
	      (34433, 0.65, 0, 0, 0, 'Priest - Shadowfiend'),
	      (34490, 0, 0, 0, 0, 'Hunter - Silencing Shot'),
	      (34587, 0, 0, 0, 0, 'Item - Romulo\'s Poison Vial'),
	      (34913, 0, 0, 0, 0, 'Mage - Molten Armor Triggered'),
	      (34914, 0, 0.2, 0, 0, 'Priest - Vampiric Touch'),
	      (37661, 0, 0, 0, 0, 'Item - Lightning Capacitor'),
	      (38395, 0, 0, 0, 0, 'Item - Siphon Essence'),
	      (39445, 0, 0, 0, 0, 'Item - Aura of Vengeance (s.39444)'),
	      (40293, 0, 0, 0, 0, 'Item - Siphon Essence'),
	      (40471, 0, 0, 0, 0, 'Item - Ashtongue Talisman of Zeal -
	      Enduring Light'),
	      (40472, 0, 0, 0, 0, 'Item - Ashtongue Talisman of Zeal -
	      Enduring Judgement'),
	      (40972, 0, 0, 0, 0, 'Item - Crystal Spire of Karabor'),
	      (42208, 0.1435, 0, 0, 0, 'Mage - Blizzard Triggered'),
	      (42223, 0.238, 0, 0, 0, 'Warlock - Rain of Fire
	      Triggered'),
	      (42231, 0.12898, 0, 0, 0, 'Druid - Hurricane Triggered'),
	      (42243, 0.125, 0, 0, 0, 'Hunter - Volley Triggered'),
	      (42463, 0.022, 0, 0, 0, 'Paladin - Seal of Vengeance Proc
	      on Enemy (fully stacked)'),
	      (43733, 0, 0, 0, 0, 'Item - Lightning Zap'),
	      (44041, 0.143, 0, 0, 0, 'Priest - Chastise'),
	      (44203, 0.1825, 0, 0, 0, 'Druid - Tranquility Triggered'),
	      (45055, 0, 0, 0, 0, 'Item - Timbal\'s Focusing Crystal'),
	      (45428, 0, 0, 0, 0, 'Item - Shattered Sun Pendant of
	      Might'),
	      (45429, 0, 0, 0, 0, 'Item - Shattered Sun Pendant of
	      Acumen'),
	      (45430, 0, 0, 0, 0, 'Item - Shattered Sun Pendant of
	      Restoration'),
	      (46567, 0, 0, 0, 0, 'Item - Goblin Rocket Launcher');
```