### PR TITLE
Fix creature assistance on pull not working as intended

### DIFF
--- a/src/game/AI/BaseAI/UnitAI.cpp
+++ b/src/game/AI/BaseAI/UnitAI.cpp
@@ -81,7 +81,14 @@ void UnitAI::MoveInLineOfSight(Unit* who)
         return;
 
     if (who->GetObjectGuid().IsCreature() && who->IsInCombat())
-        CheckForHelp(who, m_unit, sWorld.getConfig(CONFIG_FLOAT_CREATURE_CHECK_FOR_HELP_RADIUS));
+    {
+        float radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_CHECK_FOR_HELP_RADIUS);
+        if (((Creature*)who)->GetCreatureInfo()->CallForHelp > 0)
+            radius = ((Creature*)who)->GetCreatureInfo()->CallForHelp;
+
+        CheckForHelp(who, m_unit, radius);
+    }
+        
 
     if (!HasReactState(REACT_AGGRESSIVE)) // mobs who are aggressive can still assist
         return;

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -2234,26 +2234,18 @@ void Creature::CallAssistance(Unit* enemy)
     }
 }
 
-std::pair<bool, CreatureList> Creature::MarkCallAssistanceOnPull(Unit* enemy)
+bool Creature::MarkCallAssistanceOnPull()
 {
     bool stored = m_AlreadyCallAssistance;
     SetNoCallAssistance(true);
 
     if (!CanCallForAssistance())
-        return {false, CreatureList()};
+        return false;
 
-    float radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS);
-    if (GetCreatureInfo()->CallForHelp > 0)
-        radius = GetCreatureInfo()->CallForHelp;
-
-    CreatureList receiverList;
-    MaNGOS::AnyAssistCreatureInRangeCheck u_check(this, enemy, radius);
-    MaNGOS::CreatureListSearcher<MaNGOS::AnyAssistCreatureInRangeCheck> searcher(receiverList, u_check);
-    Cell::VisitAllObjects(this, searcher, radius);
-    return {stored, receiverList};
+    return stored;
 }
 
-void Creature::CallAssistanceOnPull(Unit* enemy, CreatureList const& receiverList)
+void Creature::CallAssistanceOnPull(Unit* enemy)
 {
     if (enemy && !HasCharmer())
     {

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -2254,7 +2254,7 @@ void Creature::CallAssistanceOnPull(Unit* enemy)
         float radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS);
         if (GetCreatureInfo()->CallForHelp > 0)
             radius = GetCreatureInfo()->CallForHelp;
-        AI()->SendAIEventAround(AI_EVENT_CALL_ASSISTANCE, enemy, 0, radius);
+        AI()->SendAIEventAround(AI_EVENT_CALL_ASSISTANCE, enemy, sWorld.getConfig(CONFIG_UINT32_CREATURE_FAMILY_ASSISTANCE_DELAY), radius);
     }
 }
 
@@ -2264,7 +2264,14 @@ void Creature::CallForHelp(float radius)
         return;
 
     if (radius <= 0.0f)
-        radius = GetCreatureInfo()->CallForHelp;
+    {
+        // call for help can be 0
+        if (GetCreatureInfo()->CallForHelp > 0)
+            radius = GetCreatureInfo()->CallForHelp;
+        else
+            radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS); 
+    }   
+
 
     MaNGOS::CallOfHelpCreatureInRangeDo u_do(this, GetVictim(), radius);
     MaNGOS::CreatureWorker<MaNGOS::CallOfHelpCreatureInRangeDo> worker(this, u_do);

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -788,8 +788,8 @@ class Creature : public Unit
         void CallForHelp(float radius);
         void CallAssistance();
         void CallAssistance(Unit* enemy);
-        std::pair<bool, CreatureList> MarkCallAssistanceOnPull(Unit* enemy);
-        void CallAssistanceOnPull(Unit* enemy, CreatureList const& receiverList);
+        bool MarkCallAssistanceOnPull();
+        void CallAssistanceOnPull(Unit* enemy);
         void SetNoCallAssistance(bool val) { m_AlreadyCallAssistance = val; }
         bool CanAssistTo(const Unit* u, const Unit* enemy, bool checkfaction = true) const;
         bool CanInitiateAttack() const;

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -580,7 +580,7 @@ void Unit::TriggerAggroLinkingEvent(Unit* enemy)
     if (callAssistance)
         static_cast<Creature*>(this)->CallAssistanceOnPull(enemy);
 
