### PR TITLE
Anticheat: Fix silence persistence, cheat log truncation and Warden scan request handling

### DIFF
--- a/src/game/Anticheat/module/Warden/warden.cpp
+++ b/src/game/Anticheat/module/Warden/warden.cpp
@@ -222,7 +222,15 @@ void Warden::RequestScans(std::vector<std::shared_ptr<const Scan>> &&scans)
         // if the scan did not change the buffer size or the string size, consider
         // it a NOP and don't bother marking it as pending
         if (scan.wpos() != startSize || strings.size() != startStringSize)
+        {
             _pendingScans.push_back(*i);
+
+            // account for the space this scan consumes.  without this the checks above only ever
+            // compare a single scan against the buffer limits, so a request could be built which
+            // overflows the client's buffers, bounded only by Warden.ScanCount.
+            request += (*i)->requestSize;
+            reply += (*i)->replySize;
+        }
     }
 
     // if there are still no pending scans, no request can be built this cycle.  this used to assert

--- a/src/game/Anticheat/module/Warden/warden.cpp
+++ b/src/game/Anticheat/module/Warden/warden.cpp
@@ -225,9 +225,35 @@ void Warden::RequestScans(std::vector<std::shared_ptr<const Scan>> &&scans)
             _pendingScans.push_back(*i);
     }
 
-    // if there are still no pending scans, it means that there is a single scan which is too big.
-    // this should never happen, so if it does, just crash
-    MANGOS_ASSERT(!_pendingScans.empty());
+    // if there are still no pending scans, no request can be built this cycle.  this used to assert
+    // (crashing the server), which is reachable if an oversized scan is ever added -- e.g. via the
+    // warden_scans table -- so handle each possible cause gracefully instead.
+    if (_pendingScans.empty())
+    {
+        // the loop ran to completion, so every scan we examined was a NOP.  nothing is pending and
+        // nothing is worth retrying, which matches what the normal path below does with the queue.
+        if (!queueUpdated)
+        {
+            _enqueuedScans.clear();
+            return;
+        }
+
+        // otherwise we stopped on the very first scan.  if it can never fit in a single request,
+        // drop it so it does not block the queue forever.  if we merely hit the per-request scan
+        // count limit (Warden.ScanCount set to zero), leave the queue intact and retry later.
+        auto const &next = _enqueuedScans.front();
+
+        if (next->requestSize > MaxRequest || next->replySize > MaxReply)
+        {
+            sLog.outError("[Warden] Dropping scan too large for a single request (request %u/%u, reply %u/%u bytes)",
+                static_cast<uint32>(next->requestSize), static_cast<uint32>(MaxRequest),
+                static_cast<uint32>(next->replySize), static_cast<uint32>(MaxReply));
+
+            _enqueuedScans.erase(_enqueuedScans.begin());
+        }
+
+        return;
+    }
 
     // if the scan queue has not been updated, its because we were able to fit the entire queue into one request.
     // therefore, the queue can be emptied

--- a/src/game/Anticheat/module/config.cpp
+++ b/src/game/Anticheat/module/config.cpp
@@ -81,6 +81,10 @@ void AnticheatConfig::loadConfigSettings()
     setConfig(CONFIG_UINT32_AC_IP_BAN_DELAY_MIN, "IPBanDelay.Min", 5);
     setConfig(CONFIG_UINT32_AC_IP_BAN_DELAY_MAX, "IPBanDelay.Max", 10);
 
+    setConfig(CONFIG_UINT32_AC_BAN_WAVE_DAY, "BanWave.Day", 1);
+    setConfig(CONFIG_UINT32_AC_BAN_WAVE_HOUR, "BanWave.Hour", 10);
+    setConfig(CONFIG_UINT32_AC_BAN_WAVE_MINUTE, "BanWave.Minute", 0);
+
     setConfig(CONFIG_UINT32_AC_ANTISPAM_MAX_LEVEL, "Antispam.MaxLevel", 25);
     setConfig(CONFIG_UINT32_AC_ANTISPAM_NORMALIZE_MASK, "Antispam.NormalizeMask", 0);
     setConfig(CONFIG_UINT32_AC_ANTISPAM_ANALYSIS_TIMER, "Antispam.AnalysisTimer", 30);
@@ -191,7 +195,7 @@ void AnticheatConfig::GetBanWaveTime(uint32 &day, uint32 &hour, uint32 &minute) 
 {
     day = getConfig(CONFIG_UINT32_AC_BAN_WAVE_DAY);
     hour = getConfig(CONFIG_UINT32_AC_BAN_WAVE_HOUR);
-    minute = getConfig(CONFIG_UINT32_AC_BAN_WAVE_DAY);
+    minute = getConfig(CONFIG_UINT32_AC_BAN_WAVE_MINUTE);
 }
 
 const char *AnticheatConfig::GetDetectorName(CheatType cheatType)

--- a/src/game/Anticheat/module/libanticheat.cpp
+++ b/src/game/Anticheat/module/libanticheat.cpp
@@ -110,7 +110,7 @@ std::string ActionMaskToString(uint32 actionMask)
         r << "Silence, ";
 
     auto ret = r.str();
-    if (ret[ret.length() - 2] == ',')
+    if (ret.length() >= 2 && ret[ret.length() - 2] == ',')
         ret = ret.substr(0, ret.length() - 2);
 
     return ret;
@@ -151,7 +151,7 @@ void LogCheat(WorldSession *session, uint32 actionMask, const std::string &info)
     else
         stmt.addUInt32(0);
 
