### PR TITLE
Fix mobs treating new targets in combat as though they were first in combat

### DIFF
--- a/src/game/AI/BaseAI/CreatureAI.cpp
+++ b/src/game/AI/BaseAI/CreatureAI.cpp
@@ -227,7 +227,7 @@ void CreatureAI::HandleAssistanceCall(Unit* sender, Unit* invoker)
 {
     if (!invoker || m_creature->IsCritter())
         return;
-    if (m_creature->CanAssistInCombatAgainst(sender, invoker) && m_creature->CanJoinInAttacking(invoker) && invoker->IsVisibleForOrDetect(m_creature, m_creature, false))
+    if (m_creature->CanAssistInCombatAgainst(sender, invoker) && m_creature->CanJoinInAttacking(invoker) && invoker->IsVisibleForOrDetect(m_creature, m_creature, false) && !m_creature->GetNoCallAssistance())
     {
         m_creature->SetNoCallAssistance(true);
         OnCallForHelp(invoker);

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -2284,7 +2284,7 @@ std::pair<bool, GuidVector> Creature::MarkCallAssistanceOnPull(Unit* enemy)
 
 void Creature::CallAssistanceOnPull(Unit* enemy, GuidVector const& receiverList)
 {
-    if (enemy && !HasCharmer())
+    if (enemy && !HasCharmer() && !m_AlreadyCallAssistance)
     {
         MANGOS_ASSERT(AI());
 

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -2284,7 +2284,7 @@ std::pair<bool, GuidVector> Creature::MarkCallAssistanceOnPull(Unit* enemy)
 
 void Creature::CallAssistanceOnPull(Unit* enemy, GuidVector const& receiverList)
 {
-    if (enemy && !HasCharmer() && !m_AlreadyCallAssistance)
+    if (enemy && !HasCharmer())
     {
         MANGOS_ASSERT(AI());
 

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -791,6 +791,7 @@ class Creature : public Unit
         std::pair<bool, GuidVector> MarkCallAssistanceOnPull(Unit* enemy);
         void CallAssistanceOnPull(Unit* enemy, GuidVector const& receiverList);
         void SetNoCallAssistance(bool val) { m_AlreadyCallAssistance = val; }
+        bool GetNoCallAssistance() { return m_AlreadyCallAssistance; }
         bool CanAssistTo(const Unit* u, const Unit* enemy, bool checkfaction = true) const;
         bool CanInitiateAttack() const override;
         bool CanCallForAssistance() const override { return m_canCallForAssistance; }

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -8407,7 +8407,7 @@ void Unit::SetInCombatState(bool PvP, Unit* enemy)
                     if (PvP)
                         enemy->GetCombatManager().TriggerCombatTimer(controller);
                 }
-                else if (controller->CanHaveThreatList() && controller->getThreatManager() && !controller->getThreatManager().getCurrentVictim())
+                else if (controller->CanHaveThreatList() && controller->getThreatManager() && !controller->getThreatManager().isThreatListEmpty && !controller->getThreatManager().getCurrentVictim())
                 {
                     MANGOS_ASSERT(controller->AI()); // a player without UNIT_FLAG_PLAYER_CONTROLLED should always have AI
                     controller->AI()->AttackStart(enemy);

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -8407,7 +8407,7 @@ void Unit::SetInCombatState(bool PvP, Unit* enemy)
                     if (PvP)
                         enemy->GetCombatManager().TriggerCombatTimer(controller);
                 }
-                else if (controller->CanHaveThreatList() && controller->getThreatManager().isThreatListEmpty())
+                else if (!controller->GetVictim())
                 {
                     MANGOS_ASSERT(controller->AI()); // a player without UNIT_FLAG_PLAYER_CONTROLLED should always have AI
                     controller->AI()->AttackStart(enemy);

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -8407,7 +8407,7 @@ void Unit::SetInCombatState(bool PvP, Unit* enemy)
                     if (PvP)
                         enemy->GetCombatManager().TriggerCombatTimer(controller);
                 }
-                else
+                else if (!controller->GetVictim())
                 {
                     MANGOS_ASSERT(controller->AI()); // a player without UNIT_FLAG_PLAYER_CONTROLLED should always have AI
                     controller->AI()->AttackStart(enemy);

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -8407,7 +8407,7 @@ void Unit::SetInCombatState(bool PvP, Unit* enemy)
                     if (PvP)
                         enemy->GetCombatManager().TriggerCombatTimer(controller);
                 }
-                else if (controller->CanHaveThreatList() && controller->getThreatManager() && !controller->getThreatManager().isThreatListEmpty && !controller->getThreatManager().getCurrentVictim())
+                else if (controller->CanHaveThreatList() && controller->getThreatManager().isThreatListEmpty())
                 {
                     MANGOS_ASSERT(controller->AI()); // a player without UNIT_FLAG_PLAYER_CONTROLLED should always have AI
                     controller->AI()->AttackStart(enemy);

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -8407,7 +8407,7 @@ void Unit::SetInCombatState(bool PvP, Unit* enemy)
                     if (PvP)
                         enemy->GetCombatManager().TriggerCombatTimer(controller);
                 }
-                else if (!controller->GetVictim())
+                else if (controller->CanHaveThreatList() && controller->getThreatManager() && !controller->getThreatManager().getCurrentVictim())
                 {
                     MANGOS_ASSERT(controller->AI()); // a player without UNIT_FLAG_PLAYER_CONTROLLED should always have AI
                     controller->AI()->AttackStart(enemy);


### PR DESCRIPTION
Currently in dungeons, when you are near mobs that are fighting someone else, and that someone else has 0 threat on them, when those mobs place combat status on you by virtue of being nearby, they will switch to treating you as the new victim and not the person who went in first, even if everyone has 0 threat. If a third person then went near these mobs and everyone still had 0 threat, that third person would then become the victim, and so on and so forth which is a behavior not shown in real tbc.

This is especially noticeable in the Old Hillsbrad Foothills dungeon where often Thrall will be attacked and placed in combat and thus by extension, you are too, and because you get placed after Thrall does, they go to attack you and not Thrall because of this line of code, they act as though there isn't already a current target to attack and combat just started every time.

Take for example this video from 2.4.3. https://youtu.be/6lOWgKhAMvU?t=257

At 4:17, when the next wave shows up, everyone gets placed in combat. There is no threat assigned to Thrall but the mobs are scripted to attack him first. Now you see in the video they do actually go up to Thrall and start attacking him, even though the player filming the video was placed in combat (the crossed swords above his level), but he has not done anything to merit threat so they do not attack him.

In our server in this situation, the mobs would target Thrall at first, then they would then quickly switch to attacking someone else who was just placed in combat instead of focusing on Thrall, even if everyone in the party and Thrall has 0 threat. That is because of this line not accounting for current victim already. If hypothetically the distance is determining the order of who gets assigned combat (so as the mobs go closer, people get added to combat), then the furthest player from the spawn would become the ultimate victim rather than the first thing they find or, in this case, the intended target of Thrall. Meaning it is very well possible that the mobs are going to go after your healer if they are in the back, rather than the tank up front, if nobody does anything and the healer is added last to combat. This is of course a problem if the mobs have instant attack abilities that they then dump on your healer immediately on spawn, rather than the target that should be attacked (Thrall or the nearest target to them).

Basically unless the mobs are scripted to choose random targets, in a dungeon, the person who first attracts the attention of mobs should be the target of their auto attacks (victim), until someone does something. It should not depend on new people being placed in combat to change this current victim. If there is random spell targeting or mob random targeting scripted, that is a different story, but I am referring to mobs who would have no such mechanics, which is the majority.

So to recap, if everyone has 0 threat and you join in combat after someone else, you should be placed in combat, you should get a threat value assigned to you (usually 0 by AddThreat), but if the mobs already have someone with 0 threat to attack, then they shouldn't switch to auto attacking you and following you around. Once someone has above 0 threat, this doesn't matter as threat rules start to apply.