### PR TITLE
Refactor calling for help on pull 

### DIFF
--- a/src/game/AI/BaseAI/UnitAI.cpp
+++ b/src/game/AI/BaseAI/UnitAI.cpp
@@ -81,15 +81,8 @@ void UnitAI::MoveInLineOfSight(Unit* who)
         return;
 
     if (who->GetObjectGuid().IsCreature() && who->IsInCombat())
-    {
-        float radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_CHECK_FOR_HELP_RADIUS);
-        if (((Creature*)who)->GetCreatureInfo()->CallForHelp > 0)
-            radius = ((Creature*)who)->GetCreatureInfo()->CallForHelp;
-
-        CheckForHelp(who, m_unit, radius);
-    }
+        CheckForHelp(who, m_unit, sWorld.getConfig(CONFIG_FLOAT_CREATURE_CHECK_FOR_HELP_RADIUS));
         
-
     if (!HasReactState(REACT_AGGRESSIVE)) // mobs who are aggressive can still assist
         return;
 

--- a/src/game/AI/BaseAI/UnitAI.cpp
+++ b/src/game/AI/BaseAI/UnitAI.cpp
@@ -82,7 +82,7 @@ void UnitAI::MoveInLineOfSight(Unit* who)
 
     if (who->GetObjectGuid().IsCreature() && who->IsInCombat())
         CheckForHelp(who, m_unit, sWorld.getConfig(CONFIG_FLOAT_CREATURE_CHECK_FOR_HELP_RADIUS));
-        
+
     if (!HasReactState(REACT_AGGRESSIVE)) // mobs who are aggressive can still assist
         return;
 

--- a/src/game/AI/BaseAI/UnitAI.cpp
+++ b/src/game/AI/BaseAI/UnitAI.cpp
@@ -81,7 +81,14 @@ void UnitAI::MoveInLineOfSight(Unit* who)
         return;
 
     if (who->GetObjectGuid().IsCreature() && who->IsInCombat())
-        CheckForHelp(who, m_unit, sWorld.getConfig(CONFIG_FLOAT_CREATURE_CHECK_FOR_HELP_RADIUS));
+    {
+        float radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_CHECK_FOR_HELP_RADIUS);
+        if (((Creature*)who)->GetCreatureInfo()->CallForHelp > 0)
+            radius = ((Creature*)who)->GetCreatureInfo()->CallForHelp;
+
+        CheckForHelp(who, m_unit, radius);
+    }
+        
 
     if (!HasReactState(REACT_AGGRESSIVE)) // mobs who are aggressive can still assist
         return;

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -2264,14 +2264,7 @@ void Creature::CallForHelp(float radius)
         return;
 
     if (radius <= 0.0f)
-    {
-        // call for help can be 0
-        if (GetCreatureInfo()->CallForHelp > 0)
-            radius = GetCreatureInfo()->CallForHelp;
-        else
-            radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS); 
-    }   
-
+        radius = GetCreatureInfo()->CallForHelp;
 
     MaNGOS::CallOfHelpCreatureInRangeDo u_do(this, GetVictim(), radius);
     MaNGOS::CreatureWorker<MaNGOS::CallOfHelpCreatureInRangeDo> worker(this, u_do);

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -2254,7 +2254,7 @@ void Creature::CallAssistanceOnPull(Unit* enemy)
         float radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS);
         if (GetCreatureInfo()->CallForHelp > 0)
             radius = GetCreatureInfo()->CallForHelp;
-        AI()->SendAIEventAround(AI_EVENT_CALL_ASSISTANCE, enemy, 0, radius);
+        AI()->SendAIEventAround(AI_EVENT_CALL_ASSISTANCE, enemy, sWorld.getConfig(CONFIG_UINT32_CREATURE_FAMILY_ASSISTANCE_DELAY), radius);
     }
 }
 
@@ -2264,7 +2264,14 @@ void Creature::CallForHelp(float radius)
         return;
 
     if (radius <= 0.0f)
-        radius = GetCreatureInfo()->CallForHelp;
+    {
+        // call for help can be 0
+        if (GetCreatureInfo()->CallForHelp > 0)
+            radius = GetCreatureInfo()->CallForHelp;
+        else
+            radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS); 
+    }   
+
 
     MaNGOS::CallOfHelpCreatureInRangeDo u_do(this, GetVictim(), radius);
     MaNGOS::CreatureWorker<MaNGOS::CallOfHelpCreatureInRangeDo> worker(this, u_do);

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -2234,29 +2234,18 @@ void Creature::CallAssistance(Unit* enemy)
     }
 }
 
