### PR TITLE
[Spell] Windsor's Frenzy 15167 should not be removed on Evade

### DIFF
--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -2384,6 +2384,7 @@ UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|0x00
 12898, -- Smoke Aura Visual
 13483, -- Wither Touch
 13879, -- Magma Splash
+15167, -- Windsor's Frenzy
 16331, -- Incorporeal Defense
 16577, -- Disease Cloud
 16592, -- Shadowform


### PR DESCRIPTION
https://youtu.be/5PLaMnz3ah4?si=X1SGWyyVEmI3WStQ&t=715