-    stmt.addUInt8(actionMask);
+    stmt.addUInt32(actionMask);
     stmt.addString(name);
     stmt.addString(info);
 
@@ -914,7 +914,7 @@ void SessionAnticheat::RecordCheat(uint32 actionMask, const char *detector, cons
         {
             // ACCOUNT FLAGS
             LoginDatabase.PExecute("UPDATE account SET flags = flags | 0x%x WHERE id = %u",
-                _session->GetAccountId(), ACCOUNT_FLAG_SILENCED);
+                ACCOUNT_FLAG_SILENCED, _session->GetAccountId());
 
             _session->AddAccountFlag(ACCOUNT_FLAG_SILENCED);
         }


### PR DESCRIPTION
## 🍰 Pullrequest

Fixes six defects in the anticheat module, found while auditing `src/game/Anticheat/`.
Split into two commits: the first covers 1-5, the second the Warden buffer accounting in 6.

**1. Account silence never persisted and corrupted an unrelated row** (`libanticheat.cpp`)

The arguments to the silence query were transposed:

```cpp
LoginDatabase.PExecute("UPDATE account SET flags = flags | 0x%x WHERE id = %u",
    _session->GetAccountId(), ACCOUNT_FLAG_SILENCED);
```

`%x` received the account id and `%u` received the flag constant, so the statement
executed as `flags |= <accountId> WHERE id = 2` (`ACCOUNT_FLAG_SILENCED == 0x02`).
The intended account was never silenced in the database — only in memory, so the
silence was lost on relog — and whichever account has `id = 2` had garbage OR'd into
its flags.

The equivalent statement in `Antispam/antispammgr.cpp:417` already uses the correct
order, which is what this change matches.

**2. `actionMask` truncated to 8 bits when logged** (`libanticheat.cpp`)

`logs_anticheat.actionMask` is `INT(10) UNSIGNED` and `actionMask` is a `uint32`, but
it was bound with `addUInt8`, silently discarding any action flag above bit 7.

**3. Out-of-bounds read in `ActionMaskToString`** (`libanticheat.cpp`)

`ret[ret.length() - 2]` was evaluated without a length check; on an empty result string
the `size_t` subtraction underflows. Added a `length() >= 2` guard.

**4. Ban wave configuration was unreachable and read the wrong key** (`config.cpp`)

`BanWave.Day`, `BanWave.Hour` and `BanWave.Minute` were declared in the config enum and
documented in `anticheat.conf.dist.in`, but never loaded in `loadConfigSettings()`, so
they kept their zero-initialised values. Additionally `GetBanWaveTime()` assigned
`minute` from `CONFIG_UINT32_AC_BAN_WAVE_DAY`. Both are fixed.

Note that `GetBanWaveTime()` currently has no callers, so this is latent rather than
observable — it is fixed so the feature is correct if/when it is wired up.

**5. Server crash reachable from an oversized Warden scan** (`Warden/warden.cpp`)

`Warden::RequestScans` ended with:

```cpp
// if there are still no pending scans, it means that there is a single scan which is too big.
// this should never happen, so if it does, just crash
MANGOS_ASSERT(!_pendingScans.empty());
```

Scans are loaded from the `warden_scans` table, so a single row whose request or reply
exceeds the 256-byte buffers is enough to abort the server. The assert is replaced with
handling for the three distinct ways the loop can leave `_pendingScans` empty:

- loop ran to completion (every scan was a NOP) → clear the queue, matching what the
  normal path below already does
- stopped on the first scan and that scan cannot ever fit → log an error and drop it, so
  it cannot block the queue indefinitely
- stopped on the first scan only because the per-request scan limit was hit
  (`Warden.ScanCount = 0`) → leave the queue intact and retry on the next cycle

**6. Warden scan requests were not bounded by the client buffer sizes** (`Warden/warden.cpp`)

`RequestScans` initialised its `request` and `reply` accumulators to zero but never updated
them, so the checks in the loop only ever compared a *single* scan against `MaxRequest` and
`MaxReply`.  A request was consequently bounded only by `Warden.ScanCount` (10 by default)
and could be built well past the 256 byte buffers.  Both sizes are now accumulated for each
scan added to the pending list, matching what `WardenScanMgr::GetRandomScans` already does.

### Proof
- None

### Issues
- None

### How2Test

These changes are compile-verified only (GCC 15, Release, `BUILD_GAME_SERVER` +
`BUILD_LOGIN_SERVER` + `BUILD_SCRIPTDEV`); they have not been exercised against a live
realm, so review of the reasoning is welcome.

Suggested verification for anyone with an anticheat-enabled setup:

- **Silence:** trigger a detection configured with `CHEAT_ACTION_SILENCE` (0x20), then
  confirm `account.flags` gains `0x02` for the offending account and that the silence
  survives a relog. Before this change the row with `id = 2` was modified instead.
- **Action mask:** configure an action mask using a bit above 7 and confirm the value is
  stored intact in `logs_anticheat.actionMask`.
- **Warden:** add a `warden_scans` row whose data pushes `requestSize` past 256 bytes.
  Before this change the server asserts; after it, the scan is dropped with an error in
  the log and the server keeps running.
- **Warden buffer bound:** with `Warden.ScanCount` at its default of 10, confirm the
  combined `requestSize`/`replySize` of the scans in a single request now stays within 256
  bytes, and that clients are no longer sent requests exceeding their buffers.

### Todo / Checklist
- [X] None