-std::pair<bool, GuidVector> Creature::MarkCallAssistanceOnPull(Unit* enemy)
+bool Creature::MarkCallAssistanceOnPull()
 {
     bool stored = m_AlreadyCallAssistance;
     SetNoCallAssistance(true);
 
     if (!CanCallForAssistance())
-        return {false, GuidVector()};
+        return false;
 
-    float radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS);
-    if (GetCreatureInfo()->CallForHelp > 0)
-        radius = GetCreatureInfo()->CallForHelp;
-
-    CreatureList receiverList;
-    MaNGOS::AnyAssistCreatureInRangeCheck u_check(this, enemy, radius);
-    MaNGOS::CreatureListSearcher<MaNGOS::AnyAssistCreatureInRangeCheck> searcher(receiverList, u_check);
-    Cell::VisitAllObjects(this, searcher, radius);
-    GuidVector guids;
-    for (Creature* creature : receiverList)
-        guids.push_back(creature->GetObjectGuid());
-    return {stored, guids};
+    return stored;
 }
 
-void Creature::CallAssistanceOnPull(Unit* enemy, GuidVector const& receiverList)
+void Creature::CallAssistanceOnPull(Unit* enemy)
 {
     if (enemy && !HasCharmer())
     {
@@ -2265,7 +2254,7 @@ void Creature::CallAssistanceOnPull(Unit* enemy, GuidVector const& receiverList)
         float radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS);
         if (GetCreatureInfo()->CallForHelp > 0)
             radius = GetCreatureInfo()->CallForHelp;
-        AI()->SendAIEventAround(AI_EVENT_CALL_ASSISTANCE, enemy, sWorld.getConfig(CONFIG_UINT32_CREATURE_FAMILY_ASSISTANCE_DELAY), radius);
+        AI()->SendAIEventAround(AI_EVENT_CALL_ASSISTANCE, enemy, 0, radius);
     }
 }
 

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -2254,7 +2254,7 @@ void Creature::CallAssistanceOnPull(Unit* enemy)
         float radius = sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS);
         if (GetCreatureInfo()->CallForHelp > 0)
             radius = GetCreatureInfo()->CallForHelp;
-        AI()->SendAIEventAround(AI_EVENT_CALL_ASSISTANCE, enemy, 0, radius);
+        AI()->SendAIEventAround(AI_EVENT_CALL_ASSISTANCE, enemy, sWorld.getConfig(CONFIG_UINT32_CREATURE_FAMILY_ASSISTANCE_DELAY), radius);
     }
 }
 

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -788,8 +788,8 @@ class Creature : public Unit
         void CallForHelp(float radius);
         void CallAssistance();
         void CallAssistance(Unit* enemy);
-        std::pair<bool, GuidVector> MarkCallAssistanceOnPull(Unit* enemy);
-        void CallAssistanceOnPull(Unit* enemy, GuidVector const& receiverList);
+        bool MarkCallAssistanceOnPull();
+        void CallAssistanceOnPull(Unit* enemy);
         void SetNoCallAssistance(bool val) { m_AlreadyCallAssistance = val; }
         bool CanAssistTo(const Unit* u, const Unit* enemy, bool checkfaction = true) const;
         bool CanInitiateAttack() const;

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -577,10 +577,8 @@ void Unit::TriggerAggroLinkingEvent(Unit* enemy)
         return;
 
     bool callAssistance = static_cast<Creature*>(this)->MarkCallAssistanceOnPull();
-    if (callAssistance)
-        static_cast<Creature*>(this)->CallAssistanceOnPull(enemy);
 
