### PR TITLE
Fix Hungarfen mushroom spell bug and behavior

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -785,7 +785,8 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (32173,'spell_entangling_roots'),
 (34520,'spell_elemental_power_extractor'),
 (35268,'spell_raging_flames_inferno'),
-(39346,'spell_raging_flames_inferno');
+(39346,'spell_raging_flames_inferno'),
+(34168,'spell_spore_cloud_underbog');
 
 -- Wotlk
 INSERT INTO spell_scripts(Id, ScriptName) VALUES

--- a/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/underbog/boss_hungarfen.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/underbog/boss_hungarfen.cpp
@@ -69,6 +69,12 @@ struct boss_hungarfenAI : public CombatAI
         DoCastSpellIfCan(nullptr, SPELL_DESPAWN_MUSHROOMS, CAST_TRIGGERED);
     }
 
+    void EnterEvadeMode() override
+    {
+        DoCastSpellIfCan(nullptr, SPELL_DESPAWN_MUSHROOMS, CAST_TRIGGERED);
+        CombatAI::EnterEvadeMode();
+    }
+
     void ExecuteAction(uint32 action) override
     {
         switch (action)
@@ -179,6 +185,16 @@ struct DespawnMushrooms : public SpellScript
     }
 };
 
+// 34168 - Spore Cloud (Underbog)   
+struct SporeCloud : public AuraScript
+{
+    void OnPeriodicTrigger(Aura* aura, PeriodicTriggerData& data) const override
+    {
+        data.caster = aura->GetCaster();
+        data.target = aura->GetTarget();
+    }
+};
+
 void AddSC_boss_hungarfen()
 {
     Script* pNewScript = new Script;
@@ -192,4 +208,5 @@ void AddSC_boss_hungarfen()
     pNewScript->RegisterSelf();
 
     RegisterSpellScript<DespawnMushrooms>("spell_despawn_underbog_mushrooms");
+    RegisterSpellScript<SporeCloud>("spell_spore_cloud_underbog");
 }

--- a/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/underbog/boss_hungarfen.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/underbog/boss_hungarfen.cpp
@@ -132,7 +132,7 @@ struct mob_underbog_mushroomAI : public ScriptedAI
         {
             if (m_uiSporeTimer <= uiDiff)
             {
-                if (DoCastSpellIfCan(m_creature, SPELL_SPORE_CLOUD) == CAST_OK)
+                if (DoCastSpellIfCan(m_creature, SPELL_SPORE_CLOUD, CAST_INTERRUPT_PREVIOUS | CAST_TRIGGERED | CAST_FORCE_CAST) == CAST_OK)
                 {
                     m_uiGrowTimer = 0;
                     m_uiSporeTimer = 0;
@@ -158,7 +158,8 @@ struct mob_underbog_mushroomAI : public ScriptedAI
             if (m_uiShrinkTimer <= uiDiff)
             {
                 m_creature->RemoveAurasDueToSpell(SPELL_GROW);
-                m_uiShrinkTimer = 0;
+                if (DoCastSpellIfCan(nullptr, SPELL_SHRINK, CAST_TRIGGERED | CAST_AURA_NOT_PRESENT) == CAST_OK)
+                    m_uiShrinkTimer = 0;
             }
             else
                 m_uiShrinkTimer -= uiDiff;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1932,8 +1932,7 @@ void Aura::TriggerSpell()
             {
                 casterGUID = target->GetObjectGuid();
                 break;
-            }
-            case 34168:                                     // Spore Cloud (Underbog)   
+            } 
             case 38652:                                     // Spore Cloud (SSC)
             case 40106:                                     // Merge
             {

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1933,7 +1933,8 @@ void Aura::TriggerSpell()
                 casterGUID = target->GetObjectGuid();
                 break;
             }
-            case 38652:                                     // Spore Cloud
+            case 34168:                                     // Spore Cloud (Underbog)   
+            case 38652:                                     // Spore Cloud (SSC)
             case 40106:                                     // Merge
             {
                 triggerCaster = GetCaster();


### PR DESCRIPTION
Fix the mushroom spell on Hungarfen not working properly.

The spell should leave a cloud that does damage and also applies a DoT debuff to players standing nearby. It works very similarly to Rotten Mushrooms in SSC, which works correctly. Currently, it's leaving a cloud but you then get an aura that causes all enemies nearby to receive the DoT, and since each DoT stacks per caster, the boss would receive 5 versions of this DoT and die quickly.

Also, we shrink the mushrooms when they spawn to start small (correct) but we forgot to shrink them once we reach the shrink timer after they cast their Spore cloud spell (we removed grow but forgot to actually cast shrink).

So I looked at how the Spore Cloud spell in SSC works for Rotten Mushrooms and I emulated the same requirements.

Proof:

https://youtu.be/bGLJ4zhHH7M?t=193

You can see that players are supposed to receive the debuff, not the mushrooms or the boss.

Harder to see, but when mushrooms explode, they should shrink after some time, which it looks like the code intended but they weren't actually shrinking.

TODO: Now that players are receiving the dot correctly, and this debuff stacks to 5, we need to determine if this is unique per each mushroom that casts the spore cloud or if they all share it and each application just adds the same stack count to 5. At the moment, every spore cloud has a unique debuff, so it will stack up to max debuff count given enough mushrooms... quickly killing players especially in normal mode.