### PR TITLE
Scripts: Add Initial SCRIPT_COMMAND_SPAWN_SPAWN_GROUP

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -452,3 +452,8 @@ Defining a buddy could be done in several way:
                                             * datalong = string_id id
                                             * apply = 0 remove, 1 add
 
+56 57 used in wotlk
+
+58 SCRIPT_COMMAND_SPAWN_SPAWN_GROUP	    Spawns the spawn_group
+                                            * datalong = spawn_group.id
+                                            * datalong2 = despawn-delay - Time to despawn group

--- a/src/game/DBScripts/ScriptMgr.cpp
+++ b/src/game/DBScripts/ScriptMgr.cpp
@@ -950,6 +950,19 @@ void ScriptMgr::LoadScripts(ScriptMapType scriptType)
                 }
                 break;
             }
+            case SCRIPT_COMMAND_SPAWN_SPAWN_GROUP: 
+            {
+                auto const& spgCont = sObjectMgr.GetSpawnGroupContainer()->spawnGroupMap;
+                if (spgCont.find(tmp.spawnGroupData.groupId) == spgCont.end())
+                {
+                    sLog.outErrorDb("Table `%s` uses invalid spawngroup id(%u) skipping",
+                        tablename,
+                        tmp.spawnGroupData.groupId);
+                    continue;
+                }
+
+                break;
+            }
             default:
             {
                 sLog.outErrorDb("Table `%s` unknown command %u, skipping", tablename, tmp.command);
@@ -3273,6 +3286,13 @@ bool ScriptAction::ExecuteDbscriptCommand(WorldObject* pSource, WorldObject* pTa
         case SCRIPT_COMMAND_SET_STRING_ID:
         {
             pSource->SetStringId(m_script->stringId.stringId, m_script->stringId.apply);
+            break;
+        }
+        case SCRIPT_COMMAND_SPAWN_SPAWN_GROUP: 
+        {
+            SpawnGroup* group = pSource->GetMap()->GetSpawnManager().GetSpawnGroup(m_script->spawnGroupData.groupId);
+            if (group)
+                group->Spawn(true);
             break;
         }
         default:

--- a/src/game/DBScripts/ScriptMgr.cpp
+++ b/src/game/DBScripts/ScriptMgr.cpp
@@ -3294,8 +3294,9 @@ bool ScriptAction::ExecuteDbscriptCommand(WorldObject* pSource, WorldObject* pTa
             SpawnGroup* group = pSource->GetMap()->GetSpawnManager().GetSpawnGroup(m_script->spawnGroupData.groupId);
             if (group)
             {
-                group->Spawn(true);
-                group->Despawn(true, time_to_despawn);
+                group->Spawn(true, false);
+                if (time_to_despawn != 0)
+                    group->Despawn(time_to_despawn, true);
             }
             break;
         }

--- a/src/game/DBScripts/ScriptMgr.cpp
+++ b/src/game/DBScripts/ScriptMgr.cpp
@@ -3290,9 +3290,13 @@ bool ScriptAction::ExecuteDbscriptCommand(WorldObject* pSource, WorldObject* pTa
         }
         case SCRIPT_COMMAND_SPAWN_SPAWN_GROUP: 
         {
+            uint32 time_to_despawn = m_script->spawnGroupData.despawnDelay;
             SpawnGroup* group = pSource->GetMap()->GetSpawnManager().GetSpawnGroup(m_script->spawnGroupData.groupId);
             if (group)
+            {
                 group->Spawn(true);
+                group->Despawn(true, time_to_despawn);
+            }
             break;
         }
         default:

--- a/src/game/DBScripts/ScriptMgr.h
+++ b/src/game/DBScripts/ScriptMgr.h
@@ -140,6 +140,7 @@ enum ScriptCommand                                          // resSource, resTar
     SCRIPT_COMMAND_SET_SHEATHE              = 54,           // dataint = worldstate id, dataint2 = new value,
     SCRIPT_COMMAND_SET_STRING_ID            = 55,           // datalong = string_id id, datalong2 = 0 unapply, 1 apply
     // 56 57 used in wotlk
+    SCRIPT_COMMAND_SPAWN_SPAWN_GROUP        = 58,           // datalong = spawn_group_id, 
 };
 
 #define MAX_TEXT_ID 4                                       // used for SCRIPT_COMMAND_TALK, SCRIPT_COMMAND_EMOTE, SCRIPT_COMMAND_CAST_SPELL, SCRIPT_COMMAND_TERMINATE_SCRIPT
@@ -477,6 +478,11 @@ struct ScriptInfo
             uint32 stringId;                                // datalong
             uint32 apply;                                   // datalong2
         } stringId;
+
+        struct                                              // SCRIPT_COMMAND_SPAWN_SPAWN_GROUP (58)
+        {
+            uint32 groupId;                                 // datalong = spawn_group.Id
+        } spawnGroupData;
 
         struct
         {

--- a/src/game/DBScripts/ScriptMgr.h
+++ b/src/game/DBScripts/ScriptMgr.h
@@ -140,7 +140,7 @@ enum ScriptCommand                                          // resSource, resTar
     SCRIPT_COMMAND_SET_SHEATHE              = 54,           // dataint = worldstate id, dataint2 = new value,
     SCRIPT_COMMAND_SET_STRING_ID            = 55,           // datalong = string_id id, datalong2 = 0 unapply, 1 apply
     // 56 57 used in wotlk
-    SCRIPT_COMMAND_SPAWN_SPAWN_GROUP        = 58,           // datalong = spawn_group_id, 
+    SCRIPT_COMMAND_SPAWN_SPAWN_GROUP        = 58,           // datalong = spawn_group_id, datalong2=despawn_delay
 };
 
 #define MAX_TEXT_ID 4                                       // used for SCRIPT_COMMAND_TALK, SCRIPT_COMMAND_EMOTE, SCRIPT_COMMAND_CAST_SPELL, SCRIPT_COMMAND_TERMINATE_SCRIPT
@@ -482,6 +482,7 @@ struct ScriptInfo
         struct                                              // SCRIPT_COMMAND_SPAWN_SPAWN_GROUP (58)
         {
             uint32 groupId;                                 // datalong = spawn_group.Id
+            uint32 despawnDelay;                            // datalong2
         } spawnGroupData;
 
         struct


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This is the initial version of the new SpawnGroup spawn command, intended to remove the dependency on the current world state.

Hopefully this will be extended later with additional options, such as ignoreRespawnTimer (true/false) or SetActive (to set the active object for the new spawn_group).

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
