### PR TITLE
Fix astral flare AddThreat on Curator

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/boss_curator.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/karazhan/boss_curator.cpp
@@ -178,7 +178,7 @@ struct boss_curatorAI : public CombatAI
 
                 summoned->SetInCombatWithZone();
                 if (Unit* pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, nullptr, SELECT_FLAG_PLAYER))
-                    summoned->AddThreat(pTarget, 100001.f);
+                    summoned->AddThreat(pTarget, 1000.f);
                 m_sparkGuids.push_back(summoned->GetObjectGuid());
                 break;
             }


### PR DESCRIPTION
Astral Flares on Curator fight target a random player, but the initial threat added should be much smaller than it is currently.

Proof:
(classic)
https://youtu.be/pebt92hl-to?t=4023
(tbc)
https://www.youtube.com/watch?v=oeew9QD9p-8

In classic, consistently throughout this fight the threat meter accurately represents when dps take aggro of the astral flare. In particular during this timestamp, you can see that when it first spawns and threat is read, it has 1000 threat on the target, and eventually the rogue overtakes threat and becomes target of the astral flare at about 2.7k threat.

These classic threat meters represent accurate threat reading from server unlike traditional threat meters on 2.4.3

With the current value of 100001 threat, it would be impossible to rip aggro off of them as quickly as shown in classic. Especially given these only have 13k hp and are taunt immune. And they definitely don't fixate since they do switch target easily.

You can also see this 1000 threat is applied on spawn again, this time to a Hunter in this timestamp. It's not healer aggro and the hunter didn't start damage on it yet. The UI health updates much quicker than the threat meter does:

https://youtu.be/pebt92hl-to?t=3958

<img width="1427" height="982" alt="image" src="https://github.com/user-attachments/assets/91840281-d982-4647-bc9f-6ca5f7a7391d" />

In the next second, the rogue would overtake the 1000 threat to become the new target.

In the TBC video you can very clearly see the ret paladin filming the video is constantly becoming target of the astral flares after the initial target on spawn. In fact, it does seem like it was their intended role to grab them given that they were not focused on the boss, which would be impossible currently.


