### PR TITLE
[Spell] s.34700 should only proc to UNIT_FLAG_PLAYER_CONTROLLED

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -782,6 +782,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (29354,'spell_gameobject_call_for_help_on_usage'), -- Mining (Master)
 (30434,'spell_gameobject_call_for_help_on_usage'), -- Elemental Seaforium Charge
 (34799,'spell_arcane_devastation'),
+(34700,'spell_allergic_reaction'),
 (34145,'spell_ritual_of_souls_dummy'),
 (34219,'spell_recharging_battery'),
 (32173,'spell_entangling_roots'),

--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/botanica/boss_laj.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/botanica/boss_laj.cpp
@@ -173,10 +173,24 @@ struct boss_lajAI : public CombatAI
     }
 };
 
+struct AllergicReaction : public SpellScript
+{
+    bool OnCheckTarget(const Spell* spell, Unit* target, SpellEffectIndex /*eff*/) const override
+    {
+        // Player with aura 34697 can ONLY proc Aura 34700 on other UNIT_FLAG_PLAYER_CONTROLLED targets
+        if (!target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED))
+            return false;
+
+        return true;
+    }
+};
+
 void AddSC_boss_laj()
 {
     Script* pNewScript = new Script;
     pNewScript->Name = "boss_laj";
     pNewScript->GetAI = &GetNewAIInstance<boss_lajAI>;
     pNewScript->RegisterSelf();
+
+    RegisterSpellScript<AllergicReaction>("spell_allergic_reaction");
 }


### PR DESCRIPTION
Based on https://github.com/cmangos/mangos-tbc/pull/675/changes/c9cea3ff9ffcb79f3bb108022263783d0ce6ade8

---

s.34681,34682,34684,34685

```
SELECT * FROM creature_template where entry IN (19919,19920,21580,21579);

const std::vector<uint32> summonSpellsFirstLoc = { SPELL_SUMMON_LASHER_1, SPELL_SUMMON_FLAYER_1 };
const std::vector<uint32> summonSpellsSecondLoc = { SPELL_SUMMON_LASHER_2, SPELL_SUMMON_FLAYER_2 };
```

do nothing in parts.