### PR TITLE
Fix "Auto-Shot" spamming clipping itself.

### DIFF
--- a/src/game/Spells/SpellHandler.cpp
+++ b/src/game/Spells/SpellHandler.cpp
@@ -418,6 +418,11 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
     if (_player->HasQueuedSpell())
         return;
 
+    if (IsAutoRepeatRangedSpell(spellInfo))
+        if (const Spell* repeatSpell = caster->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL))
+            if (spellId == repeatSpell->m_spellInfo->Id)
+                return;
+
     bool handled = false;
     Spell* spell = new Spell(caster, spellInfo, TRIGGERED_NONE);
     spell->m_cast_count = cast_count;                       // set count of casts


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Currently spamming the auto-shot ability from a macro
(`/cast !Auto Shot`) keeps clipping the Auto Shot by re-triggering autorepeat freshly.
With this PR Auto Shot succeeds even when spamming such a macro. Fixes 3:2 macro, too.