-    m_events.AddEvent(new UnitLambdaEvent(*this, [enemyGuid = enemy->GetObjectGuid(), creatureGroup = static_cast<Creature*>(this)->GetCreatureGroup(), callAssistance, receiverList](Unit& unit)
+    m_events.AddEvent(new UnitLambdaEvent(*this, [enemyGuid = enemy->GetObjectGuid(), creatureGroup = static_cast<Creature*>(this)->GetCreatureGroup(), callAssistance](Unit& unit)
     {
         Unit* enemy = unit.GetMap()->GetUnit(enemyGuid);
         if (!enemy || !unit.IsInCombat())

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -577,6 +577,8 @@ void Unit::TriggerAggroLinkingEvent(Unit* enemy)
         return;
 
     bool callAssistance = static_cast<Creature*>(this)->MarkCallAssistanceOnPull();
+    if (callAssistance)
+        static_cast<Creature*>(this)->CallAssistanceOnPull(enemy);
 
     m_events.AddEvent(new UnitLambdaEvent(*this, [enemyGuid = enemy->GetObjectGuid(), creatureGroup = static_cast<Creature*>(this)->GetCreatureGroup(), callAssistance](Unit& unit)
     {
@@ -590,8 +592,6 @@ void Unit::TriggerAggroLinkingEvent(Unit* enemy)
         if (creatureGroup) // if npc dies before event execution, group will be removed from him, however groups are persistent and safe to access like this
             creatureGroup->TriggerLinkingEvent(CREATURE_GROUP_EVENT_AGGRO, enemy);
 
-        if (callAssistance)
-            static_cast<Creature&>(unit).CallAssistanceOnPull(enemy);
     }), m_events.CalculateTime(sWorld.getConfig(CONFIG_UINT32_CREATURE_CHECK_FOR_HELP_AGGRO_DELAY)));
 }
 
@@ -8448,6 +8448,7 @@ void Unit::SetInCombatState(bool PvP, Unit* enemy)
         creature->m_events.AddEvent(new UnitLambdaEvent(*creature, [](Unit& unit)
         {
             static_cast<Creature&>(unit).SetCanCheckForHelp(true);
+            
         }), creature->m_events.CalculateTime(sWorld.getConfig(CONFIG_UINT32_CREATURE_CHECK_FOR_HELP_AGGRO_DELAY)));
 
         TriggerAggroLinkingEvent(enemy);


### PR DESCRIPTION
address https://github.com/cmangos/issues/issues/4099

Creature assistance on pull was not working as intended: On pull, the call for help radius should determine what mobs aggro alongside the mob that you just pulled, assuming that they are capable of aggroing eachother (linking outside of a group).

Here's a comparison of what it looks like in classic tbc anniversary:

https://www.youtube.com/watch?v=KzAp7Gw623s

You can see in this instance that when the mob is pulled, the nearby mobs within it's callforhelp distance (which we will assume here is 10 as the 5 yards default doesn't reach) will pull at the exact same time.

If you try to replicate this pull on cmangos in those exact positions, neither of those mobs will pull from that angle, because it won't send out the request for assistance until about 3 seconds have passed.

As it is working currently, two delays are being applied to creatures on pull: first the delay for checking for help, and then another delay to actually do the linking. As a result, once a mob is pulled, it won't aggro a nearby mob, even if it should because it is within the callforhelp radius, because the aggro event won't happen for a couple of seconds, at which point the creature would be out of range of those mobs.

Also, the radius used to check for help is different from the one used to call for help. Callforhelp is something that's set in creature_template (0 would use default 5 yd in server config), while checkforhelp was using a radius that comes from the config and is by default 5. I made the checkforhelp radius use the callforhelp radius if the value is > 0 (which would mean it is not the default 5 yards), such that the call and check radius match each other for creatures who do not use the standard callforhelp value.

For the purposes of testing I found that the callforhelp of this particular creature (tempest-forge patroller) should be 10 (it currently has 0 which defaults to 5 yards which is too short to reach the 3 pack on the side when you do this pull, but it does reach the patroller behind it which is impossible in current code). 

Here's what the pulls look like with the changes I made

https://www.youtube.com/watch?v=SqSuqze5xT0

The behavior in this video is not applicable in current code when setting callforhelp for creature 19166 to 10.

As soon as I pull the mob, it sends out the event for assistance so the other mobs within its callforhelp will pull. Currently we didn't have a delay assigned to CallAssistanceOnPull reaction event (delay for when the mobs actually decide to assist after receiving the event to do so) now they wait a bit (based on server config) and then assist. We had the delay set to sending out the event, which is wrong since it will cause those mobs nearby in the original position to not assist as the pulled mob would be too far away from them by that time.

TL;DR: Creatures who are not in the same group are not linking together accurately when one of them is pulled and all are stationary as the event is sent out too late, once the pulled mob has moved away, for the others to be in range to receive it. Also, the radius to check for help was not accounting for different call for help radius in the creature_template. By fixing both of these, creature linking outside of groups works as close to blizzlike as possible.
