### PR TITLE
Fix melee miss/dodge/parry etc not setting in combat

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -8489,6 +8489,7 @@ void Unit::EngageInCombatWith(Unit* enemy)
 void Unit::EngageInCombatWithAggressor(Unit* aggressor)
 {
     MANGOS_ASSERT(aggressor);
+    aggressor->AddThreat(this);
     SetInCombatWithAggressor(aggressor);
     aggressor->SetInCombatWithVictim(this);
     GetCombatManager().TriggerCombatTimer(aggressor);


### PR DESCRIPTION
Address https://github.com/cmangos/issues/issues/4195

Miss/parry/dodge etc on a mob you are not currently in combat with should not turn off auto attack and should put/keep you in combat. In fact, that's what the current code was trying to do. However, while we set combat states bidirectionally, we neglected to add threat, so the combat engaging was moot as it would be reverted after game detects that you don't have threat on the creature (since you did no damage), and were thus not on the threat table.

In other words, only actually dealing damage or applying something that does threat would put you in combat in this situation because those would apply the threat elsewhere.

This keeps this function in line with EngageInCombatWith, which does actually add threat (even if it is 0, just to have that threat entry) so it keeps you in combat. Also keeps the behavior in line with spell resists putting you in combat.

If hypothetically, you had low weapon skill and wanted to grind weapon skill on a mob someone else is tanking... then you would have to keep turning on auto attack again and again for the misses...

This probably needs to be done for all 3 versions of the game.

Proof:
https://youtu.be/lc8IlhPXo78?t=69