-    m_events.AddEvent(new UnitLambdaEvent(*this, [enemyGuid = enemy->GetObjectGuid(), creatureGroup = static_cast<Creature*>(this)->GetCreatureGroup(), callAssistance, receiverList](Unit& unit)
+    m_events.AddEvent(new UnitLambdaEvent(*this, [enemyGuid = enemy->GetObjectGuid(), creatureGroup = static_cast<Creature*>(this)->GetCreatureGroup(), callAssistance](Unit& unit)
     {
         Unit* enemy = unit.GetMap()->GetUnit(enemyGuid);
         if (!enemy || !unit.IsInCombat())
@@ -592,6 +590,8 @@ void Unit::TriggerAggroLinkingEvent(Unit* enemy)
         if (creatureGroup) // if npc dies before event execution, group will be removed from him, however groups are persistent and safe to access like this
             creatureGroup->TriggerLinkingEvent(CREATURE_GROUP_EVENT_AGGRO, enemy);
 
+        if (callAssistance)
+            static_cast<Creature&>(unit).CallAssistanceOnPull(enemy);
     }), m_events.CalculateTime(sWorld.getConfig(CONFIG_UINT32_CREATURE_CHECK_FOR_HELP_AGGRO_DELAY)));
 }
 

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -577,6 +577,8 @@ void Unit::TriggerAggroLinkingEvent(Unit* enemy)
         return;
 
     bool callAssistance = static_cast<Creature*>(this)->MarkCallAssistanceOnPull();
+    if (callAssistance)
+        static_cast<Creature*>(this)->CallAssistanceOnPull(enemy);
 
     m_events.AddEvent(new UnitLambdaEvent(*this, [enemyGuid = enemy->GetObjectGuid(), creatureGroup = static_cast<Creature*>(this)->GetCreatureGroup(), callAssistance](Unit& unit)
     {
@@ -590,8 +592,6 @@ void Unit::TriggerAggroLinkingEvent(Unit* enemy)
         if (creatureGroup) // if npc dies before event execution, group will be removed from him, however groups are persistent and safe to access like this
             creatureGroup->TriggerLinkingEvent(CREATURE_GROUP_EVENT_AGGRO, enemy);
 
-        if (callAssistance)
-            static_cast<Creature&>(unit).CallAssistanceOnPull(enemy);
     }), m_events.CalculateTime(sWorld.getConfig(CONFIG_UINT32_CREATURE_CHECK_FOR_HELP_AGGRO_DELAY)));
 }
 

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -577,6 +577,8 @@ void Unit::TriggerAggroLinkingEvent(Unit* enemy)
         return;
 
     bool callAssistance = static_cast<Creature*>(this)->MarkCallAssistanceOnPull();
+    if (callAssistance)
+        static_cast<Creature*>(this)->CallAssistanceOnPull(enemy);
 
     m_events.AddEvent(new UnitLambdaEvent(*this, [enemyGuid = enemy->GetObjectGuid(), creatureGroup = static_cast<Creature*>(this)->GetCreatureGroup(), callAssistance](Unit& unit)
     {
@@ -590,8 +592,6 @@ void Unit::TriggerAggroLinkingEvent(Unit* enemy)
         if (creatureGroup) // if npc dies before event execution, group will be removed from him, however groups are persistent and safe to access like this
             creatureGroup->TriggerLinkingEvent(CREATURE_GROUP_EVENT_AGGRO, enemy);
 
-        if (callAssistance)
-            static_cast<Creature&>(unit).CallAssistanceOnPull(enemy);
     }), m_events.CalculateTime(sWorld.getConfig(CONFIG_UINT32_CREATURE_CHECK_FOR_HELP_AGGRO_DELAY)));
 }
 
@@ -8448,6 +8448,7 @@ void Unit::SetInCombatState(bool PvP, Unit* enemy)
         creature->m_events.AddEvent(new UnitLambdaEvent(*creature, [](Unit& unit)
         {
             static_cast<Creature&>(unit).SetCanCheckForHelp(true);
+            
         }), creature->m_events.CalculateTime(sWorld.getConfig(CONFIG_UINT32_CREATURE_CHECK_FOR_HELP_AGGRO_DELAY)));
 
         TriggerAggroLinkingEvent(enemy);


### PR DESCRIPTION
Continuation of https://github.com/cmangos/mangos-tbc/pull/839 but I had to open separate PR because I force pushed on the branch.

Refactor assist on pull to use less code. This achieves the same thing as latest but without having to make a receiverlist like SendAIEventAround does in MarkCallAssistanceOnPull when a delay is specified. This also turns the receiverlist into a guid list so that it's safe to check the references if mobs are despawned by using code that already exists.

In other words, this aims to do what my original PR did but without the peripheral changes I made. I tested as well and it works.
