### PR TITLE
[SD][Spell] Readd Target Change Logic for Raging Flames 20481

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -783,7 +783,9 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (34145,'spell_ritual_of_souls_dummy'),
 (34219,'spell_recharging_battery'),
 (32173,'spell_entangling_roots'),
-(34520,'spell_elemental_power_extractor');
+(34520,'spell_elemental_power_extractor'),
+(35268,'spell_raging_flames_inferno'),
+(39346,'spell_raging_flames_inferno');
 
 -- Wotlk
 INSERT INTO spell_scripts(Id, ScriptName) VALUES

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_mechanar/boss_nethermancer_sepethrea.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_mechanar/boss_nethermancer_sepethrea.cpp
@@ -102,6 +102,7 @@ struct boss_nethermancer_sepethreaAI : public CombatAI
 
 enum
 {
+    SPELL_INVIS_AND_STEALTH_DETECT = 18950,
     SPELL_RAGING_FLAMES = 35281,
     SPELL_INFERNO       = 35268,
     SPELL_INFERNO_H     = 39346,
@@ -125,6 +126,7 @@ struct npc_raging_flamesAI : public CombatAI
     {
         CombatAI::Reset();
         DoCastSpellIfCan(nullptr, SPELL_RAGING_FLAMES, CAST_TRIGGERED | CAST_AURA_NOT_PRESENT);
+        DoCastSpellIfCan(nullptr, SPELL_INVIS_AND_STEALTH_DETECT, CAST_TRIGGERED | CAST_AURA_NOT_PRESENT);
     }
 
     void Aggro(Unit* /*who*/) override
@@ -137,8 +139,20 @@ struct npc_raging_flamesAI : public CombatAI
         DoResetThreat();
 
         if (Creature* summoner = m_creature->GetMap()->GetCreature(m_summonerGuid))
-            if (Unit* newTarget = summoner->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 1, nullptr, SELECT_FLAG_PLAYER))
+            if (Unit* newTarget = summoner->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, nullptr, SELECT_FLAG_PLAYER))
                 m_creature->AddThreat(newTarget, 10000000.0f);
+    }
+};
+
+// 35268,39346 - Inferno
+struct RagingFlamesInferno : public AuraScript
+{
+    void OnApply(Aura* aura, bool apply) const override
+    {
+        if (!apply)
+            if (Unit* caster = aura->GetCaster())
+                if (Unit* newTarget = caster->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, nullptr, SELECT_FLAG_PLAYER))
+                    caster->AddThreat(newTarget, 10000000.0f);
     }
 };
 
@@ -153,4 +167,6 @@ void AddSC_boss_nethermancer_sepethrea()
     pNewScript->Name = "npc_raging_flames";
     pNewScript->GetAI = &GetNewAIInstance<npc_raging_flamesAI>;
     pNewScript->RegisterSelf();
+
+    RegisterSpellScript<RagingFlamesInferno>("spell_raging_flames_inferno");
 }

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_mechanar/boss_nethermancer_sepethrea.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_mechanar/boss_nethermancer_sepethrea.cpp
@@ -140,7 +140,7 @@ struct npc_raging_flamesAI : public CombatAI
 
         if (Creature* summoner = m_creature->GetMap()->GetCreature(m_summonerGuid))
             if (Unit* newTarget = summoner->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, nullptr, SELECT_FLAG_PLAYER))
-                m_creature->AddThreat(newTarget, 10000000.0f);
+                m_creature->AddThreat(newTarget, 1000000.0f);
     }
 };
 
@@ -152,7 +152,7 @@ struct RagingFlamesInferno : public AuraScript
         if (!apply)
             if (Unit* caster = aura->GetCaster())
                 if (Unit* newTarget = caster->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, nullptr, SELECT_FLAG_PLAYER))
-                    caster->AddThreat(newTarget, 10000000.0f);
+                    caster->AddThreat(newTarget, 1000000.0f);
     }
 };
 


### PR DESCRIPTION
Removed with https://github.com/cmangos/mangos-tbc/commit/329ad4f81d8576625d8dec6d710eebe66b5bef96
Originally added with https://github.com/cmangos/mangos-tbc/commit/ea618a7c4eec3f8d9dee94b1b62966f21f91d3b8

Can also Focus Tank on Aggro, should be even more unpredictable when they change their focus, needs to be figured out or timed. (they only have 35281 aura passive)

See: https://www.youtube.com/watch?v=KuRH5PzZ3DA first 10 seconds how the add turns around without inferno used

https://www.youtube.com/watch?v=f3P3-odMKeA - watch with sound on

Also seem to cast invis and stealth detect within the first few seconds of a fight - might be a classictbc thing, confirmed with 7.3.5 sniff