### PR TITLE
[Spell] Gor'drek's Ointment Ointment 32578 should not be removed on Evade

### DIFF
--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -3210,6 +3210,7 @@ UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|0x00
 32732, -- Flay
 37248, -- Power Converters: Electromental Visual
 38471, -- Spore Burst
+39152, -- Darkfury
 43119, -- Cyclone Visual
 43120, -- Cyclone
 43457  -- Ball of Energy

--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -3206,6 +3206,7 @@ UPDATE `spell_template` SET `EffectMiscValueB1`=64 WHERE `Id` IN(38107);
 -- ============================================================
 UPDATE `spell_template` SET `AttributesServerSide` = `AttributesServerSide`|0x00000004 WHERE `Id` IN (
 32008, -- Fel Fire - c.17152,18944,19298
+32578, -- Gor'drek's Ointment
 32732, -- Flay
 37248, -- Power Converters: Electromental Visual
 38471, -- Spore Burst


### PR DESCRIPTION
Bolsters the Thunderlord dire wolf's size and damage done for $d. However, it might also anger the wolf and turn it against you.
Multiples of this spell may not be applied to the same wolf at the same time.